### PR TITLE
fix: index migrated project memories for search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2026-05-11
+
+### Fixed
+
+- **Searchable project-memory backfill**: Startup now runs the same Markdown-to-SQLite sync used by `/memory-sync-markdown` after migrating legacy project folders. This makes memories in `~/.pi/agent/projects-memory/<project>/MEMORY.md` searchable via `memory_search` automatically, including entries copied forward from the old `~/.pi/agent/<project>/MEMORY.md` layout.
+- **Project-scoped correction search**: Correction/failure memories captured while a project is active are now synced into SQLite with that project scope, so `memory_search` can retrieve them using the project filter.
+- **Explicit project writes**: `target="project"` now routes to the project `MEMORY.md` target explicitly before mirroring the entry into SQLite.
+
+### Tests
+
+- Added coverage proving new-layout project Markdown is indexed into SQLite and returned by `memory_search`.
+- Added coverage for project-scoped correction memory sync and explicit project target routing.
+
 ## [0.7.1] - 2026-05-11
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hermes-memory",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.9.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.7.1",
-  "description": "🧠 Persistent memory + 🔍 session search + 🛡️ secret scanning for Pi. Token-aware policy-only memory by default, SQLite FTS5 search, auto-consolidation, procedural skills. 366 tests. Ported from Hermes agent.",
+  "version": "0.7.2",
+  "description": "🧠 Persistent memory + 🔍 session search + 🛡️ secret scanning for Pi. Token-aware policy-only memory by default, SQLite FTS5 search, auto-consolidation, procedural skills. 368 tests. Ported from Hermes agent.",
   "type": "module",
   "main": "src/index.ts",
   "files": [

--- a/src/handlers/correction-detector.ts
+++ b/src/handlers/correction-detector.ts
@@ -78,6 +78,7 @@ export function setupCorrectionDetector(
   projectStore: MemoryStore | null,
   config: MemoryConfig,
   dbManager: DatabaseManager | null = null,
+  projectName?: string | null,
 ): void {
   if (!config.correctionDetection) return;
 
@@ -174,11 +175,11 @@ export function setupCorrectionDetector(
         if (correctionText) {
           const directive = extractCorrectionDirective(correctionText);
           const failureReason = "User corrected the agent";
-          const projectMarker = projectStore ? "project" : undefined;
+          const scopedProjectName = projectStore ? projectName?.trim() || null : null;
           const addResult = await store.addFailure(directive, {
             category: "correction",
             failureReason,
-            project: projectMarker,
+            project: scopedProjectName ?? undefined,
           });
 
           if (addResult.success && dbManager) {
@@ -187,9 +188,10 @@ export function setupCorrectionDetector(
                 content: formatFailureMemoryContent(directive, {
                   category: "correction",
                   failureReason,
-                  project: projectMarker,
+                  project: scopedProjectName,
                 }),
                 target: "failure",
+                project: scopedProjectName,
                 category: "correction",
                 failureReason,
               });

--- a/src/handlers/sync-markdown-memories.ts
+++ b/src/handlers/sync-markdown-memories.ts
@@ -13,7 +13,7 @@ import {
 } from '../store/sqlite-memory-store.js';
 import { ENTRY_DELIMITER, MEMORY_FILE, USER_FILE } from '../constants.js';
 
-interface BackfillCounters {
+export interface BackfillCounters {
   filesScanned: number;
   entriesScanned: number;
   imported: number;
@@ -82,6 +82,47 @@ function scanProjectDirs(agentRoot: string, globalDir: string, projectsMemoryDir
     .filter(({ memoryFile }) => fs.existsSync(memoryFile));
 }
 
+export function syncMarkdownMemoriesToSqlite(
+  dbManager: DatabaseManager,
+  globalDir: string,
+  projectsMemoryDir?: string,
+): BackfillCounters & { projectCount: number } {
+  const counters: BackfillCounters = {
+    filesScanned: 0,
+    entriesScanned: 0,
+    imported: 0,
+    skipped: 0,
+    warnings: [],
+  };
+
+  const globalMemoryFile = path.join(globalDir, MEMORY_FILE);
+  const globalUserFile = path.join(globalDir, USER_FILE);
+  const globalFailureFile = path.join(globalDir, 'failures.md');
+
+  const importFile = (
+    filePath: string,
+    target: 'memory' | 'user' | 'failure',
+    project: string | null = null,
+  ) => {
+    if (!fs.existsSync(filePath)) return;
+    counters.filesScanned++;
+    const entries = readEntries(filePath);
+    importEntries(dbManager, counters, entries, target, project);
+  };
+
+  importFile(globalMemoryFile, 'memory');
+  importFile(globalUserFile, 'user');
+  importFile(globalFailureFile, 'failure');
+
+  const agentRoot = path.dirname(globalDir);
+  const projects = scanProjectDirs(agentRoot, globalDir, projectsMemoryDir);
+  for (const project of projects) {
+    importFile(project.memoryFile, 'memory', project.name);
+  }
+
+  return { ...counters, projectCount: projects.length };
+}
+
 export function registerSyncMarkdownMemoriesCommand(
   pi: ExtensionAPI,
   dbManager: DatabaseManager,
@@ -91,41 +132,10 @@ export function registerSyncMarkdownMemoriesCommand(
   pi.registerCommand('memory-sync-markdown', {
     description: 'Backfill Markdown memories into the SQLite search store',
     handler: async (_args, ctx: ExtensionCommandContext) => {
-      const counters: BackfillCounters = {
-        filesScanned: 0,
-        entriesScanned: 0,
-        imported: 0,
-        skipped: 0,
-        warnings: [],
-      };
-
       ctx.ui.notify('🔄 Scanning Markdown memory files for SQLite backfill...', 'info');
 
       try {
-        const globalMemoryFile = path.join(globalDir, MEMORY_FILE);
-        const globalUserFile = path.join(globalDir, USER_FILE);
-        const globalFailureFile = path.join(globalDir, 'failures.md');
-
-        const importFile = (
-          filePath: string,
-          target: 'memory' | 'user' | 'failure',
-          project: string | null = null,
-        ) => {
-          if (!fs.existsSync(filePath)) return;
-          counters.filesScanned++;
-          const entries = readEntries(filePath);
-          importEntries(dbManager, counters, entries, target, project);
-        };
-
-        importFile(globalMemoryFile, 'memory');
-        importFile(globalUserFile, 'user');
-        importFile(globalFailureFile, 'failure');
-
-        const agentRoot = path.dirname(globalDir);
-        const projects = scanProjectDirs(agentRoot, globalDir, projectsMemoryDir);
-        for (const project of projects) {
-          importFile(project.memoryFile, 'memory', project.name);
-        }
+        const counters = syncMarkdownMemoriesToSqlite(dbManager, globalDir, projectsMemoryDir);
 
         let output = `\n✅ Markdown → SQLite sync complete!\n\n`;
         output += `📊 Results:\n`;
@@ -134,8 +144,8 @@ export function registerSyncMarkdownMemoriesCommand(
         output += `├─ Imported into SQLite: ${counters.imported}\n`;
         output += `└─ Skipped as duplicates: ${counters.skipped}\n`;
 
-        if (projects.length > 0) {
-          output += `\n📁 Project memories scanned: ${projects.length}\n`;
+        if (counters.projectCount > 0) {
+          output += `\n📁 Project memories scanned: ${counters.projectCount}\n`;
         }
 
         if (counters.warnings.length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ import { registerInterviewCommand } from "./handlers/interview.js";
 import { registerSwitchProjectCommand } from "./handlers/switch-project.js";
 import { registerIndexSessionsCommand } from "./handlers/index-sessions.js";
 import { registerLearnMemoryCommand } from "./handlers/learn-memory.js";
-import { registerSyncMarkdownMemoriesCommand } from "./handlers/sync-markdown-memories.js";
+import { registerSyncMarkdownMemoriesCommand, syncMarkdownMemoriesToSqlite } from "./handlers/sync-markdown-memories.js";
 import { registerPreviewContextCommand } from "./handlers/preview-context.js";
 import { loadConfig } from "./config.js";
 import { detectProject } from "./project.js";
@@ -64,6 +64,11 @@ export default function (pi: ExtensionAPI) {
   // ~/.pi/agent/<project>/ layout. This is non-destructive: legacy folders
   // remain in place while entries are copied/merged into projects-memory/.
   migrateLegacyProjectMemoryDirs(globalDir, config.projectsMemoryDir);
+  try {
+    syncMarkdownMemoriesToSqlite(dbManager, globalDir, config.projectsMemoryDir);
+  } catch {
+    // Best-effort only: failed SQLite backfill should not block extension startup.
+  }
 
   // Detect project from cwd using shared helper
   const project = detectProject(config.projectsMemoryDir);
@@ -111,7 +116,7 @@ export default function (pi: ExtensionAPI) {
   registerConsolidateCommand(pi, store);
 
   // ── 8. Setup correction detection ──
-  setupCorrectionDetector(pi, store, projectStore, config, dbManager);
+  setupCorrectionDetector(pi, store, projectStore, config, dbManager, projectName);
 
   // ── 9. Setup skill auto-trigger ──
   setupSkillAutoTrigger(pi, store, skillStore, config);

--- a/src/tools/memory-tool.ts
+++ b/src/tools/memory-tool.ts
@@ -179,8 +179,8 @@ export function registerMemoryTool(
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const { action, target: rawTarget, content, old_text, category, failure_reason } = params;
 
-      // Route 'project' to projectStore (internal target 'memory')
-      const target = rawTarget as "memory" | "user" | "failure";
+      // Route 'project' to projectStore using the normal MEMORY.md target.
+      const target = rawTarget === "project" ? "memory" : rawTarget as "memory" | "user" | "failure";
       const activeStore = rawTarget === "project" ? projectStore : store;
 
       if (rawTarget === "project" && !projectStore) {

--- a/tests/handlers/correction-detector.test.ts
+++ b/tests/handlers/correction-detector.test.ts
@@ -330,6 +330,34 @@ describe("setupCorrectionDetector handler", () => {
     assert.strictEqual(failures[0].category, 'correction');
   });
 
+  it("syncs project correction saves into SQLite with project scope", async () => {
+    const pi = createMockPi();
+    const correctionStore = {
+      ...mockStore,
+      addFailure: async () => ({ success: true, target: 'failure', entry_count: 1, message: 'Failure memory saved: correction' }),
+    } as any;
+    const projectStore = {
+      getMemoryEntries: () => [],
+    } as any;
+
+    setupCorrectionDetector(pi, correctionStore, projectStore, config, dbManager, 'project-a');
+
+    const branch = [
+      { type: "message", message: { role: "user", content: [{ type: "text", text: "no, use pnpm in this repo" }] } },
+      { type: "message", message: { role: "assistant", content: [{ type: "text", text: "ok" }] } },
+    ];
+
+    fireMessageEnd("user", "no, use pnpm in this repo");
+    fireTurnEnd(branch);
+    await settle();
+
+    const projectFailures = getMemories(dbManager, { target: 'failure', project: 'project-a' });
+    assert.strictEqual(projectFailures.length, 1);
+    assert.match(projectFailures[0].content, /use pnpm in this repo/);
+    assert.match(projectFailures[0].content, /Project: project-a/);
+    assert.strictEqual(projectFailures[0].category, 'correction');
+  });
+
   it("does not break correction handling when SQLite sync fails", async () => {
     const pi = createMockPi();
     let addFailureCalls = 0;

--- a/tests/handlers/sync-markdown-memories.test.ts
+++ b/tests/handlers/sync-markdown-memories.test.ts
@@ -6,7 +6,10 @@ import path from 'node:path';
 import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
 import { DatabaseManager } from '../../src/store/db.js';
 import { registerMemoryTool } from '../../src/tools/memory-tool.js';
-import { registerSyncMarkdownMemoriesCommand } from '../../src/handlers/sync-markdown-memories.js';
+import {
+  registerSyncMarkdownMemoriesCommand,
+  syncMarkdownMemoriesToSqlite,
+} from '../../src/handlers/sync-markdown-memories.js';
 import { ENTRY_DELIMITER } from '../../src/constants.js';
 import { getMemories, searchMemories } from '../../src/store/sqlite-memory-store.js';
 
@@ -154,5 +157,27 @@ describe('memory sqlite sync + markdown backfill', () => {
     const projectRows = getMemories(dbManager, { project: 'legacy-project', target: 'memory' });
     assert.strictEqual(projectRows.length, 1);
     assert.strictEqual(projectRows[0].content, 'legacy project entry');
+  });
+
+  it('makes new-layout project markdown searchable when startup sync runs', () => {
+    const projectDir = path.join(agentRoot, 'projects-memory', 'latest-project');
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDir, 'MEMORY.md'),
+      'latest path searchable entry <!-- created=2026-05-11, last=2026-05-11 -->',
+      'utf-8',
+    );
+
+    const counters = syncMarkdownMemoriesToSqlite(dbManager, globalDir);
+
+    assert.strictEqual(counters.projectCount, 1);
+    assert.strictEqual(counters.imported, 1);
+
+    const results = searchMemories(dbManager, 'latest path searchable entry', {
+      project: 'latest-project',
+      target: 'memory',
+    });
+    assert.strictEqual(results.length, 1);
+    assert.strictEqual(results[0].content, 'latest path searchable entry');
   });
 });

--- a/tests/tools/memory-tool.test.ts
+++ b/tests/tools/memory-tool.test.ts
@@ -120,15 +120,19 @@ describe("registerMemoryTool", () => {
       },
     } as unknown as ExtensionAPI;
 
+    const addTargets: string[] = [];
     const mockProjectStore = {
-      add: () => ({
-        success: true,
-        target: "memory",
-        entries: ["Project entry"],
-        usage: "2% — 20/5000 chars",
-        entry_count: 1,
-        message: "Entry added.",
-      }),
+      add: (target: string) => {
+        addTargets.push(target);
+        return {
+          success: true,
+          target,
+          entries: ["Project entry"],
+          usage: "2% — 20/5000 chars",
+          entry_count: 1,
+          message: "Entry added.",
+        };
+      },
     } as unknown as MemoryStore;
 
     registerMemoryTool(mockPi, {} as MemoryStore, mockProjectStore, dbManager, 'project-a');
@@ -136,6 +140,8 @@ describe("registerMemoryTool", () => {
 
     const parsed = JSON.parse(result.content[0].text);
     assert.strictEqual(parsed.target, 'project');
+    assert.strictEqual(result.details.target, 'project');
+    assert.deepStrictEqual(addTargets, ['memory']);
 
     const results = getMemories(dbManager, { project: 'project-a', target: 'memory' });
     assert.strictEqual(results.length, 1);


### PR DESCRIPTION
## Summary
- Run Markdown-to-SQLite sync on startup after legacy project memory migration, so migrated and new-layout project memories are immediately available to `memory_search`.
- Reuse the same sync path as `/memory-sync-markdown` to keep command behavior and startup behavior consistent.
- Make `target="project"` route explicitly to project `MEMORY.md` before SQLite mirroring.
- Store project-scoped correction/failure memories in SQLite with the active project name.
- Bump package metadata to `0.7.2`.

## Verification
- `npm run check`
- `npm test` (all 24 test files, 368 tests)
- Focused tests for memory tool, correction detector, markdown sync, and project migration
- `git diff --check`