### PR TITLE
fix: migrate legacy project memory layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2026-05-11
+
+### Fixed
+
+- **Legacy project memory migration**: Users upgrading from the old `~/.pi/agent/<project>/MEMORY.md` layout now keep their existing project memories. On startup, legacy project memory files are copied or merged into `~/.pi/agent/projects-memory/<project>/MEMORY.md` without deleting the old folders.
+- **Markdown backfill compatibility**: `/memory-sync-markdown` now scans both the new `projects-memory/<project>` layout and legacy `~/.pi/agent/<project>` project folders, so existing project memories can still be imported into SQLite search.
+
+### Tests
+
+- Added migration coverage for copy, merge/dedupe, skip behavior, and legacy project backfill.
+
 ## [0.7.0] - 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -412,6 +412,8 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 
 These are plain markdown files. You can read and edit them directly if you want to curate what the agent remembers. Memory entries are separated by `§` (section sign). Skills use standard SKILL.md format with frontmatter.
 
+If you are upgrading from a version that stored project memory directly at `~/.pi/agent/<project>/MEMORY.md`, the extension copies or merges those entries into `~/.pi/agent/projects-memory/<project>/MEMORY.md` on startup. The old folders are left in place as a backup.
+
 The `sessions.db` SQLite database stores session history and extended memory entries. It's searchable via FTS5 full-text search.
 
 ## Known Limitations

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hermes-memory",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.9.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.7.0",
-  "description": "🧠 Persistent memory + 🔍 session search + 🛡️ secret scanning for Pi. Token-aware policy-only memory by default, SQLite FTS5 search, auto-consolidation, procedural skills. 362 tests. Ported from Hermes agent.",
+  "version": "0.7.1",
+  "description": "🧠 Persistent memory + 🔍 session search + 🛡️ secret scanning for Pi. Token-aware policy-only memory by default, SQLite FTS5 search, auto-consolidation, procedural skills. 366 tests. Ported from Hermes agent.",
   "type": "module",
   "main": "src/index.ts",
   "files": [

--- a/src/handlers/sync-markdown-memories.ts
+++ b/src/handlers/sync-markdown-memories.ts
@@ -52,12 +52,33 @@ function importEntries(
 
 function scanProjectDirs(agentRoot: string, globalDir: string, projectsMemoryDir = "projects-memory"): Array<{ name: string; memoryFile: string }> {
   const projectsRoot = path.join(agentRoot, projectsMemoryDir);
-  if (!fs.existsSync(projectsRoot)) return [];
+  const projects = new Map<string, string>();
 
-  return fs.readdirSync(projectsRoot)
-    .map((name) => ({ name, dir: path.join(projectsRoot, name) }))
-    .filter(({ dir }) => fs.existsSync(dir) && fs.statSync(dir).isDirectory())
-    .map(({ name, dir }) => ({ name, memoryFile: path.join(dir, MEMORY_FILE) }))
+  if (fs.existsSync(projectsRoot)) {
+    for (const name of fs.readdirSync(projectsRoot)) {
+      const dir = path.join(projectsRoot, name);
+      const memoryFile = path.join(dir, MEMORY_FILE);
+      if (fs.existsSync(dir) && fs.statSync(dir).isDirectory() && fs.existsSync(memoryFile)) {
+        projects.set(name, memoryFile);
+      }
+    }
+  }
+
+  const globalDirName = path.basename(globalDir);
+  if (fs.existsSync(agentRoot)) {
+    for (const name of fs.readdirSync(agentRoot)) {
+      if (name === globalDirName || name === projectsMemoryDir || name === 'skills' || name.startsWith('.')) continue;
+      if (projects.has(name)) continue;
+      const dir = path.join(agentRoot, name);
+      const memoryFile = path.join(dir, MEMORY_FILE);
+      if (fs.existsSync(dir) && fs.statSync(dir).isDirectory() && fs.existsSync(memoryFile)) {
+        projects.set(name, memoryFile);
+      }
+    }
+  }
+
+  return [...projects.entries()]
+    .map(([name, memoryFile]) => ({ name, memoryFile }))
     .filter(({ memoryFile }) => fs.existsSync(memoryFile));
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ import { registerPreviewContextCommand } from "./handlers/preview-context.js";
 import { loadConfig } from "./config.js";
 import { detectProject } from "./project.js";
 import { buildPromptContext } from "./prompt-context.js";
+import { migrateLegacyProjectMemoryDirs } from "./project-memory-migration.js";
 
 export default function (pi: ExtensionAPI) {
   const config = loadConfig();
@@ -58,6 +59,11 @@ export default function (pi: ExtensionAPI) {
   const store = new MemoryStore(config);
   const skillStore = new SkillStore(path.join(globalDir, "skills"));
   const dbManager = new DatabaseManager(globalDir);
+
+  // Keep project memory available for users upgrading from the old
+  // ~/.pi/agent/<project>/ layout. This is non-destructive: legacy folders
+  // remain in place while entries are copied/merged into projects-memory/.
+  migrateLegacyProjectMemoryDirs(globalDir, config.projectsMemoryDir);
 
   // Detect project from cwd using shared helper
   const project = detectProject(config.projectsMemoryDir);

--- a/src/project-memory-migration.ts
+++ b/src/project-memory-migration.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+import path from "node:path";
+import { ENTRY_DELIMITER, MEMORY_FILE } from "./constants.js";
+
+export interface ProjectMemoryMigrationResult {
+  scanned: number;
+  copied: number;
+  merged: number;
+  skipped: number;
+  warnings: string[];
+}
+
+function readEntries(filePath: string): string[] {
+  if (!fs.existsSync(filePath)) return [];
+  const raw = fs.readFileSync(filePath, "utf-8").trim();
+  if (!raw) return [];
+  return raw.split(ENTRY_DELIMITER).map((entry) => entry.trim()).filter(Boolean);
+}
+
+function writeEntries(filePath: string, entries: string[]): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, entries.join(ENTRY_DELIMITER), "utf-8");
+}
+
+function isLegacyProjectDir(agentRoot: string, projectsMemoryDir: string, name: string): boolean {
+  if (name === "memory" || name === "skills" || name === projectsMemoryDir) return false;
+  if (name.startsWith(".")) return false;
+
+  const dir = path.join(agentRoot, name);
+  return fs.existsSync(dir) && fs.statSync(dir).isDirectory() && fs.existsSync(path.join(dir, MEMORY_FILE));
+}
+
+export function migrateLegacyProjectMemoryDirs(
+  globalDir: string,
+  projectsMemoryDir = "projects-memory",
+): ProjectMemoryMigrationResult {
+  const result: ProjectMemoryMigrationResult = {
+    scanned: 0,
+    copied: 0,
+    merged: 0,
+    skipped: 0,
+    warnings: [],
+  };
+
+  const agentRoot = path.dirname(globalDir);
+  if (!fs.existsSync(agentRoot)) return result;
+
+  const projectsRoot = path.join(agentRoot, projectsMemoryDir);
+
+  for (const name of fs.readdirSync(agentRoot)) {
+    if (!isLegacyProjectDir(agentRoot, projectsMemoryDir, name)) continue;
+    result.scanned++;
+
+    const legacyFile = path.join(agentRoot, name, MEMORY_FILE);
+    const targetFile = path.join(projectsRoot, name, MEMORY_FILE);
+
+    try {
+      const legacyEntries = readEntries(legacyFile);
+      if (legacyEntries.length === 0) {
+        result.skipped++;
+        continue;
+      }
+
+      if (!fs.existsSync(targetFile)) {
+        writeEntries(targetFile, legacyEntries);
+        result.copied++;
+        continue;
+      }
+
+      const targetEntries = readEntries(targetFile);
+      const mergedEntries = [...targetEntries];
+      const seen = new Set(targetEntries);
+
+      for (const entry of legacyEntries) {
+        if (!seen.has(entry)) {
+          seen.add(entry);
+          mergedEntries.push(entry);
+        }
+      }
+
+      if (mergedEntries.length === targetEntries.length) {
+        result.skipped++;
+        continue;
+      }
+
+      writeEntries(targetFile, mergedEntries);
+      result.merged++;
+    } catch (err) {
+      result.warnings.push(`${name}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  return result;
+}

--- a/tests/handlers/sync-markdown-memories.test.ts
+++ b/tests/handlers/sync-markdown-memories.test.ts
@@ -125,4 +125,34 @@ describe('memory sqlite sync + markdown backfill', () => {
       'command should report completion',
     );
   });
+
+  it('backfills legacy project memory directories from the old ~/.pi/agent/<project> layout', async () => {
+    const legacyProjectDir = path.join(agentRoot, 'legacy-project');
+    fs.mkdirSync(legacyProjectDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(legacyProjectDir, 'MEMORY.md'),
+      'legacy project entry <!-- created=2026-05-08, last=2026-05-09 -->',
+      'utf-8',
+    );
+
+    let handler: any;
+    const mockPi = {
+      registerCommand: (_name: string, opts: any) => {
+        handler = opts.handler;
+      },
+    } as unknown as ExtensionAPI;
+
+    const ctx = {
+      ui: {
+        notify: () => {},
+      },
+    } as any;
+
+    registerSyncMarkdownMemoriesCommand(mockPi, dbManager, globalDir);
+    await handler({}, ctx);
+
+    const projectRows = getMemories(dbManager, { project: 'legacy-project', target: 'memory' });
+    assert.strictEqual(projectRows.length, 1);
+    assert.strictEqual(projectRows[0].content, 'legacy project entry');
+  });
 });

--- a/tests/project-memory-migration.test.ts
+++ b/tests/project-memory-migration.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { ENTRY_DELIMITER } from "../src/constants.js";
+import { migrateLegacyProjectMemoryDirs } from "../src/project-memory-migration.js";
+
+describe("migrateLegacyProjectMemoryDirs", () => {
+  let tmpDir: string;
+  let agentRoot: string;
+  let globalDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "project-memory-migration-test-"));
+    agentRoot = path.join(tmpDir, "agent");
+    globalDir = path.join(agentRoot, "memory");
+    fs.mkdirSync(globalDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("copies legacy project memory into projects-memory without deleting the legacy file", () => {
+    const legacyDir = path.join(agentRoot, "project-a");
+    const legacyFile = path.join(legacyDir, "MEMORY.md");
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.writeFileSync(legacyFile, "legacy project memory", "utf-8");
+
+    const result = migrateLegacyProjectMemoryDirs(globalDir);
+
+    const migratedFile = path.join(agentRoot, "projects-memory", "project-a", "MEMORY.md");
+    assert.strictEqual(fs.readFileSync(migratedFile, "utf-8"), "legacy project memory");
+    assert.strictEqual(fs.readFileSync(legacyFile, "utf-8"), "legacy project memory");
+    assert.deepStrictEqual(
+      { scanned: result.scanned, copied: result.copied, merged: result.merged, skipped: result.skipped },
+      { scanned: 1, copied: 1, merged: 0, skipped: 0 },
+    );
+  });
+
+  it("merges legacy-only entries when the new project memory file already exists", () => {
+    const legacyDir = path.join(agentRoot, "project-a");
+    const migratedDir = path.join(agentRoot, "projects-memory", "project-a");
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.mkdirSync(migratedDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(legacyDir, "MEMORY.md"),
+      ["shared", "legacy only"].join(ENTRY_DELIMITER),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(migratedDir, "MEMORY.md"),
+      ["shared", "new only"].join(ENTRY_DELIMITER),
+      "utf-8",
+    );
+
+    const result = migrateLegacyProjectMemoryDirs(globalDir);
+    const merged = fs.readFileSync(path.join(migratedDir, "MEMORY.md"), "utf-8");
+
+    assert.deepStrictEqual(merged.split(ENTRY_DELIMITER), ["shared", "new only", "legacy only"]);
+    assert.deepStrictEqual(
+      { scanned: result.scanned, copied: result.copied, merged: result.merged, skipped: result.skipped },
+      { scanned: 1, copied: 0, merged: 1, skipped: 0 },
+    );
+  });
+
+  it("skips global memory and the new projects-memory directory", () => {
+    fs.writeFileSync(path.join(globalDir, "MEMORY.md"), "global memory", "utf-8");
+    fs.mkdirSync(path.join(agentRoot, "projects-memory", "project-a"), { recursive: true });
+    fs.writeFileSync(path.join(agentRoot, "projects-memory", "project-a", "MEMORY.md"), "new memory", "utf-8");
+
+    const result = migrateLegacyProjectMemoryDirs(globalDir);
+
+    assert.deepStrictEqual(
+      { scanned: result.scanned, copied: result.copied, merged: result.merged, skipped: result.skipped },
+      { scanned: 0, copied: 0, merged: 0, skipped: 0 },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add a non-destructive startup migration from legacy `~/.pi/agent/<project>/MEMORY.md` folders into the new `~/.pi/agent/projects-memory/<project>/MEMORY.md` layout introduced around PR #18.
- Preserve existing new-layout entries, merge legacy-only entries, and leave legacy folders in place as a backup.
- Teach `/memory-sync-markdown` to scan both layouts so older installations can still backfill into SQLite.
- Bump package metadata to `0.7.1` and document the upgrade behavior.

## Verification
- `npm run check`
- `npm test` (all 24 test files, 366 tests)
- `npx tsx --test tests/project-memory-migration.test.ts tests/handlers/sync-markdown-memories.test.ts tests/config.test.ts`
- `git diff --check`