### PR TITLE
feat: move project-scoped memory to projects-memory/subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The extension stores memory at two levels:
 | Tier | Location | What goes here | Injected when |
 |---|---|---|---|
 | **Global** | `~/.pi/agent/memory/` | Facts that apply everywhere — your name, preferences, OS, tools | Always (every session) |
-| **Project** | `~/.pi/agent/<project>/` | Facts scoped to one codebase — architecture decisions, API quirks, team norms | When cwd matches the project |
+| **Project** | `~/.pi/agent/projects-memory/<project>/` | Facts scoped to one codebase — architecture decisions, API quirks, team norms | When cwd matches the project |
 
 Both tiers are injected into the system prompt under separate `<memory-context>` blocks.
 
@@ -391,6 +391,7 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 | `userCharLimit` | `5000` | Max characters in USER.md |
 | `projectCharLimit` | `5000` | Max characters in project-scoped MEMORY.md |
 | `memoryDir` | `~/.pi/agent/memory` | Custom directory for memory files |
+| `projectsMemoryDir` | `projects-memory` | Subdirectory under `~/.pi/agent/` for project-scoped memory |
 | `nudgeInterval` | `10` | Turns between auto-reviews |
 | `nudgeToolCalls` | `15` | Tool calls between auto-reviews (OR with turns) |
 | `reviewEnabled` | `true` | Enable/disable background learning loop |
@@ -406,13 +407,21 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 ## Where Data Lives
 
 ```
-~/.pi/agent/memory/
-├── MEMORY.md          ← Agent's personal notes (env facts, patterns, lessons)
-├── USER.md            ← User profile (name, preferences, habits)
-├── sessions.db        ← SQLite database (session history + extended memory)
-└── skills/
-    ├── debug-typescript-errors.md
-    └── deploy-checklist.md
+~/.pi/agent/
+├── projects-memory/       ← ALL project-scoped memories (one subfolder per project)
+│   ├── my-project/
+│   │   └── MEMORY.md
+│   └── another-project/
+│       └── MEMORY.md
+├── memory/                ← Global memory
+│   ├── MEMORY.md          ← Agent's personal notes (env facts, patterns, lessons)
+│   ├── USER.md            ← User profile (name, preferences, habits)
+│   ├── sessions.db        ← SQLite database (session history + extended memory)
+│   └── skills/
+│       ├── debug-typescript-errors.md
+│       └── deploy-checklist.md
+├── hermes-memory-config.json
+└── ...
 ```
 
 These are plain markdown files. You can read and edit them directly if you want to curate what the agent remembers. Memory entries are separated by `§` (section sign). Skills use standard SKILL.md format with frontmatter.

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_MEMORY_CHAR_LIMIT,
   DEFAULT_USER_CHAR_LIMIT,
   DEFAULT_PROJECT_CHAR_LIMIT,
+  DEFAULT_PROJECTS_MEMORY_DIR,
   DEFAULT_NUDGE_INTERVAL,
   DEFAULT_FLUSH_MIN_TURNS,
   DEFAULT_NUDGE_TOOL_CALLS,
@@ -28,6 +29,7 @@ const DEFAULT_CONFIG: MemoryConfig = {
   failureInjectionMaxAgeDays: DEFAULT_FAILURE_INJECTION_MAX_AGE_DAYS,
   failureInjectionMaxEntries: DEFAULT_FAILURE_INJECTION_MAX_ENTRIES,
   nudgeToolCalls: DEFAULT_NUDGE_TOOL_CALLS,
+  projectsMemoryDir: DEFAULT_PROJECTS_MEMORY_DIR,
 };
 
 export const DEFAULT_CONFIG_PATH = path.join(
@@ -59,6 +61,7 @@ export function loadConfig(): MemoryConfig {
       if (typeof parsed.nudgeToolCalls === "number") config.nudgeToolCalls = parsed.nudgeToolCalls;
       if (typeof parsed.projectCharLimit === "number") config.projectCharLimit = parsed.projectCharLimit;
       if (typeof parsed.memoryDir === "string") config.memoryDir = parsed.memoryDir;
+      if (typeof parsed.projectsMemoryDir === "string") config.projectsMemoryDir = parsed.projectsMemoryDir;
       return config;
     }
   } catch {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,9 @@
 // ─── Entry delimiter (same as Hermes) ───
 export const ENTRY_DELIMITER = "\n§\n";
 
+// ─── Directory names ───
+export const DEFAULT_PROJECTS_MEMORY_DIR = "projects-memory";
+
 // ─── Character limits (not tokens — model-independent) ───
 export const DEFAULT_MEMORY_CHAR_LIMIT = 5000;
 export const DEFAULT_USER_CHAR_LIMIT = 5000;

--- a/src/handlers/switch-project.ts
+++ b/src/handlers/switch-project.ts
@@ -8,27 +8,29 @@
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { MemoryConfig } from "../types.js";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";
 
-export function registerSwitchProjectCommand(pi: ExtensionAPI): void {
+export function registerSwitchProjectCommand(pi: ExtensionAPI, config?: MemoryConfig): void {
+  const projectsMemoryDir = config?.projectsMemoryDir ?? "projects-memory";
   pi.registerCommand("memory-switch-project", {
     description: "Switch the active project for project-scoped memory",
 
     async handler(_args, ctx) {
       const homeDir = os.homedir();
       const agentDir = path.join(homeDir, ".pi", "agent");
+      const projectsDir = path.join(agentDir, projectsMemoryDir);
 
-      // Discover all project directories (subdirectories of ~/.pi/agent/ that have MEMORY.md)
+      // Discover all project directories (subdirectories of projects-memory/ that have MEMORY.md)
       let projects: string[] = [];
       try {
-        const entries = await fs.readdir(agentDir, { withFileTypes: true });
+        const entries = await fs.readdir(projectsDir, { withFileTypes: true });
         for (const entry of entries) {
           if (!entry.isDirectory()) continue;
-          if (entry.name === "memory" || entry.name === "skills") continue; // skip core dirs
           try {
-            await fs.access(path.join(agentDir, entry.name, "MEMORY.md"));
+            await fs.access(path.join(projectsDir, entry.name, "MEMORY.md"));
             projects.push(entry.name);
           } catch { /* no MEMORY.md — skip */ }
         }
@@ -57,7 +59,7 @@ export function registerSwitchProjectCommand(pi: ExtensionAPI): void {
         // Read entry count
         let entryCount = 0;
         try {
-          const raw = await fs.readFile(path.join(agentDir, proj, "MEMORY.md"), "utf-8");
+          const raw = await fs.readFile(path.join(projectsDir, proj, "MEMORY.md"), "utf-8");
           entryCount = raw.split("\n§\n").filter(Boolean).length;
         } catch { /* ignore */ }
 

--- a/src/handlers/sync-markdown-memories.ts
+++ b/src/handlers/sync-markdown-memories.ts
@@ -50,13 +50,13 @@ function importEntries(
   }
 }
 
-function scanProjectDirs(agentRoot: string, globalDir: string): Array<{ name: string; memoryFile: string }> {
-  if (!fs.existsSync(agentRoot)) return [];
-  const globalDirName = path.basename(globalDir);
+function scanProjectDirs(agentRoot: string, globalDir: string, projectsMemoryDir = "projects-memory"): Array<{ name: string; memoryFile: string }> {
+  const projectsRoot = path.join(agentRoot, projectsMemoryDir);
+  if (!fs.existsSync(projectsRoot)) return [];
 
-  return fs.readdirSync(agentRoot)
-    .map((name) => ({ name, dir: path.join(agentRoot, name) }))
-    .filter(({ name, dir }) => name !== globalDirName && fs.existsSync(dir) && fs.statSync(dir).isDirectory())
+  return fs.readdirSync(projectsRoot)
+    .map((name) => ({ name, dir: path.join(projectsRoot, name) }))
+    .filter(({ dir }) => fs.existsSync(dir) && fs.statSync(dir).isDirectory())
     .map(({ name, dir }) => ({ name, memoryFile: path.join(dir, MEMORY_FILE) }))
     .filter(({ memoryFile }) => fs.existsSync(memoryFile));
 }
@@ -65,6 +65,7 @@ export function registerSyncMarkdownMemoriesCommand(
   pi: ExtensionAPI,
   dbManager: DatabaseManager,
   globalDir: string,
+  projectsMemoryDir?: string,
 ): void {
   pi.registerCommand('memory-sync-markdown', {
     description: 'Backfill Markdown memories into the SQLite search store',
@@ -100,7 +101,7 @@ export function registerSyncMarkdownMemoriesCommand(
         importFile(globalFailureFile, 'failure');
 
         const agentRoot = path.dirname(globalDir);
-        const projects = scanProjectDirs(agentRoot, globalDir);
+        const projects = scanProjectDirs(agentRoot, globalDir, projectsMemoryDir);
         for (const project of projects) {
           importFile(project.memoryFile, 'memory', project.name);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export default function (pi: ExtensionAPI) {
   const dbManager = new DatabaseManager(globalDir);
 
   // Detect project from cwd using shared helper
-  const project = detectProject();
+  const project = detectProject(config.projectsMemoryDir);
 
   // Project-scoped store: ~/.pi/agent/<project_name>/
   const projectConfig = project.memoryDir
@@ -120,9 +120,9 @@ export default function (pi: ExtensionAPI) {
   registerInsightsCommand(pi, store, projectStore, projectName);
   registerSkillsCommand(pi, skillStore);
   registerInterviewCommand(pi, store);
-  registerSwitchProjectCommand(pi);
+  registerSwitchProjectCommand(pi, config);
   registerLearnMemoryCommand(pi);
-  registerSyncMarkdownMemoriesCommand(pi, dbManager, globalDir);
+  registerSyncMarkdownMemoriesCommand(pi, dbManager, globalDir, config.projectsMemoryDir);
   registerPreviewContextCommand(pi, store, projectStore, skillStore, projectName);
 
   // ── 11. SQLite session search + extended memory ──

--- a/src/project.ts
+++ b/src/project.ts
@@ -18,9 +18,9 @@ export interface ProjectInfo {
  *
  * A "project" is any directory that is not the user's home directory.
  * The project name is the directory's basename.
- * Project-scoped memory is stored at ~/.pi/agent/<projectName>/.
+ * Project-scoped memory is stored at ~/.pi/agent/<projectsMemoryDir>/<projectName>/.
  */
-export function detectProject(cwd?: string): ProjectInfo {
+export function detectProject(projectsMemoryDir = "projects-memory", cwd?: string): ProjectInfo {
   const dir = cwd ?? process.cwd();
   const homeDir = os.homedir();
 
@@ -39,6 +39,6 @@ export function detectProject(cwd?: string): ProjectInfo {
 
   return {
     name,
-    memoryDir: path.join(homeDir, ".pi", "agent", name),
+    memoryDir: path.join(homeDir, ".pi", "agent", projectsMemoryDir, name),
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,8 @@ export interface MemoryConfig {
   flushMinTurns: number;
   /** Override memory directory. Default: ~/.pi/agent/memory */
   memoryDir?: string;
+  /** Directory for project-scoped memory (relative to ~/.pi/agent). Default: "projects-memory" */
+  projectsMemoryDir?: string;
   /** Auto-consolidate when memory is full instead of returning error. Default: true */
   autoConsolidate: boolean;
   /** Detect user corrections and trigger immediate memory save. Default: true */

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -18,6 +18,7 @@ describe("loadConfig", () => {
     assert.strictEqual(config.failureInjectionEnabled, true);
     assert.strictEqual(config.failureInjectionMaxAgeDays, 7);
     assert.strictEqual(config.failureInjectionMaxEntries, 5);
+    assert.strictEqual(config.projectsMemoryDir, "projects-memory");
   });
 
   it("overrides defaults when config file exists", () => {
@@ -29,6 +30,7 @@ describe("loadConfig", () => {
       failureInjectionEnabled: false,
       failureInjectionMaxAgeDays: 30,
       failureInjectionMaxEntries: 2,
+      projectsMemoryDir: "my-memory",
     }));
     const config = loadConfig();
     assert.strictEqual(config.memoryCharLimit, 3000);
@@ -36,6 +38,7 @@ describe("loadConfig", () => {
     assert.strictEqual(config.failureInjectionEnabled, false);
     assert.strictEqual(config.failureInjectionMaxAgeDays, 30);
     assert.strictEqual(config.failureInjectionMaxEntries, 2);
+    assert.strictEqual(config.projectsMemoryDir, "my-memory");
     // Unset values use defaults
     assert.strictEqual(config.userCharLimit, 5000);
     assert.strictEqual(config.reviewEnabled, true);
@@ -52,6 +55,7 @@ describe("loadConfig", () => {
     assert.strictEqual(config.failureInjectionEnabled, true);
     assert.strictEqual(config.failureInjectionMaxAgeDays, 7);
     assert.strictEqual(config.failureInjectionMaxEntries, 5);
+    assert.strictEqual(config.projectsMemoryDir, "projects-memory");
     fs.rmSync(DEFAULT_CONFIG_PATH);
   });
 

--- a/tests/handlers/sync-markdown-memories.test.ts
+++ b/tests/handlers/sync-markdown-memories.test.ts
@@ -79,7 +79,7 @@ describe('memory sqlite sync + markdown backfill', () => {
     fs.writeFileSync(path.join(globalDir, 'USER.md'), userEntries.join(ENTRY_DELIMITER), 'utf-8');
     fs.writeFileSync(path.join(globalDir, 'failures.md'), failureEntries.join(ENTRY_DELIMITER), 'utf-8');
 
-    const projectDir = path.join(agentRoot, 'project-a');
+    const projectDir = path.join(agentRoot, 'projects-memory', 'project-a');
     fs.mkdirSync(projectDir, { recursive: true });
     fs.writeFileSync(
       path.join(projectDir, 'MEMORY.md'),


### PR DESCRIPTION
# feat: move project-scoped memory to projects-memory/ subdirectory

## Summary

Move per-project memory from `~/.pi/agent/<project>/` to `~/.pi/agent/projects-memory/<project>/` to keep the agent configuration directory clean.

**Before:**

```
~/.pi/agent/
├── nix-darwin-config/    ← clutters main config directory
├── my-project/            ← each new project adds noise
├── memory/                ← global memory
├── settings.json
└── ...
```

**After:**

```
~/.pi/agent/
├── projects-memory/       ← one folder for all projects
│   ├── nix-darwin-config/
│   └── my-project/
├── memory/                ← global memory
├── settings.json
└── ...
```

## Why

Every project created a top-level directory in `~/.pi/agent/`, mixing config files (`settings.json`, `mcp.json`) with project data. This reorganization keeps the agent directory clean as the number of projects grows.

The base directory is configurable via `projectsMemoryDir` in `hermes-memory-config.json`, defaulting to `"projects-memory"`.

## What changed

| File                                            | Change                                                     |
| ----------------------------------------------- | ---------------------------------------------------------- |
| `src/types.ts`                                  | Add `projectsMemoryDir?: string` to `MemoryConfig`         |
| `src/constants.ts`                              | Add `DEFAULT_PROJECTS_MEMORY_DIR = "projects-memory"`      |
| `src/config.ts`                                 | Parse `projectsMemoryDir` from JSON config with default    |
| `src/project.ts`                                | `detectProject()` now accepts configurable base directory  |
| `src/index.ts`                                  | Pass `config.projectsMemoryDir` to all handlers            |
| `src/handlers/switch-project.ts`                | Scan `projects-memory/` instead of `~/.pi/agent/`          |
| `src/handlers/sync-markdown-memories.ts`        | `scanProjectDirs()` uses configurable subdirectory         |
| `tests/config.test.ts`                          | Test default and override of `projectsMemoryDir`           |
| `tests/handlers/sync-markdown-memories.test.ts` | Update test path to `projects-memory/project-a`            |
| `README.md`                                     | Update paths, config table, and "Where Data Lives" section |

## Behavior guarantees

- **Backward compatible**: existing `~/.pi/agent/<project>/` directories are not touched — only new writes go to `projects-memory/`.
- **Configurable**: users can change the subdirectory name via `projectsMemoryDir` in `hermes-memory-config.json`.
- **All existing features preserved**: auto-detection, `/memory-switch-project`, `/memory-sync-markdown`, and SQLite search all work with the new layout.

## Validation

- `npm run check` (tsc --noEmit): ✅ 0 errors
- `npm test` (22 test files, all pass): ✅
- Live-tested in Pi with local install:
  - Project-scoped `memory` tool writes land in `projects-memory/<name>/MEMORY.md`
  - Old project dirs in `~/.pi/agent/` can be safely migrated or removed
  - `/memory-switch-project` discovers projects from the new path
