### PR TITLE
feat(memory): add project-scoped store and fix tool-call counting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
   test:
     name: Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -305,6 +305,8 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 {
   "memoryCharLimit": 2200,
   "userCharLimit": 1375,
+  "projectCharLimit": 2200,
+  "memoryDir": "~/.pi/agent/memory",
   "nudgeInterval": 10,
   "nudgeToolCalls": 15,
   "reviewEnabled": true,
@@ -320,6 +322,8 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 |---|---|---|
 | `memoryCharLimit` | `2200` | Max characters in MEMORY.md |
 | `userCharLimit` | `1375` | Max characters in USER.md |
+| `projectCharLimit` | `2200` | Max characters in project-scoped MEMORY.md |
+| `memoryDir` | `~/.pi/agent/memory` | Custom directory for memory files |
 | `nudgeInterval` | `10` | Turns between auto-reviews |
 | `nudgeToolCalls` | `15` | Tool calls between auto-reviews (OR with turns) |
 | `reviewEnabled` | `true` | Enable/disable background learning loop |

--- a/docs/0.2/TASKS.md
+++ b/docs/0.2/TASKS.md
@@ -118,8 +118,8 @@ _Done when: v0.2.0 is tagged and released with updated docs._
 - [x] Update `docs/ROADMAP.md` — v0.2 roadmap documented (`d5b7518`)
 - [x] `npm run check` passes with zero errors (`c6317dd`)
 - [x] `npm test` — all 218 tests pass (`83e7c46`)
-- [ ] Bump `package.json` version to `0.2.0`
-- [ ] Tag v0.2.0 release
+- [x] Bump `package.json` version to `0.2.0`
+- [x] Tag v0.2.0 release
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@mariozechner/pi-ai": "^0.70.0",
         "@mariozechner/pi-coding-agent": "^0.70.0",
+        "tsx": "^4.21.0",
         "typebox": "^1.1.33",
         "typescript": "^6.0.3"
       },
@@ -851,6 +852,448 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@google/genai": {
@@ -2369,6 +2812,48 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -2567,6 +3052,21 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/gaxios": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
@@ -2634,6 +3134,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/get-uri": {
@@ -3303,6 +3816,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -3552,6 +4075,26 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/typebox": {
       "version": "1.1.33",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "typescript": "^6.0.3"
       },
       "peerDependencies": {
-        "@mariozechner/pi-coding-agent": "*"
+        "@mariozechner/pi-coding-agent": ">=0.70.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/chandra447/pi-hermes-memory"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*"
+    "@mariozechner/pi-coding-agent": ">=0.70.0"
   },
   "devDependencies": {
     "@mariozechner/pi-ai": "^0.70.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "check": "tsc --noEmit",
-    "test": "npx tsx --test 'tests/**/*.test.ts' --test-concurrency=1"
+    "test": "npx tsx --test 'tests/**/*.test.ts'"
   },
   "keywords": [
     "pi-package",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "check": "tsc --noEmit",
-    "test": "npx tsx --test 'tests/**/*.test.ts'"
+    "test": "for f in $(find tests -name '*.test.ts' | sort); do echo \"::group::$f\"; npx tsx --test \"$f\" || exit 1; echo \"::endgroup::\"; done"
   },
   "keywords": [
     "pi-package",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "check": "tsc --noEmit",
-    "test": "for f in $(find tests -name '*.test.ts' | sort); do echo \"::group::$f\"; npx tsx --test \"$f\" || exit 1; echo \"::endgroup::\"; done"
+    "test": "tests/run-all.sh"
   },
   "keywords": [
     "pi-package",
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@mariozechner/pi-ai": "^0.70.0",
     "@mariozechner/pi-coding-agent": "^0.70.0",
+    "tsx": "^4.21.0",
     "typebox": "^1.1.33",
     "typescript": "^6.0.3"
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ import type { MemoryConfig } from "./types.js";
 import {
   DEFAULT_MEMORY_CHAR_LIMIT,
   DEFAULT_USER_CHAR_LIMIT,
+  DEFAULT_PROJECT_CHAR_LIMIT,
   DEFAULT_NUDGE_INTERVAL,
   DEFAULT_FLUSH_MIN_TURNS,
   DEFAULT_NUDGE_TOOL_CALLS,
@@ -13,6 +14,7 @@ import {
 const DEFAULT_CONFIG: MemoryConfig = {
   memoryCharLimit: DEFAULT_MEMORY_CHAR_LIMIT,
   userCharLimit: DEFAULT_USER_CHAR_LIMIT,
+  projectCharLimit: DEFAULT_PROJECT_CHAR_LIMIT,
   nudgeInterval: DEFAULT_NUDGE_INTERVAL,
   reviewEnabled: true,
   flushOnCompact: true,
@@ -47,6 +49,8 @@ export function loadConfig(): MemoryConfig {
       if (typeof parsed.autoConsolidate === "boolean") config.autoConsolidate = parsed.autoConsolidate;
       if (typeof parsed.correctionDetection === "boolean") config.correctionDetection = parsed.correctionDetection;
       if (typeof parsed.nudgeToolCalls === "number") config.nudgeToolCalls = parsed.nudgeToolCalls;
+      if (typeof parsed.projectCharLimit === "number") config.projectCharLimit = parsed.projectCharLimit;
+      if (typeof parsed.memoryDir === "string") config.memoryDir = parsed.memoryDir;
       return config;
     }
   } catch {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,8 @@ export const DEFAULT_MEMORY_CHAR_LIMIT = 2200;
 export const DEFAULT_USER_CHAR_LIMIT = 1375;
 
 // ─── Learning loop defaults ───
+export const DEFAULT_PROJECT_CHAR_LIMIT = 2200;
+
 export const DEFAULT_NUDGE_INTERVAL = 10;
 export const DEFAULT_FLUSH_MIN_TURNS = 6;
 export const DEFAULT_NUDGE_TOOL_CALLS = 15;
@@ -35,9 +37,10 @@ PRIORITY: User preferences and corrections > environment facts > procedural know
 
 Do NOT save task progress, session outcomes, completed-work logs, or temporary TODO state.
 
-TWO TARGETS:
+THREE TARGETS:
 - 'user': who the user is -- name, role, preferences, communication style, pet peeves
-- 'memory': your notes -- environment facts, project conventions, tool quirks, lessons learned
+- 'memory': your global notes -- environment facts, tool quirks, lessons learned (shared across all projects)
+- 'project': project-specific notes -- architecture decisions, API quirks, team norms, codebase conventions (scoped to current project)
 
 ACTIONS: add (new entry), replace (update existing -- old_text identifies it), remove (delete -- old_text identifies it).`;
 

--- a/src/handlers/background-review.ts
+++ b/src/handlers/background-review.ts
@@ -16,6 +16,7 @@ import { getMessageText } from "../types.js";
 export function setupBackgroundReview(
   pi: ExtensionAPI,
   store: MemoryStore,
+  projectStore: MemoryStore | null,
   config: MemoryConfig,
 ): void {
   let turnsSinceReview = 0;
@@ -35,17 +36,17 @@ export function setupBackgroundReview(
     if (!config.reviewEnabled) return;
     if (reviewInProgress) return;
 
-    // Count tool-use entries from the branch for tool-call-aware nudge
+    // Count tool calls from this turn's message only (not cumulative branch scan —
+    // otherwise the counter resets to 0 at review, then immediately re-counts all
+    // historical tool calls and re-triggers on every subsequent turn).
     try {
-      const branch = ctx.sessionManager.getBranch();
-      for (const entry of branch) {
-        if (entry.type === "message" && entry.message?.role === "assistant") {
-          const content = entry.message?.content;
-          if (Array.isArray(content)) {
-            for (const block of content) {
-              if (block && typeof block === "object" && block.type === "toolCall") {
-                toolCallsSinceReview++;
-              }
+      const msg = event.message;
+      if (msg?.role === "assistant") {
+        const content = msg?.content;
+        if (Array.isArray(content)) {
+          for (const block of content) {
+            if (block && typeof block === "object" && block.type === "toolCall") {
+              toolCallsSinceReview++;
             }
           }
         }
@@ -82,6 +83,7 @@ export function setupBackgroundReview(
 
       const currentMemory = store.getMemoryEntries().join("\n§\n");
       const currentUser = store.getUserEntries().join("\n§\n");
+      const currentProject = projectStore ? projectStore.getMemoryEntries().join("\n§\n") : null;
 
       const reviewPrompt = [
         COMBINED_REVIEW_PROMPT,
@@ -91,12 +93,23 @@ export function setupBackgroundReview(
         "",
         "--- Current User Profile ---",
         currentUser || "(empty)",
+      ];
+
+      if (currentProject !== null) {
+        reviewPrompt.push(
+          "",
+          "--- Current Project Memory ---",
+          currentProject || "(empty)",
+        );
+      }
+
+      reviewPrompt.push(
         "",
         "--- Conversation to Review ---",
         parts.join("\n\n"),
-      ].join("\n");
+      );
 
-      const result = await pi.exec("pi", ["-p", "--no-session", reviewPrompt], {
+      const result = await pi.exec("pi", ["-p", "--no-session", reviewPrompt.join("\n")], {
         signal: ctx.signal,
         timeout: 60000,
       });

--- a/src/handlers/correction-detector.ts
+++ b/src/handlers/correction-detector.ts
@@ -57,6 +57,7 @@ export function isCorrection(text: string): boolean {
 export function setupCorrectionDetector(
   pi: ExtensionAPI,
   store: MemoryStore,
+  projectStore: MemoryStore | null,
   config: MemoryConfig,
 ): void {
   if (!config.correctionDetection) return;
@@ -109,6 +110,7 @@ export function setupCorrectionDetector(
 
       const currentMemory = store.getMemoryEntries().join(ENTRY_DELIMITER);
       const currentUser = store.getUserEntries().join(ENTRY_DELIMITER);
+      const currentProject = projectStore ? projectStore.getMemoryEntries().join(ENTRY_DELIMITER) : null;
 
       const prompt = [
         CORRECTION_SAVE_PROMPT,
@@ -118,12 +120,23 @@ export function setupCorrectionDetector(
         "",
         "--- Current User Profile ---",
         currentUser || "(empty)",
+      ];
+
+      if (currentProject !== null) {
+        prompt.push(
+          "",
+          "--- Current Project Memory ---",
+          currentProject || "(empty)",
+        );
+      }
+
+      prompt.push(
         "",
         "--- Recent Conversation ---",
         recentParts.join("\n\n"),
-      ].join("\n");
+      );
 
-      const result = await pi.exec("pi", ["-p", "--no-session", prompt], {
+      const result = await pi.exec("pi", ["-p", "--no-session", prompt.join("\n")], {
         signal: ctx.signal,
         timeout: 30000,
       });

--- a/src/handlers/insights.ts
+++ b/src/handlers/insights.ts
@@ -5,12 +5,13 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { MemoryStore } from "../store/memory-store.js";
 
-export function registerInsightsCommand(pi: ExtensionAPI, store: MemoryStore): void {
+export function registerInsightsCommand(pi: ExtensionAPI, store: MemoryStore, projectStore: MemoryStore | null, projectName: string): void {
   pi.registerCommand("memory-insights", {
     description: "Show what's stored in persistent memory",
     handler: async (_args, ctx) => {
       const memoryEntries = store.getMemoryEntries();
       const userEntries = store.getUserEntries();
+      const projectEntries = projectStore ? projectStore.getMemoryEntries() : null;
 
       const lines: string[] = [];
       lines.push("");
@@ -50,6 +51,24 @@ export function registerInsightsCommand(pi: ExtensionAPI, store: MemoryStore): v
         }
       }
       lines.push("");
+
+      // Project section
+      if (projectEntries !== null) {
+        lines.push(`  📁 PROJECT MEMORY: ${projectName}`);
+        lines.push("  " + "─".repeat(44));
+        if (projectEntries.length === 0) {
+          lines.push("  (empty)");
+        } else {
+          for (let i = 0; i < projectEntries.length; i++) {
+            const preview =
+              projectEntries[i].length > 100
+                ? projectEntries[i].slice(0, 100) + "..."
+                : projectEntries[i];
+            lines.push(`  ${i + 1}. ${preview}`);
+          }
+        }
+        lines.push("");
+      }
 
       ctx.ui.notify(lines.join("\n"), "info");
     },

--- a/src/handlers/session-flush.ts
+++ b/src/handlers/session-flush.ts
@@ -13,6 +13,7 @@ import { getMessageText } from "../types.js";
 export function setupSessionFlush(
   pi: ExtensionAPI,
   store: MemoryStore,
+  projectStore: MemoryStore | null,
   config: MemoryConfig,
 ): void {
   let userTurnCount = 0;

--- a/src/handlers/skill-auto-trigger.ts
+++ b/src/handlers/skill-auto-trigger.ts
@@ -20,24 +20,24 @@ export function setupSkillAutoTrigger(
 ): void {
   let triggeredThisSession = false;
 
+  // Accumulate tool calls across turns (reset on trigger)
+  let toolCallCount = 0;
+  const toolTypes = new Set<string>();
+
   pi.on("turn_end", async (event, ctx) => {
     if (triggeredThisSession) return;
 
-    // Count tool-use entries from this turn's branch
-    let toolCallCount = 0;
-    const toolTypes = new Set<string>();
-
+    // Count tool calls from this turn's message only (not cumulative branch scan —
+    // otherwise the counter accumulates historical tool calls and fires prematurely).
     try {
-      const branch = ctx.sessionManager.getBranch();
-      for (const entry of branch) {
-        if (entry.type === "message" && entry.message?.role === "assistant") {
-          const content = entry.message?.content;
-          if (Array.isArray(content)) {
-            for (const block of content) {
-              if (block && typeof block === "object" && block.type === "toolCall") {
-                toolCallCount++;
-                if ((block as { name?: string }).name) toolTypes.add((block as { name: string }).name);
-              }
+      const msg = event.message;
+      if (msg?.role === "assistant") {
+        const content = msg?.content;
+        if (Array.isArray(content)) {
+          for (const block of content) {
+            if (block && typeof block === "object" && block.type === "toolCall") {
+              toolCallCount++;
+              if ((block as { name?: string }).name) toolTypes.add((block as { name: string }).name);
             }
           }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,22 +37,37 @@ import { loadConfig } from "./config.js";
 export default function (pi: ExtensionAPI) {
   const config = loadConfig();
 
-  const memoryDir = config.memoryDir ?? path.join(os.homedir(), ".pi", "agent", "memory");
+  const globalDir = config.memoryDir ?? path.join(os.homedir(), ".pi", "agent", "memory");
   const store = new MemoryStore(config);
-  const skillStore = new SkillStore(path.join(memoryDir, "skills"));
+  const skillStore = new SkillStore(path.join(globalDir, "skills"));
+
+  // Detect project name from cwd — skip if running from home directory
+  const cwd = process.cwd();
+  const homeDir = os.homedir();
+  const projectName = path.basename(cwd);
+  const hasProject = cwd !== homeDir;
+
+  // Project-scoped store: ~/.pi/agent/<project_name>/
+  // Uses memoryCharLimit overridden to projectCharLimit for the "memory" target
+  const projectDir = hasProject ? path.join(homeDir, ".pi", "agent", projectName) : null;
+  const projectConfig = { ...config, memoryCharLimit: config.projectCharLimit, memoryDir: projectDir ?? undefined };
+  const projectStore = hasProject ? new MemoryStore(projectConfig) : null;
 
   // ── 1. Load memory from disk on session start ──
   pi.on("session_start", async (_event, _ctx) => {
     await store.loadFromDisk();
+    if (projectStore) await projectStore.loadFromDisk();
   });
 
-  // ── 2. Inject frozen snapshot + skill index into system prompt ──
+  // ── 2. Inject frozen snapshot + skill index + project memory into system prompt ──
   pi.on("before_agent_start", async (event, _ctx) => {
     const memoryBlock = store.formatForSystemPrompt();
     const skillIndex = await skillStore.formatIndexForSystemPrompt();
+    const projectBlock = projectStore ? projectStore.formatProjectBlock(projectName) : "";
 
     const parts: string[] = [];
     if (memoryBlock) parts.push(memoryBlock);
+    if (projectBlock) parts.push(projectBlock);
     if (skillIndex) parts.push(skillIndex);
 
     if (parts.length > 0) {
@@ -62,17 +77,17 @@ export default function (pi: ExtensionAPI) {
     }
   });
 
-  // ── 3. Register the memory tool ──
-  registerMemoryTool(pi, store);
+  // ── 3. Register the memory tool (with project store) ──
+  registerMemoryTool(pi, store, projectStore);
 
   // ── 4. Register the skill tool ──
   registerSkillTool(pi, skillStore);
 
   // ── 5. Setup background learning loop (with tool-call-aware nudge) ──
-  setupBackgroundReview(pi, store, config);
+  setupBackgroundReview(pi, store, projectStore, config);
 
   // ── 6. Setup session-end flush ──
-  setupSessionFlush(pi, store, config);
+  setupSessionFlush(pi, store, projectStore, config);
 
   // ── 7. Setup auto-consolidation (inject consolidator into store) ──
   store.setConsolidator(async (target, signal) => {
@@ -81,12 +96,12 @@ export default function (pi: ExtensionAPI) {
   registerConsolidateCommand(pi, store);
 
   // ── 8. Setup correction detection ──
-  setupCorrectionDetector(pi, store, config);
+  setupCorrectionDetector(pi, store, projectStore, config);
 
   // ── 9. Setup skill auto-trigger ──
   setupSkillAutoTrigger(pi, store, skillStore, config);
 
   // ── 10. Register commands ──
-  registerInsightsCommand(pi, store);
+  registerInsightsCommand(pi, store, projectStore, projectName);
   registerSkillsCommand(pi, skillStore);
 }

--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -127,12 +127,12 @@ export class MemoryStore {
 
     entries.push(content);
     this.setEntries(target, entries);
-    this.saveToDisk(target);
+    await this.saveToDisk(target);
 
     return this.successResponse(target, "Entry added.");
   }
 
-  replace(target: "memory" | "user", oldText: string, newContent: string): MemoryResult {
+  async replace(target: "memory" | "user", oldText: string, newContent: string): Promise<MemoryResult> {
     oldText = oldText.trim();
     newContent = newContent.trim();
     if (!oldText) return { success: false, error: "old_text cannot be empty." };
@@ -167,12 +167,12 @@ export class MemoryStore {
 
     entries[idx] = newContent;
     this.setEntries(target, entries);
-    this.saveToDisk(target);
+    await this.saveToDisk(target);
 
     return this.successResponse(target, "Entry replaced.");
   }
 
-  remove(target: "memory" | "user", oldText: string): MemoryResult {
+  async remove(target: "memory" | "user", oldText: string): Promise<MemoryResult> {
     oldText = oldText.trim();
     if (!oldText) return { success: false, error: "old_text cannot be empty." };
 
@@ -191,7 +191,7 @@ export class MemoryStore {
     const idx = entries.indexOf(matches[0]);
     entries.splice(idx, 1);
     this.setEntries(target, entries);
-    this.saveToDisk(target);
+    await this.saveToDisk(target);
 
     return this.successResponse(target, "Entry removed.");
   }
@@ -203,6 +203,14 @@ export class MemoryStore {
     if (this.snapshot.memory) parts.push(this.snapshot.memory);
     if (this.snapshot.user) parts.push(this.snapshot.user);
     return parts.join("\n\n");
+  }
+
+  /**
+   * Render a project-specific memory block for system prompt injection.
+   * Uses only the memory entries (no user split) with a project-labelled header.
+   */
+  formatProjectBlock(projectName: string): string {
+    return this.renderProjectBlock(projectName, this.memoryEntries);
   }
 
   getMemoryEntries(): string[] {
@@ -247,6 +255,18 @@ export class MemoryStore {
     return `${separator}\n${header}\n${separator}\n${content}`;
   }
 
+  private renderProjectBlock(projectName: string, entries: string[]): string {
+    if (!entries.length) return "";
+    const limit = this.config.memoryCharLimit;
+    const content = entries.join(ENTRY_DELIMITER);
+    const current = content.length;
+    const pct = limit > 0 ? Math.min(100, Math.floor((current / limit) * 100)) : 0;
+
+    const header = `PROJECT MEMORY: ${projectName} [${pct}% — ${current}/${limit} chars]`;
+    const separator = "═".repeat(46);
+    return `${separator}\n${header}\n${separator}\n${content}`;
+  }
+
   private async readFile(filePath: string): Promise<string[]> {
     try {
       const raw = await fs.readFile(filePath, "utf-8");
@@ -258,23 +278,22 @@ export class MemoryStore {
   }
 
   /** Atomic write: temp file + fs.rename() — same crash-safety as Hermes. */
-  private saveToDisk(target: "memory" | "user"): void {
+  private async saveToDisk(target: "memory" | "user"): Promise<void> {
     const filePath = this.pathFor(target);
     const entries = this.entriesFor(target);
     const content = entries.length ? entries.join(ENTRY_DELIMITER) : "";
 
-    // Fire-and-forget atomic write
-    fs.mkdtemp(path.join(os.tmpdir(), "pi-memory-")).then((tmpDir) => {
-      const tmpPath = path.join(tmpDir, "write.tmp");
-      return fs
-        .writeFile(tmpPath, content, "utf-8")
-        .then(() => fs.rename(tmpPath, filePath))
-        .catch(async () => {
-          try { await fs.unlink(tmpPath); } catch { /* ignore */ }
-        })
-        .finally(async () => {
-          try { await fs.rmdir(tmpDir); } catch { /* ignore */ }
-        });
-    });
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-memory-"));
+    const tmpPath = path.join(tmpDir, "write.tmp");
+
+    try {
+      await fs.writeFile(tmpPath, content, "utf-8");
+      await fs.rename(tmpPath, filePath);
+    } catch (err) {
+      try { await fs.unlink(tmpPath); } catch { /* ignore */ }
+      throw err;
+    } finally {
+      try { await fs.rmdir(tmpDir); } catch { /* ignore */ }
+    }
   }
 }

--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -106,11 +106,23 @@ export class MemoryStore {
     if (newTotal > limit) {
       // Auto-consolidate if configured and consolidator available
       if (this.config.autoConsolidate && this.consolidator) {
+        // Track consolidation attempts to prevent infinite recursion
+        // when the consolidator fails to free enough space
+        const beforeCount = entries.length;
         try {
           const result = await this.consolidator(target, signal);
           if (result.consolidated) {
             // CRITICAL: reload from disk — child process modified files, our arrays are stale
             await this.loadFromDisk();
+            // Guard: if consolidation didn't reduce entries, stop recursing
+            const afterEntries = this.entriesFor(target);
+            const afterCount = afterEntries.length;
+            if (afterCount >= beforeCount && afterCount > 0) {
+              return {
+                success: false,
+                error: `Memory at capacity and consolidation did not free enough space. Entry count unchanged at ${afterCount}.`,
+              };
+            }
             // Retry the add with fresh data
             return this.add(target, content, signal);
           }

--- a/src/tools/memory-tool.ts
+++ b/src/tools/memory-tool.ts
@@ -10,7 +10,7 @@ import { StringEnum } from "@mariozechner/pi-ai";
 import { MemoryStore } from "../store/memory-store.js";
 import { MEMORY_TOOL_DESCRIPTION } from "../constants.js";
 
-export function registerMemoryTool(pi: ExtensionAPI, store: MemoryStore): void {
+export function registerMemoryTool(pi: ExtensionAPI, store: MemoryStore, projectStore: MemoryStore | null): void {
   pi.registerTool({
     name: "memory",
     label: "Memory",
@@ -24,7 +24,7 @@ export function registerMemoryTool(pi: ExtensionAPI, store: MemoryStore): void {
     ],
     parameters: Type.Object({
       action: StringEnum(["add", "replace", "remove"] as const),
-      target: StringEnum(["memory", "user"] as const),
+      target: StringEnum(["memory", "user", "project"] as const),
       content: Type.Optional(
         Type.String({ description: "Entry content for add/replace" })
       ),
@@ -36,7 +36,21 @@ export function registerMemoryTool(pi: ExtensionAPI, store: MemoryStore): void {
       ),
     }),
     async execute(toolCallId, params, signal, onUpdate, ctx) {
-      const { action, target, content, old_text } = params;
+      const { action, target: rawTarget, content, old_text } = params;
+
+      // Route 'project' to projectStore (internal target 'memory')
+      const target = rawTarget as "memory" | "user";
+      const activeStore = rawTarget === "project" ? projectStore : store;
+
+      if (rawTarget === "project" && !projectStore) {
+        return {
+          content: [{ type: "text", text: JSON.stringify({ success: false, error: "Project memory is not available (no project detected)." }) }],
+          details: {},
+        };
+      }
+
+      // After the guard above, activeStore is guaranteed non-null when rawTarget === 'project'
+      const store_ = activeStore!;
 
       let result;
       switch (action) {
@@ -55,7 +69,7 @@ export function registerMemoryTool(pi: ExtensionAPI, store: MemoryStore): void {
               details: {},
             };
           }
-          result = await store.add(target, content);
+          result = await store_.add(target, content);
           break;
 
         case "replace":
@@ -87,7 +101,7 @@ export function registerMemoryTool(pi: ExtensionAPI, store: MemoryStore): void {
               details: {},
             };
           }
-          result = store.replace(target, old_text, content);
+          result = await store_.replace(target, old_text, content);
           break;
 
         case "remove":
@@ -105,7 +119,7 @@ export function registerMemoryTool(pi: ExtensionAPI, store: MemoryStore): void {
               details: {},
             };
           }
-          result = store.remove(target, old_text);
+          result = await store_.remove(target, old_text);
           break;
 
         default:
@@ -113,6 +127,11 @@ export function registerMemoryTool(pi: ExtensionAPI, store: MemoryStore): void {
             success: false,
             error: `Unknown action '${action}'. Use: add, replace, remove`,
           };
+      }
+
+      // Tag project results so the caller knows the scope
+      if (rawTarget === "project" && result.success) {
+        (result as any).target = "project";
       }
 
       return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,8 @@ export interface MemoryConfig {
   memoryCharLimit: number;
   /** Max chars for USER.md (user profile). Default: 1375 */
   userCharLimit: number;
+  /** Max chars for project-level MEMORY.md. Default: 2200 */
+  projectCharLimit: number;
   /** Turns between background auto-reviews. Default: 10 */
   nudgeInterval: number;
   /** Enable background learning loop. Default: true */

--- a/tests/handlers/auto-consolidate.test.ts
+++ b/tests/handlers/auto-consolidate.test.ts
@@ -2,8 +2,11 @@
  * Unit tests for auto-consolidation — triggerConsolidation and /memory-consolidate command.
  */
 
-import { describe, it, beforeEach } from "node:test";
+import { describe, it, beforeEach, before, after } from "node:test";
 import assert from "node:assert/strict";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
 import { triggerConsolidation } from "../../src/handlers/auto-consolidate.js";
 import { ENTRY_DELIMITER } from "../../src/constants.js";
 
@@ -113,6 +116,16 @@ describe("triggerConsolidation", () => {
 });
 
 describe("MemoryStore auto-consolidation integration", () => {
+  let MEMORY_DIR = "";
+
+  before(async () => {
+    MEMORY_DIR = await fs.mkdtemp(path.join(os.tmpdir(), "pi-consolidation-test-"));
+  });
+
+  after(async () => {
+    try { await fs.rm(MEMORY_DIR, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
   it("add() triggers consolidation when over limit with consolidator", async () => {
     let consolidatorCalled = false;
     let consolidatorTarget: string | undefined;
@@ -129,15 +142,18 @@ describe("MemoryStore auto-consolidation integration", () => {
       autoConsolidate: true,
       correctionDetection: false,
       nudgeToolCalls: 15,
+      memoryDir: MEMORY_DIR,
     });
 
-    // Inject a mock consolidator that "frees space" by loading new data
+    // Mock consolidator that actually frees space by removing all entries
     store.setConsolidator(async (target, signal) => {
       consolidatorCalled = true;
       consolidatorTarget = target;
-      // Simulate consolidation freeing up space
-      // After consolidation, loadFromDisk would show fewer entries
-      // We cheat by directly accessing internals — in real use, pi.exec modifies the file
+      // Remove all entries to simulate consolidation freeing space
+      const entries = target === "memory" ? store.getMemoryEntries() : store.getUserEntries();
+      for (const entry of [...entries]) {
+        await store.remove(target, entry);
+      }
       return { consolidated: true };
     });
 
@@ -152,9 +168,8 @@ describe("MemoryStore auto-consolidation integration", () => {
 
     assert.ok(consolidatorCalled, "consolidator should have been called");
     assert.strictEqual(consolidatorTarget, "memory");
-    // Result depends on whether consolidation actually freed space
-    // In this mock, the in-memory array doesn't change, so it'll still be over limit
-    // The real test is that consolidation was attempted
+    // After consolidation removes entries, the new entry should fit
+    assert.ok(result.success, "add should succeed after consolidation");
   });
 
   it("add() skips consolidation when autoConsolidate is false", async () => {
@@ -172,6 +187,7 @@ describe("MemoryStore auto-consolidation integration", () => {
       autoConsolidate: false,
       correctionDetection: false,
       nudgeToolCalls: 15,
+      memoryDir: MEMORY_DIR,
     });
 
     store.setConsolidator(async () => {
@@ -201,6 +217,7 @@ describe("MemoryStore auto-consolidation integration", () => {
       autoConsolidate: true,
       correctionDetection: false,
       nudgeToolCalls: 15,
+      memoryDir: MEMORY_DIR,
     });
 
     // Intentionally NOT calling setConsolidator

--- a/tests/handlers/background-review.test.ts
+++ b/tests/handlers/background-review.test.ts
@@ -63,6 +63,7 @@ const defaultConfig = {
   flushOnShutdown: true,
   memoryCharLimit: 2200,
   userCharLimit: 1375,
+  projectCharLimit: 2200,
 };
 
 const mockStore = {
@@ -82,8 +83,18 @@ function fireTurnEnd(branch: any[] = makeBranch(10), ctxOverrides: Record<string
   const h = handlers["turn_end"];
   if (!h) throw new Error("No turn_end handler registered");
   const ctx = makeCtx(branch, ctxOverrides);
+  // Extract the last assistant message from the branch to pass as event.message
+  // (the handler now reads tool calls from event.message, not from the branch)
+  let assistantMessage = undefined;
+  for (let i = branch.length - 1; i >= 0; i--) {
+    if (branch[i]?.message?.role === "assistant") {
+      assistantMessage = branch[i].message;
+      break;
+    }
+  }
+  const event = assistantMessage ? { message: assistantMessage } : {};
   for (const fn of h) {
-    fn({}, ctx);
+    fn(event, ctx);
   }
   return ctx;
 }
@@ -104,7 +115,7 @@ describe("setupBackgroundReview", () => {
 
   it("increments user turn count on message_end for user messages", () => {
     const pi = createMockPi();
-    setupBackgroundReview(pi, mockStore, defaultConfig);
+    setupBackgroundReview(pi, mockStore, null, defaultConfig);
 
     fireMessageEnd("user");
     fireMessageEnd("user");
@@ -123,7 +134,7 @@ describe("setupBackgroundReview", () => {
 
   it("triggers review at nudgeInterval (10) turns", async () => {
     const pi = createMockPi();
-    setupBackgroundReview(pi, mockStore, defaultConfig);
+    setupBackgroundReview(pi, mockStore, null, defaultConfig);
 
     // Register 3 user messages first
     fireMessageEnd("user");
@@ -152,7 +163,7 @@ describe("setupBackgroundReview", () => {
   it("does NOT trigger review when reviewEnabled is false", async () => {
     const config = { ...defaultConfig, reviewEnabled: false };
     const pi = createMockPi();
-    setupBackgroundReview(pi, mockStore, config);
+    setupBackgroundReview(pi, mockStore, null, config);
 
     fireMessageEnd("user");
     fireMessageEnd("user");
@@ -168,7 +179,7 @@ describe("setupBackgroundReview", () => {
 
   it("does NOT trigger review with fewer than 3 user turns", async () => {
     const pi = createMockPi();
-    setupBackgroundReview(pi, mockStore, defaultConfig);
+    setupBackgroundReview(pi, mockStore, null, defaultConfig);
 
     // Only 2 user messages
     fireMessageEnd("user");
@@ -199,7 +210,7 @@ describe("setupBackgroundReview", () => {
       registerCommand: () => {},
     } as any;
 
-    setupBackgroundReview(slowPi, mockStore, defaultConfig);
+    setupBackgroundReview(slowPi, mockStore, null, defaultConfig);
 
     fireMessageEnd("user");
     fireMessageEnd("user");
@@ -228,7 +239,7 @@ describe("setupBackgroundReview", () => {
 
   it("does NOT trigger for short conversations (< 4 message parts)", async () => {
     const pi = createMockPi();
-    setupBackgroundReview(pi, mockStore, defaultConfig);
+    setupBackgroundReview(pi, mockStore, null, defaultConfig);
 
     fireMessageEnd("user");
     fireMessageEnd("user");
@@ -250,7 +261,7 @@ describe("setupBackgroundReview", () => {
 
   it("resets turn counter after review triggers", async () => {
     const pi = createMockPi();
-    setupBackgroundReview(pi, mockStore, defaultConfig);
+    setupBackgroundReview(pi, mockStore, null, defaultConfig);
 
     fireMessageEnd("user");
     fireMessageEnd("user");
@@ -275,7 +286,7 @@ describe("setupBackgroundReview", () => {
 
   it("shows notification only when review saves something", async () => {
     const pi = createMockPi({ code: 0, stdout: "Saved new memory about user preferences", stderr: "" });
-    setupBackgroundReview(pi, mockStore, defaultConfig);
+    setupBackgroundReview(pi, mockStore, null, defaultConfig);
 
     fireMessageEnd("user");
     fireMessageEnd("user");
@@ -296,7 +307,7 @@ describe("setupBackgroundReview", () => {
     notifyCalls = [];
 
     const nothingPi = createMockPi({ code: 0, stdout: "Nothing to save.", stderr: "" });
-    setupBackgroundReview(nothingPi, mockStore, defaultConfig);
+    setupBackgroundReview(nothingPi, mockStore, null, defaultConfig);
 
     fireMessageEnd("user");
     fireMessageEnd("user");
@@ -325,7 +336,7 @@ describe("setupBackgroundReview", () => {
       registerCommand: () => {},
     } as any;
 
-    setupBackgroundReview(crashPi, mockStore, defaultConfig);
+    setupBackgroundReview(crashPi, mockStore, null, defaultConfig);
 
     fireMessageEnd("user");
     fireMessageEnd("user");
@@ -344,7 +355,7 @@ describe("setupBackgroundReview", () => {
 
   it("assistant message_end does NOT increment user turn count", async () => {
     const pi = createMockPi();
-    setupBackgroundReview(pi, mockStore, defaultConfig);
+    setupBackgroundReview(pi, mockStore, null, defaultConfig);
 
     // Only assistant messages — userTurnCount stays 0
     fireMessageEnd("assistant");
@@ -364,7 +375,7 @@ describe("setupBackgroundReview", () => {
   it("triggers on tool call count threshold even with low turn count", async () => {
     const config = { ...defaultConfig, nudgeToolCalls: 5 };
     const pi = createMockPi();
-    setupBackgroundReview(pi, mockStore, config);
+    setupBackgroundReview(pi, mockStore, null, config);
 
     fireMessageEnd("user");
     fireMessageEnd("user");
@@ -400,7 +411,7 @@ describe("setupBackgroundReview", () => {
   it("triggers when both thresholds are met", async () => {
     const config = { ...defaultConfig, nudgeToolCalls: 5 };
     const pi = createMockPi();
-    setupBackgroundReview(pi, mockStore, config);
+    setupBackgroundReview(pi, mockStore, null, config);
 
     fireMessageEnd("user");
     fireMessageEnd("user");
@@ -433,7 +444,7 @@ describe("setupBackgroundReview", () => {
   it("resets both counters after review", async () => {
     const config = { ...defaultConfig, nudgeToolCalls: 3 };
     const pi = createMockPi();
-    setupBackgroundReview(pi, mockStore, config);
+    setupBackgroundReview(pi, mockStore, null, config);
 
     fireMessageEnd("user");
     fireMessageEnd("user");
@@ -471,7 +482,7 @@ describe("setupBackgroundReview", () => {
   it("does not trigger when neither threshold is met", async () => {
     const config = { ...defaultConfig, nudgeToolCalls: 15 };
     const pi = createMockPi();
-    setupBackgroundReview(pi, mockStore, config);
+    setupBackgroundReview(pi, mockStore, null, config);
 
     fireMessageEnd("user");
     fireMessageEnd("user");
@@ -504,7 +515,7 @@ describe("setupBackgroundReview", () => {
   it("ignores text blocks when counting tool calls", async () => {
     const config = { ...defaultConfig, nudgeToolCalls: 3 };
     const pi = createMockPi();
-    setupBackgroundReview(pi, mockStore, config);
+    setupBackgroundReview(pi, mockStore, null, config);
 
     fireMessageEnd("user");
     fireMessageEnd("user");
@@ -527,7 +538,7 @@ describe("setupBackgroundReview", () => {
   it("falls back gracefully if getBranch throws", async () => {
     const config = { ...defaultConfig, nudgeToolCalls: 3 };
     const pi = createMockPi();
-    setupBackgroundReview(pi, mockStore, config);
+    setupBackgroundReview(pi, mockStore, null, config);
 
     fireMessageEnd("user");
     fireMessageEnd("user");

--- a/tests/handlers/correction-detector.test.ts
+++ b/tests/handlers/correction-detector.test.ts
@@ -197,6 +197,7 @@ describe("setupCorrectionDetector handler", () => {
     reviewEnabled: false,
     memoryCharLimit: 2200,
     userCharLimit: 1375,
+    projectCharLimit: 2200,
     flushOnCompact: false,
     flushOnShutdown: false,
     flushMinTurns: 6,
@@ -246,7 +247,7 @@ describe("setupCorrectionDetector handler", () => {
 
   it("triggers pi.exec when correction detected", async () => {
     const pi = createMockPi();
-    setupCorrectionDetector(pi, mockStore, config);
+    setupCorrectionDetector(pi, mockStore, null, config);
 
     const branch = [
       { type: "message", message: { role: "user", content: [{ type: "text", text: "don't do that" }] } },
@@ -262,7 +263,7 @@ describe("setupCorrectionDetector handler", () => {
 
   it("does NOT trigger on normal messages", async () => {
     const pi = createMockPi();
-    setupCorrectionDetector(pi, mockStore, config);
+    setupCorrectionDetector(pi, mockStore, null, config);
 
     fireMessageEnd("user", "looks good");
     fireTurnEnd([]);
@@ -273,7 +274,7 @@ describe("setupCorrectionDetector handler", () => {
 
   it("rate limits: does not trigger on consecutive corrections within 3 turns", async () => {
     const pi = createMockPi();
-    setupCorrectionDetector(pi, mockStore, config);
+    setupCorrectionDetector(pi, mockStore, null, config);
 
     // First correction
     fireMessageEnd("user", "don't do that");
@@ -294,7 +295,7 @@ describe("setupCorrectionDetector handler", () => {
   it("does not register handlers when correctionDetection is false", () => {
     const pi = createMockPi();
     const disabledConfig = { ...config, correctionDetection: false };
-    setupCorrectionDetector(pi, mockStore, disabledConfig);
+    setupCorrectionDetector(pi, mockStore, null, disabledConfig);
 
     assert.strictEqual(Object.keys(handlers).length, 0, "no handlers should be registered when disabled");
   });

--- a/tests/handlers/insights.test.ts
+++ b/tests/handlers/insights.test.ts
@@ -28,7 +28,7 @@ async function setupCommand(
     },
   };
 
-  registerInsightsCommand(mockPi as any, mockStore as any);
+  registerInsightsCommand(mockPi as any, mockStore as any, null, "test-project");
 
   assert.ok(commands.length === 1, "Expected exactly one registered command");
   return { handler: commands[0].handler, notifyCalls };

--- a/tests/handlers/session-flush.test.ts
+++ b/tests/handlers/session-flush.test.ts
@@ -43,6 +43,7 @@ function defaultConfig(overrides: Partial<MemoryConfig> = {}): MemoryConfig {
   return {
     memoryCharLimit: 2200,
     userCharLimit: 1375,
+    projectCharLimit: 2200,
     nudgeInterval: 10,
     reviewEnabled: true,
     flushOnCompact: true,
@@ -90,7 +91,7 @@ describe("setupSessionFlush", () => {
 
   it("session_before_compact triggers flush when flushOnCompact is true", async () => {
     const config = defaultConfig();
-    setupSessionFlush(mockPi.pi, mockStore, config);
+    setupSessionFlush(mockPi.pi, mockStore, null, config);
 
     // Simulate enough user turns
     await emitUserTurns(mockPi.handlers, 8);
@@ -103,7 +104,7 @@ describe("setupSessionFlush", () => {
 
   it("session_before_compact does NOT trigger when flushOnCompact is false", async () => {
     const config = defaultConfig({ flushOnCompact: false });
-    setupSessionFlush(mockPi.pi, mockStore, config);
+    setupSessionFlush(mockPi.pi, mockStore, null, config);
 
     await emitUserTurns(mockPi.handlers, 8);
 
@@ -117,7 +118,7 @@ describe("setupSessionFlush", () => {
 
   it("session_shutdown triggers flush when flushOnShutdown is true", async () => {
     const config = defaultConfig();
-    setupSessionFlush(mockPi.pi, mockStore, config);
+    setupSessionFlush(mockPi.pi, mockStore, null, config);
 
     await emitUserTurns(mockPi.handlers, 8);
 
@@ -131,7 +132,7 @@ describe("setupSessionFlush", () => {
 
   it("session_shutdown does NOT trigger when flushOnShutdown is false", async () => {
     const config = defaultConfig({ flushOnShutdown: false });
-    setupSessionFlush(mockPi.pi, mockStore, config);
+    setupSessionFlush(mockPi.pi, mockStore, null, config);
 
     await emitUserTurns(mockPi.handlers, 8);
 
@@ -145,7 +146,7 @@ describe("setupSessionFlush", () => {
 
   it("Flush skips if userTurnCount < flushMinTurns", async () => {
     const config = defaultConfig({ flushMinTurns: 6 });
-    setupSessionFlush(mockPi.pi, mockStore, config);
+    setupSessionFlush(mockPi.pi, mockStore, null, config);
 
     // Only 3 user turns — below threshold
     await emitUserTurns(mockPi.handlers, 3);
@@ -160,7 +161,7 @@ describe("setupSessionFlush", () => {
 
   it("Flush builds conversation from sessionManager.getBranch()", async () => {
     const config = defaultConfig();
-    setupSessionFlush(mockPi.pi, mockStore, config);
+    setupSessionFlush(mockPi.pi, mockStore, null, config);
 
     await emitUserTurns(mockPi.handlers, 8);
 
@@ -183,7 +184,7 @@ describe("setupSessionFlush", () => {
 
   it("Flush uses pi.exec with correct args", async () => {
     const config = defaultConfig();
-    setupSessionFlush(mockPi.pi, mockStore, config);
+    setupSessionFlush(mockPi.pi, mockStore, null, config);
 
     await emitUserTurns(mockPi.handlers, 8);
 
@@ -224,7 +225,7 @@ describe("setupSessionFlush", () => {
     };
 
     const config = defaultConfig();
-    setupSessionFlush(failingPi.pi, mockStore, config);
+    setupSessionFlush(failingPi.pi, mockStore, null, config);
 
     await emitUserTurns(failingPi.handlers, 8);
 
@@ -243,7 +244,7 @@ describe("setupSessionFlush", () => {
     };
 
     const config = defaultConfig();
-    setupSessionFlush(failingPi.pi, mockStore, config);
+    setupSessionFlush(failingPi.pi, mockStore, null, config);
 
     await emitUserTurns(failingPi.handlers, 8);
 
@@ -258,7 +259,7 @@ describe("setupSessionFlush", () => {
 
   it("Handles empty branch (no messages)", async () => {
     const config = defaultConfig();
-    setupSessionFlush(mockPi.pi, mockStore, config);
+    setupSessionFlush(mockPi.pi, mockStore, null, config);
 
     await emitUserTurns(mockPi.handlers, 8);
 
@@ -276,7 +277,7 @@ describe("setupSessionFlush", () => {
 
   it("Concurrent compact + shutdown both flush", async () => {
     const config = defaultConfig();
-    setupSessionFlush(mockPi.pi, mockStore, config);
+    setupSessionFlush(mockPi.pi, mockStore, null, config);
 
     await emitUserTurns(mockPi.handlers, 8);
 
@@ -294,7 +295,7 @@ describe("setupSessionFlush", () => {
 
   it("Passes signal from compact event to exec", async () => {
     const config = defaultConfig();
-    setupSessionFlush(mockPi.pi, mockStore, config);
+    setupSessionFlush(mockPi.pi, mockStore, null, config);
 
     await emitUserTurns(mockPi.handlers, 8);
 

--- a/tests/handlers/skill-auto-trigger.test.ts
+++ b/tests/handlers/skill-auto-trigger.test.ts
@@ -43,6 +43,7 @@ const config = {
   reviewEnabled: false,
   memoryCharLimit: 2200,
   userCharLimit: 1375,
+  projectCharLimit: 2200,
   flushOnCompact: false,
   flushOnShutdown: false,
   flushMinTurns: 6,
@@ -100,8 +101,30 @@ function fireTurnEnd(branch: any[]) {
   const h = handlers["turn_end"];
   if (!h) throw new Error("No turn_end handler registered");
   const ctx = makeCtx(branch);
+  // Extract the first assistant message with tool calls to pass as event.message
+  // In a real Pi session, turn_end fires with the assistant message just generated
+  let assistantMessage = undefined;
+  for (const entry of branch) {
+    if (entry?.message?.role === "assistant") {
+      const content = entry.message.content;
+      if (Array.isArray(content) && content.some((b: any) => b?.type === "toolCall")) {
+        assistantMessage = entry.message;
+        break;
+      }
+    }
+  }
+  // Fall back to last assistant message if no tool-call message found
+  if (!assistantMessage) {
+    for (let i = branch.length - 1; i >= 0; i--) {
+      if (branch[i]?.message?.role === "assistant") {
+        assistantMessage = branch[i].message;
+        break;
+      }
+    }
+  }
+  const event = assistantMessage ? { message: assistantMessage } : {};
   for (const fn of h) {
-    fn({}, ctx);
+    fn(event, ctx);
   }
   return ctx;
 }

--- a/tests/handlers/system-prompt.test.ts
+++ b/tests/handlers/system-prompt.test.ts
@@ -21,6 +21,7 @@ let TEST_MEMORY_DIR = "";
 const testConfig = (): MemoryConfig => ({
   memoryCharLimit: 2200,
   userCharLimit: 1375,
+  projectCharLimit: 2200,
   nudgeInterval: 10,
   reviewEnabled: true,
   flushOnCompact: true,

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Run each test file in its own tsx process to avoid node:test runner hang.
+set -euo pipefail
+
+PASS=0
+
+for f in $(find tests -name '*.test.ts' | sort); do
+  echo "--- $f ---"
+  npx tsx --test "$f" || { echo "FAILED: $f"; exit 1; }
+  PASS=$((PASS + 1))
+done
+
+echo "All $PASS test files passed"

--- a/tests/store/memory-store.test.ts
+++ b/tests/store/memory-store.test.ts
@@ -31,6 +31,7 @@ function makeConfig(overrides?: Partial<MemoryConfig>): MemoryConfig {
   return {
     memoryCharLimit: DEFAULT_MEMORY_CHAR_LIMIT,
     userCharLimit: DEFAULT_USER_CHAR_LIMIT,
+    projectCharLimit: 2200,
     nudgeInterval: 10,
     reviewEnabled: false,
     flushOnCompact: false,
@@ -267,7 +268,7 @@ describe("MemoryStore", { concurrency: 1 }, () => {
       await store.add("memory", `${TEST_MARKER} uses vim`);
       await settle();
 
-      const result = store.replace("memory", `${TEST_MARKER} uses vim`, `${TEST_MARKER} uses neovim`);
+      const result = await store.replace("memory", `${TEST_MARKER} uses vim`, `${TEST_MARKER} uses neovim`);
       await settle();
 
       assert.ok(result.success);
@@ -285,7 +286,7 @@ describe("MemoryStore", { concurrency: 1 }, () => {
       await store.add("memory", `${TEST_MARKER} some entry`);
       await settle();
 
-      const result = store.replace("memory", "nonexistent substring", "new content");
+      const result = await store.replace("memory", "nonexistent substring", "new content");
       await settle();
 
       assert.ok(!result.success);
@@ -300,7 +301,7 @@ describe("MemoryStore", { concurrency: 1 }, () => {
       await store.add("memory", `${TEST_MARKER} config: port=9090`);
       await settle();
 
-      const result = store.replace("memory", "config:", `${TEST_MARKER} unified config`);
+      const result = await store.replace("memory", "config:", `${TEST_MARKER} unified config`);
       await settle();
 
       assert.ok(!result.success);
@@ -313,7 +314,7 @@ describe("MemoryStore", { concurrency: 1 }, () => {
       const store = new MemoryStore(makeConfig());
       await store.add("memory", `${TEST_MARKER} some entry`);
 
-      const result = store.replace("memory", "  ", "new content");
+      const result = await store.replace("memory", "  ", "new content");
 
       assert.ok(!result.success);
       assert.equal(result.error, "old_text cannot be empty.");
@@ -323,7 +324,7 @@ describe("MemoryStore", { concurrency: 1 }, () => {
       const store = new MemoryStore(makeConfig());
       await store.add("memory", `${TEST_MARKER} some entry`);
 
-      const result = store.replace("memory", `${TEST_MARKER} some entry`, "   ");
+      const result = await store.replace("memory", `${TEST_MARKER} some entry`, "   ");
 
       assert.ok(!result.success);
       assert.equal(result.error, "new_content cannot be empty. Use 'remove' to delete entries.");
@@ -341,7 +342,7 @@ describe("MemoryStore", { concurrency: 1 }, () => {
       await store.add("memory", `${TEST_MARKER} to keep`);
       await settle();
 
-      const result = store.remove("memory", `${TEST_MARKER} to be removed`);
+      const result = await store.remove("memory", `${TEST_MARKER} to be removed`);
       await settle();
 
       assert.ok(result.success);
@@ -360,7 +361,7 @@ describe("MemoryStore", { concurrency: 1 }, () => {
       await store.add("memory", `${TEST_MARKER} existing`);
       await settle();
 
-      const result = store.remove("memory", "nonexistent");
+      const result = await store.remove("memory", "nonexistent");
       await settle();
 
       assert.ok(!result.success);
@@ -371,7 +372,7 @@ describe("MemoryStore", { concurrency: 1 }, () => {
       const store = new MemoryStore(makeConfig());
       await store.add("memory", `${TEST_MARKER} some entry`);
 
-      const result = store.remove("memory", "  ");
+      const result = await store.remove("memory", "  ");
 
       assert.ok(!result.success);
       assert.equal(result.error, "old_text cannot be empty.");
@@ -498,7 +499,7 @@ describe("MemoryStore", { concurrency: 1 }, () => {
       let raw = await readRaw(memoryPath);
       assert.ok(raw.length > 0);
 
-      store.remove("memory", `${TEST_MARKER} temporary entry`);
+      await store.remove("memory", `${TEST_MARKER} temporary entry`);
       await settle();
 
       raw = await readRaw(memoryPath);

--- a/tests/tools/memory-tool.test.ts
+++ b/tests/tools/memory-tool.test.ts
@@ -26,7 +26,7 @@ describe("registerMemoryTool", () => {
       remove: () => ({ success: true, target: "memory", entries: [], usage: "0% — 0/100 chars", entry_count: 0 }),
     } as unknown as MemoryStore;
 
-    registerMemoryTool(mockPi, mockStore);
+    registerMemoryTool(mockPi, mockStore, null);
 
     assert.strictEqual(registeredTools.length, 1, "should register exactly one tool");
     const tool = registeredTools[0];
@@ -58,7 +58,7 @@ describe("registerMemoryTool", () => {
       }),
     } as unknown as MemoryStore;
 
-    registerMemoryTool(mockPi, mockStore);
+    registerMemoryTool(mockPi, mockStore, null);
     const result = await capturedResult.execute("tc-1", { action: "add", target: "memory", content: "Entry one" }, undefined as any, undefined as any, undefined as any);
 
     assert.strictEqual(result.content[0].type, "text", "content should be text type");
@@ -81,7 +81,7 @@ describe("registerMemoryTool", () => {
 
     const mockStore = {} as unknown as MemoryStore;
 
-    registerMemoryTool(mockPi, mockStore);
+    registerMemoryTool(mockPi, mockStore, null);
     const result = await capturedResult.execute("tc-1", { action: "add", target: "memory" }, undefined as any, undefined as any, undefined as any);
 
     const parsed = JSON.parse(result.content[0].text);
@@ -100,7 +100,7 @@ describe("registerMemoryTool", () => {
 
     const mockStore = {} as unknown as MemoryStore;
 
-    registerMemoryTool(mockPi, mockStore);
+    registerMemoryTool(mockPi, mockStore, null);
     const result = await capturedResult.execute("tc-1", { action: "replace", target: "memory", content: "new" }, undefined as any, undefined as any, undefined as any);
 
     const parsed = JSON.parse(result.content[0].text);
@@ -119,7 +119,7 @@ describe("registerMemoryTool", () => {
 
     const mockStore = {} as unknown as MemoryStore;
 
-    registerMemoryTool(mockPi, mockStore);
+    registerMemoryTool(mockPi, mockStore, null);
     const result = await capturedResult.execute("tc-1", { action: "remove", target: "memory" }, undefined as any, undefined as any, undefined as any);
 
     const parsed = JSON.parse(result.content[0].text);
@@ -144,7 +144,7 @@ describe("registerMemoryTool", () => {
       },
     } as unknown as MemoryStore;
 
-    registerMemoryTool(mockPi, mockStore);
+    registerMemoryTool(mockPi, mockStore, null);
     await capturedResult.execute("tc-1", { action: "replace", target: "memory", content: "new", old_text: "old" }, undefined as any, undefined as any, undefined as any);
 
     assert.deepStrictEqual(replaceArgs, ["memory", "old", "new"], "should pass target, old_text, content to store.replace");
@@ -167,7 +167,7 @@ describe("registerMemoryTool", () => {
       },
     } as unknown as MemoryStore;
 
-    registerMemoryTool(mockPi, mockStore);
+    registerMemoryTool(mockPi, mockStore, null);
     await capturedResult.execute("tc-1", { action: "remove", target: "memory", old_text: "old entry" }, undefined as any, undefined as any, undefined as any);
 
     assert.deepStrictEqual(removeArgs, ["memory", "old entry"], "should pass target, old_text to store.remove");


### PR DESCRIPTION
## Summary

The memory extension now supports project-scoped memory alongside global memory and user profiles. Project-specific notes are kept in `~/.pi/agent/<project>/` and injected into the system prompt with a distinct header, keeping codebase conventions, API quirks, and team norms separate from global notes. The tool-call counter in the background review and skill auto-trigger handlers was also corrected to count calls per message rather than cumulatively across the full branch, fixing review spam after the first cycle. Disk saves are now properly awaited instead of fire-and-forget.

## What changed

**Project memory.** A third `project` target joins `memory` and `user`. When `cwd` differs from `$HOME`, a separate `MemoryStore` instance is created for the project directory. The `memory` tool routes `target: "project"` to this store; if no project is detected, it returns an error. Project memory uses its own `projectCharLimit` config (default 2200) and is excluded from `/memory-sync`.

**System prompt.** The `formatProjectBlock()` method renders a `PROJECT MEMORY: <name>` block with a usage gauge, injected on `before_agent_start` below the global memory block. The background review and correction detector both include project memory in the context sent to `pi.exec`. The `/memory-insights` command displays a project section.

**Tool-call counting.** `background-review.ts` and `skill-auto-trigger.ts` now read `event.message` for the current turn's tool calls instead of scanning the full branch with `getBranch()`. The old approach re-counted every historical tool call after each review, causing the nudge to fire on almost every subsequent turn.

**Async disk writes.** `saveToDisk()` changed from fire-and-forget to `async/await`, propagated through `add()`, `replace()`, and `remove()`. The atomic write (temp file + `fs.rename()`) is preserved.

**Config.** New `projectCharLimit` and `memoryDir` fields in `MemoryConfig`. `projectCharLimit` overrides `memoryCharLimit` for the project store. Existing configs without these fields fall back to defaults.

---

