### PR TITLE
Epic 8: Configuration & Settings via local JSON config file

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,49 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import type { MemoryConfig } from "./types.js";
+import {
+  DEFAULT_MEMORY_CHAR_LIMIT,
+  DEFAULT_USER_CHAR_LIMIT,
+  DEFAULT_NUDGE_INTERVAL,
+  DEFAULT_FLUSH_MIN_TURNS,
+} from "./constants.js";
+
+const DEFAULT_CONFIG: MemoryConfig = {
+  memoryCharLimit: DEFAULT_MEMORY_CHAR_LIMIT,
+  userCharLimit: DEFAULT_USER_CHAR_LIMIT,
+  nudgeInterval: DEFAULT_NUDGE_INTERVAL,
+  reviewEnabled: true,
+  flushOnCompact: true,
+  flushOnShutdown: true,
+  flushMinTurns: DEFAULT_FLUSH_MIN_TURNS,
+};
+
+export const DEFAULT_CONFIG_PATH = path.join(
+  os.homedir(),
+  ".pi",
+  "agent",
+  "hermes-memory-config.json",
+);
+
+export function loadConfig(): MemoryConfig {
+  try {
+    if (fs.existsSync(DEFAULT_CONFIG_PATH)) {
+      const raw = fs.readFileSync(DEFAULT_CONFIG_PATH, "utf-8");
+      const parsed = JSON.parse(raw);
+      // Merge: override defaults with user config
+      const config: MemoryConfig = { ...DEFAULT_CONFIG };
+      if (typeof parsed.memoryCharLimit === "number") config.memoryCharLimit = parsed.memoryCharLimit;
+      if (typeof parsed.userCharLimit === "number") config.userCharLimit = parsed.userCharLimit;
+      if (typeof parsed.nudgeInterval === "number") config.nudgeInterval = parsed.nudgeInterval;
+      if (typeof parsed.reviewEnabled === "boolean") config.reviewEnabled = parsed.reviewEnabled;
+      if (typeof parsed.flushOnCompact === "boolean") config.flushOnCompact = parsed.flushOnCompact;
+      if (typeof parsed.flushOnShutdown === "boolean") config.flushOnShutdown = parsed.flushOnShutdown;
+      if (typeof parsed.flushMinTurns === "number") config.flushMinTurns = parsed.flushMinTurns;
+      return config;
+    }
+  } catch {
+    // Fall back to defaults on parse error or access issues
+  }
+  return { ...DEFAULT_CONFIG };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,25 +18,10 @@ import { registerMemoryTool } from "./tools/memory-tool.js";
 import { setupBackgroundReview } from "./handlers/background-review.js";
 import { setupSessionFlush } from "./handlers/session-flush.js";
 import { registerInsightsCommand } from "./handlers/insights.js";
-import type { MemoryConfig } from "./types.js";
-import {
-  DEFAULT_MEMORY_CHAR_LIMIT,
-  DEFAULT_USER_CHAR_LIMIT,
-  DEFAULT_NUDGE_INTERVAL,
-  DEFAULT_FLUSH_MIN_TURNS,
-} from "./constants.js";
+import { loadConfig } from "./config.js";
 
 export default function (pi: ExtensionAPI) {
-  // Configuration (future: read from Pi settings.json)
-  const config: MemoryConfig = {
-    memoryCharLimit: DEFAULT_MEMORY_CHAR_LIMIT,
-    userCharLimit: DEFAULT_USER_CHAR_LIMIT,
-    nudgeInterval: DEFAULT_NUDGE_INTERVAL,
-    reviewEnabled: true,
-    flushOnCompact: true,
-    flushOnShutdown: true,
-    flushMinTurns: DEFAULT_FLUSH_MIN_TURNS,
-  };
+  const config = loadConfig();
 
   const store = new MemoryStore(config);
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,94 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { loadConfig, DEFAULT_CONFIG_PATH } from "../src/config.js";
+
+describe("loadConfig", () => {
+  it("returns defaults when no config file exists", () => {
+    const config = loadConfig();
+    assert.strictEqual(config.memoryCharLimit, 2200);
+    assert.strictEqual(config.userCharLimit, 1375);
+    assert.strictEqual(config.nudgeInterval, 10);
+    assert.strictEqual(config.reviewEnabled, true);
+    assert.strictEqual(config.flushOnCompact, true);
+    assert.strictEqual(config.flushOnShutdown, true);
+    assert.strictEqual(config.flushMinTurns, 6);
+  });
+
+  it("overrides defaults when config file exists", () => {
+    // Write a config file
+    fs.mkdirSync(path.dirname(DEFAULT_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(DEFAULT_CONFIG_PATH, JSON.stringify({
+      memoryCharLimit: 3000,
+      nudgeInterval: 15,
+    }));
+    const config = loadConfig();
+    assert.strictEqual(config.memoryCharLimit, 3000);
+    assert.strictEqual(config.nudgeInterval, 15);
+    // Unset values use defaults
+    assert.strictEqual(config.userCharLimit, 1375);
+    assert.strictEqual(config.reviewEnabled, true);
+    // Clean up
+    fs.rmSync(DEFAULT_CONFIG_PATH);
+  });
+
+  it("handles partial config (missing keys use defaults)", () => {
+    fs.mkdirSync(path.dirname(DEFAULT_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(DEFAULT_CONFIG_PATH, JSON.stringify({ reviewEnabled: false }));
+    const config = loadConfig();
+    assert.strictEqual(config.reviewEnabled, false);
+    assert.strictEqual(config.memoryCharLimit, 2200); // default
+    fs.rmSync(DEFAULT_CONFIG_PATH);
+  });
+
+  it("handles partial config with all boolean overrides", () => {
+    fs.mkdirSync(path.dirname(DEFAULT_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(DEFAULT_CONFIG_PATH, JSON.stringify({
+      reviewEnabled: false,
+      flushOnCompact: false,
+      flushOnShutdown: false,
+      flushMinTurns: 20,
+    }));
+    const config = loadConfig();
+    assert.strictEqual(config.reviewEnabled, false);
+    assert.strictEqual(config.flushOnCompact, false);
+    assert.strictEqual(config.flushOnShutdown, false);
+    assert.strictEqual(config.flushMinTurns, 20);
+    assert.strictEqual(config.memoryCharLimit, 2200);
+    assert.strictEqual(config.userCharLimit, 1375);
+    assert.strictEqual(config.nudgeInterval, 10);
+    fs.rmSync(DEFAULT_CONFIG_PATH);
+  });
+
+  it("handles empty file gracefully (falls back to defaults)", () => {
+    fs.mkdirSync(path.dirname(DEFAULT_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(DEFAULT_CONFIG_PATH, "");
+    const config = loadConfig();
+    assert.strictEqual(config.reviewEnabled, true);
+    fs.rmSync(DEFAULT_CONFIG_PATH);
+  });
+
+  it("handles malformed JSON (falls back to defaults)", () => {
+    fs.mkdirSync(path.dirname(DEFAULT_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(DEFAULT_CONFIG_PATH, "{ bad json }");
+    const config = loadConfig();
+    assert.strictEqual(config.memoryCharLimit, 2200);
+    assert.strictEqual(config.reviewEnabled, true);
+    fs.rmSync(DEFAULT_CONFIG_PATH);
+  });
+
+  it("ignores unknown keys in config file", () => {
+    fs.mkdirSync(path.dirname(DEFAULT_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(DEFAULT_CONFIG_PATH, JSON.stringify({
+      unknownKey: "value",
+      anotherKey: 123,
+      memoryCharLimit: 1000,
+    }));
+    const config = loadConfig();
+    assert.strictEqual(config.memoryCharLimit, 1000);
+    assert.strictEqual(config.reviewEnabled, true);
+    fs.rmSync(DEFAULT_CONFIG_PATH);
+  });
+});


### PR DESCRIPTION

## Epic 8: Configuration & Settings

### Changes
- New `src/config.ts` — `loadConfig()` reads `~/.pi/agent/hermes-memory-config.json`, merges over defaults
- Updated `src/index.ts` — uses `loadConfig()` instead of hardcoded config
- Config file: all MemoryConfig fields are configurable with proper type validation

### Tests (7/7 passing)
- Returns defaults when no config file exists
- Overrides defaults when config file exists
- Handles partial config (missing keys use defaults)
- Handles partial config with all boolean overrides
- Handles empty file gracefully (falls back to defaults)
- Handles malformed JSON (falls back to defaults)
- Ignores unknown keys in config file
