### PR TITLE
Make failure memory injection configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,9 @@ Create `~/.pi/agent/hermes-memory-config.json`:
   "reviewEnabled": true,
   "autoConsolidate": true,
   "correctionDetection": true,
+  "failureInjectionEnabled": true,
+  "failureInjectionMaxAgeDays": 7,
+  "failureInjectionMaxEntries": 5,
   "flushOnCompact": true,
   "flushOnShutdown": true,
   "flushMinTurns": 6
@@ -380,6 +383,9 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 | `reviewEnabled` | `true` | Enable/disable background learning loop |
 | `autoConsolidate` | `true` | Auto-merge when memory hits capacity |
 | `correctionDetection` | `true` | Detect user corrections and save immediately |
+| `failureInjectionEnabled` | `true` | Enable/disable injecting recent failure memories into the system prompt |
+| `failureInjectionMaxAgeDays` | `7` | Maximum age in days for injected failure memories |
+| `failureInjectionMaxEntries` | `5` | Maximum number of failure memories to inject |
 | `flushOnCompact` | `true` | Flush memories before Pi compacts context |
 | `flushOnShutdown` | `true` | Flush memories when session ends |
 | `flushMinTurns` | `6` | Minimum turns before flush triggers |

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,8 @@ import {
   DEFAULT_NUDGE_INTERVAL,
   DEFAULT_FLUSH_MIN_TURNS,
   DEFAULT_NUDGE_TOOL_CALLS,
+  DEFAULT_FAILURE_INJECTION_MAX_AGE_DAYS,
+  DEFAULT_FAILURE_INJECTION_MAX_ENTRIES,
 } from "./constants.js";
 
 const DEFAULT_CONFIG: MemoryConfig = {
@@ -22,6 +24,9 @@ const DEFAULT_CONFIG: MemoryConfig = {
   flushMinTurns: DEFAULT_FLUSH_MIN_TURNS,
   autoConsolidate: true,
   correctionDetection: true,
+  failureInjectionEnabled: true,
+  failureInjectionMaxAgeDays: DEFAULT_FAILURE_INJECTION_MAX_AGE_DAYS,
+  failureInjectionMaxEntries: DEFAULT_FAILURE_INJECTION_MAX_ENTRIES,
   nudgeToolCalls: DEFAULT_NUDGE_TOOL_CALLS,
 };
 
@@ -48,6 +53,9 @@ export function loadConfig(): MemoryConfig {
       if (typeof parsed.flushMinTurns === "number") config.flushMinTurns = parsed.flushMinTurns;
       if (typeof parsed.autoConsolidate === "boolean") config.autoConsolidate = parsed.autoConsolidate;
       if (typeof parsed.correctionDetection === "boolean") config.correctionDetection = parsed.correctionDetection;
+      if (typeof parsed.failureInjectionEnabled === "boolean") config.failureInjectionEnabled = parsed.failureInjectionEnabled;
+      if (typeof parsed.failureInjectionMaxAgeDays === "number") config.failureInjectionMaxAgeDays = parsed.failureInjectionMaxAgeDays;
+      if (typeof parsed.failureInjectionMaxEntries === "number") config.failureInjectionMaxEntries = parsed.failureInjectionMaxEntries;
       if (typeof parsed.nudgeToolCalls === "number") config.nudgeToolCalls = parsed.nudgeToolCalls;
       if (typeof parsed.projectCharLimit === "number") config.projectCharLimit = parsed.projectCharLimit;
       if (typeof parsed.memoryDir === "string") config.memoryDir = parsed.memoryDir;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,8 @@ export const DEFAULT_NUDGE_INTERVAL = 10;
 export const DEFAULT_FLUSH_MIN_TURNS = 6;
 export const DEFAULT_NUDGE_TOOL_CALLS = 15;
 export const DEFAULT_SKILL_TRIGGER_TOOL_CALLS = 8;
+export const DEFAULT_FAILURE_INJECTION_MAX_AGE_DAYS = 7;
+export const DEFAULT_FAILURE_INJECTION_MAX_ENTRIES = 5;
 
 // ─── File names ───
 export const MEMORY_FILE = "MEMORY.md";

--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -19,6 +19,8 @@ import {
   ENTRY_DELIMITER,
   DEFAULT_MEMORY_CHAR_LIMIT,
   DEFAULT_USER_CHAR_LIMIT,
+  DEFAULT_FAILURE_INJECTION_MAX_AGE_DAYS,
+  DEFAULT_FAILURE_INJECTION_MAX_ENTRIES,
   MEMORY_FILE,
   USER_FILE,
 } from "../constants.js";
@@ -280,12 +282,17 @@ export class MemoryStore {
     if (this.snapshot.user) parts.push(this.fenceBlock(this.snapshot.user));
 
     // Add recent failure memories
-    const recentFailures = this.getFailureEntries(7);
-    if (recentFailures.length > 0) {
-      const maxFailures = 5;
-      const failures = recentFailures.slice(0, maxFailures);
-      const failureBlock = this.renderFailureBlock(failures);
-      parts.push(this.fenceBlock(failureBlock));
+    if (this.config.failureInjectionEnabled !== false) {
+      const maxAgeDays = this.config.failureInjectionMaxAgeDays ?? DEFAULT_FAILURE_INJECTION_MAX_AGE_DAYS;
+      const maxFailures = this.config.failureInjectionMaxEntries ?? DEFAULT_FAILURE_INJECTION_MAX_ENTRIES;
+      const recentFailures = this.getFailureEntries(maxAgeDays);
+      if (recentFailures.length > 0) {
+        const failures = recentFailures.slice(0, maxFailures);
+        if (failures.length > 0) {
+          const failureBlock = this.renderFailureBlock(failures);
+          parts.push(this.fenceBlock(failureBlock));
+        }
+      }
     }
 
     return parts.join("\n\n");

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,12 @@ export interface MemoryConfig {
   autoConsolidate: boolean;
   /** Detect user corrections and trigger immediate memory save. Default: true */
   correctionDetection: boolean;
+  /** Inject recent failure memories into the system prompt. Default: true */
+  failureInjectionEnabled: boolean;
+  /** Maximum age in days for injected failure memories. Default: 7 */
+  failureInjectionMaxAgeDays: number;
+  /** Maximum number of failure memories to inject. Default: 5 */
+  failureInjectionMaxEntries: number;
   /** Tool calls before triggering background review (in addition to turn count). Default: 15 */
   nudgeToolCalls: number;
   /** Enable session history search via SQLite FTS5. Default: true */

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -15,6 +15,9 @@ describe("loadConfig", () => {
     assert.strictEqual(config.flushOnCompact, true);
     assert.strictEqual(config.flushOnShutdown, true);
     assert.strictEqual(config.flushMinTurns, 6);
+    assert.strictEqual(config.failureInjectionEnabled, true);
+    assert.strictEqual(config.failureInjectionMaxAgeDays, 7);
+    assert.strictEqual(config.failureInjectionMaxEntries, 5);
   });
 
   it("overrides defaults when config file exists", () => {
@@ -23,10 +26,16 @@ describe("loadConfig", () => {
     fs.writeFileSync(DEFAULT_CONFIG_PATH, JSON.stringify({
       memoryCharLimit: 3000,
       nudgeInterval: 15,
+      failureInjectionEnabled: false,
+      failureInjectionMaxAgeDays: 30,
+      failureInjectionMaxEntries: 2,
     }));
     const config = loadConfig();
     assert.strictEqual(config.memoryCharLimit, 3000);
     assert.strictEqual(config.nudgeInterval, 15);
+    assert.strictEqual(config.failureInjectionEnabled, false);
+    assert.strictEqual(config.failureInjectionMaxAgeDays, 30);
+    assert.strictEqual(config.failureInjectionMaxEntries, 2);
     // Unset values use defaults
     assert.strictEqual(config.userCharLimit, 5000);
     assert.strictEqual(config.reviewEnabled, true);
@@ -40,6 +49,9 @@ describe("loadConfig", () => {
     const config = loadConfig();
     assert.strictEqual(config.reviewEnabled, false);
     assert.strictEqual(config.memoryCharLimit, 5000); // default
+    assert.strictEqual(config.failureInjectionEnabled, true);
+    assert.strictEqual(config.failureInjectionMaxAgeDays, 7);
+    assert.strictEqual(config.failureInjectionMaxEntries, 5);
     fs.rmSync(DEFAULT_CONFIG_PATH);
   });
 

--- a/tests/store/memory-store.test.ts
+++ b/tests/store/memory-store.test.ts
@@ -65,16 +65,29 @@ async function removeFile(filePath: string): Promise<void> {
   try { await fs.unlink(filePath); } catch { /* ignore */ }
 }
 
+function dateDaysAgo(days: number): string {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return date.toISOString().split("T")[0];
+}
+
+function failureEntry(text: string, createdDaysAgo = 0): string {
+  const date = dateDaysAgo(createdDaysAgo);
+  return `${text} <!-- created=${date}, last=${date} -->`;
+}
+
 // ─── Tests ───
 
 describe("MemoryStore", { concurrency: 1 }, () => {
   let memoryPath = "";
   let userPath = "";
+  let failurePath = "";
 
   before(async () => {
     MEMORY_DIR = await fs.mkdtemp(path.join(os.tmpdir(), "pi-memory-test-"));
     memoryPath = path.join(MEMORY_DIR, MEMORY_FILE);
     userPath = path.join(MEMORY_DIR, USER_FILE);
+    failurePath = path.join(MEMORY_DIR, "failures.md");
   });
 
   after(async () => {
@@ -93,10 +106,12 @@ describe("MemoryStore", { concurrency: 1 }, () => {
   async function cleanSlate(): Promise<void> {
     await removeFile(memoryPath);
     await removeFile(userPath);
+    await removeFile(failurePath);
     await new Promise((r) => setTimeout(r, 250));
     // Remove again in case a pending write sneaked in during the wait
     await removeFile(memoryPath);
     await removeFile(userPath);
+    await removeFile(failurePath);
     await new Promise((r) => setTimeout(r, 50));
   }
 
@@ -449,6 +464,69 @@ describe("MemoryStore", { concurrency: 1 }, () => {
 
       const result = store.formatForSystemPrompt();
       assert.equal(result, "");
+    });
+
+    it("injects recent failure memories by default", async () => {
+      await writeRaw(failurePath, [
+        failureEntry(`${TEST_MARKER} failure 1`),
+        failureEntry(`${TEST_MARKER} failure 2`),
+        failureEntry(`${TEST_MARKER} failure 3`),
+        failureEntry(`${TEST_MARKER} failure 4`),
+        failureEntry(`${TEST_MARKER} failure 5`),
+        failureEntry(`${TEST_MARKER} failure 6`),
+      ].join(ENTRY_DELIMITER));
+
+      const store = new MemoryStore(makeConfig());
+      await store.loadFromDisk();
+
+      const result = store.formatForSystemPrompt();
+      assert.ok(result.includes("RECENT FAILURES & LESSONS"));
+      assert.ok(result.includes(`${TEST_MARKER} failure 1`));
+      assert.ok(result.includes(`${TEST_MARKER} failure 5`));
+      assert.ok(!result.includes(`${TEST_MARKER} failure 6`), "default should preserve existing first-5 slice behavior");
+    });
+
+    it("does not inject failure memories when disabled", async () => {
+      await writeRaw(memoryPath, `${TEST_MARKER} regular memory`);
+      await writeRaw(failurePath, failureEntry(`${TEST_MARKER} disabled failure`));
+
+      const store = new MemoryStore(makeConfig({ failureInjectionEnabled: false }));
+      await store.loadFromDisk();
+
+      const result = store.formatForSystemPrompt();
+      assert.ok(result.includes(`${TEST_MARKER} regular memory`));
+      assert.ok(!result.includes("RECENT FAILURES & LESSONS"));
+      assert.ok(!result.includes(`${TEST_MARKER} disabled failure`));
+    });
+
+    it("respects configured failure injection max entries", async () => {
+      await writeRaw(failurePath, [
+        failureEntry(`${TEST_MARKER} max entry 1`),
+        failureEntry(`${TEST_MARKER} max entry 2`),
+        failureEntry(`${TEST_MARKER} max entry 3`),
+      ].join(ENTRY_DELIMITER));
+
+      const store = new MemoryStore(makeConfig({ failureInjectionMaxEntries: 2 }));
+      await store.loadFromDisk();
+
+      const result = store.formatForSystemPrompt();
+      assert.ok(result.includes(`${TEST_MARKER} max entry 1`));
+      assert.ok(result.includes(`${TEST_MARKER} max entry 2`));
+      assert.ok(!result.includes(`${TEST_MARKER} max entry 3`));
+    });
+
+    it("respects configured failure injection max age days", async () => {
+      await writeRaw(failurePath, [
+        failureEntry(`${TEST_MARKER} recent failure`, 1),
+        failureEntry(`${TEST_MARKER} old failure`, 3),
+      ].join(ENTRY_DELIMITER));
+
+      const store = new MemoryStore(makeConfig({ failureInjectionMaxAgeDays: 2 }));
+      await store.loadFromDisk();
+
+      const result = store.formatForSystemPrompt();
+      assert.ok(result.includes(`${TEST_MARKER} recent failure`));
+      assert.ok(!result.includes(`${TEST_MARKER} old failure`));
     });
 
     it("includes both memory and user blocks when both have entries", async () => {


### PR DESCRIPTION
## Summary

   Make recent failure-memory injection configurable while preserving current default
 behavior.

   Adds config options:

   - `failureInjectionEnabled` (default: `true`)
   - `failureInjectionMaxAgeDays` (default: `7`)
   - `failureInjectionMaxEntries` (default: `5`)

   ## Why

   Recent failure lessons are useful, but users should be able to reduce or disable their
 startup/system-prompt footprint.

   ## Validation

   - `npm run check`
   - `npm test`
   - Live-tested in Pi with the local branch as active extension:
     - disabled injection hides failure memories
     - `failureInjectionMaxEntries` limits injected entries
     - `failureInjectionMaxAgeDays` excludes old entries