### PR TITLE
fix: avoid cross-device rename (EXDEV) on Windows when TEMP is on different drive

### DIFF
--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -424,13 +424,19 @@ export class MemoryStore {
     }
   }
 
-  /** Atomic write: temp file + fs.rename() — same crash-safety as Hermes. */
+  /**
+   * Atomic write: temp file + fs.rename().
+   * Creates temp files in the same directory as the target to avoid
+   * cross-device rename errors (EXDEV) when os.tmpdir() is on a different
+   * drive than the memory directory (common on Windows).
+   */
   private async saveToDisk(target: "memory" | "user" | "failure"): Promise<void> {
     const filePath = this.pathFor(target);
     const entries = this.entriesFor(target);
     const content = entries.length ? entries.join(ENTRY_DELIMITER) : "";
 
-    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-memory-"));
+    // Use the memory directory for temp files so rename stays on the same device
+    const tmpDir = await fs.mkdtemp(path.join(this.memoryDir, ".tmp-"));
     const tmpPath = path.join(tmpDir, "write.tmp");
 
     try {
@@ -440,7 +446,7 @@ export class MemoryStore {
       try { await fs.unlink(tmpPath); } catch { /* ignore */ }
       throw err;
     } finally {
-      try { await fs.rmdir(tmpDir); } catch { /* ignore */ }
+      try { await fs.rm(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
     }
   }
 }

--- a/src/store/skill-store.ts
+++ b/src/store/skill-store.ts
@@ -283,10 +283,14 @@ export class SkillStore {
 
   // ─── Internal helpers ───
 
-  /** Atomic write: temp file + rename (same crash-safety as MemoryStore) */
+  /**
+   * Atomic write: temp file + rename.
+   * Creates temp files in the skills directory to avoid cross-device
+   * rename errors (EXDEV) on Windows when os.tmpdir() is on a different drive.
+   */
   private async atomicWrite(fileName: string, content: string): Promise<void> {
     const filePath = path.join(this.skillsDir, fileName);
-    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-skill-"));
+    const tmpDir = await fs.mkdtemp(path.join(this.skillsDir, ".tmp-"));
     const tmpPath = path.join(tmpDir, "write.tmp");
 
     try {
@@ -296,7 +300,7 @@ export class SkillStore {
       try { await fs.unlink(tmpPath); } catch { /* ignore */ }
       throw err;
     } finally {
-      try { await fs.rmdir(tmpDir); } catch { /* ignore */ }
+      try { await fs.rm(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
     }
   }
 }


### PR DESCRIPTION
## Problem

On Windows, when the TEMP environment variable points to a different drive
than the memory directory (e.g., E:\Temp vs C:\Users\...\.pi\agent\memory),
fs.rename() fails with EXDEV because Node.js cannot move files across drives.

## Fix

Changed MemoryStore.saveToDisk() and SkillStore.atomicWrite() to create temp
files in the same directory as the target instead of os.tmpdir(). Also upgraded
fs.rmdir() to fs.rm({ recursive: true, force: true }) for robust cleanup.

### Files changed
- src/store/memory-store.ts
- src/store/skill-store.ts

## Verification
- No os.tmpdir() calls remain in src/ (confirmed by grep)
- Same-device rename unaffected on Linux/macOS
- To test on Windows: set TEMP to a different drive, run memory tool