### PR TITLE
Make correction detection patterns configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Configurable correction detection patterns**: Strong, weak, and negative correction patterns plus weak-pattern directive words can now be overridden with optional config fields. Omitted fields preserve the existing defaults.
+
+### Tests
+
+- Config loading tests now use an injected temporary config path instead of writing to `~/.pi/agent/hermes-memory-config.json`.
+
 ## [0.7.3] - 2026-05-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -385,6 +385,10 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 | `reviewEnabled` | `true` | Enable/disable background learning loop |
 | `autoConsolidate` | `true` | Auto-merge when memory hits capacity |
 | `correctionDetection` | `true` | Detect user corrections and save immediately |
+| `correctionStrongPatterns` | unset | Optional case-insensitive regex sources replacing strong correction patterns; omitted preserves defaults, invalid entries are ignored |
+| `correctionWeakPatterns` | unset | Optional case-insensitive regex sources replacing weak correction patterns; omitted preserves defaults, invalid entries are ignored |
+| `correctionNegativePatterns` | unset | Optional case-insensitive regex sources replacing negative correction patterns; omitted preserves defaults, invalid entries are ignored |
+| `correctionDirectiveWords` | unset | Optional directive words replacing the weak-pattern directive words; omitted preserves defaults |
 | `failureInjectionEnabled` | `true` | Legacy mode only: enable/disable injecting recent failure memories into the system prompt |
 | `failureInjectionMaxAgeDays` | `7` | Legacy mode only: maximum age in days for injected failure memories |
 | `failureInjectionMaxEntries` | `5` | Legacy mode only: maximum number of failure memories to inject |

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,15 +45,18 @@ export const DEFAULT_CONFIG_PATH = path.join(
   "hermes-memory-config.json",
 );
 
-export function loadConfig(): MemoryConfig {
+export function loadConfig(configPath = DEFAULT_CONFIG_PATH): MemoryConfig {
   try {
-    if (fs.existsSync(DEFAULT_CONFIG_PATH)) {
-      const raw = fs.readFileSync(DEFAULT_CONFIG_PATH, "utf-8");
+    if (fs.existsSync(configPath)) {
+      const raw = fs.readFileSync(configPath, "utf-8");
       const parsed = JSON.parse(raw);
       // Merge: override defaults with user config
       const config: MemoryConfig = { ...DEFAULT_CONFIG };
       const isNonNegativeNumber = (value: unknown): value is number => (
         typeof value === "number" && Number.isFinite(value) && value >= 0
+      );
+      const isStringArray = (value: unknown): value is string[] => (
+        Array.isArray(value) && value.every((item) => typeof item === "string")
       );
       if (parsed.memoryMode === "policy-only" || parsed.memoryMode === "legacy-inject") config.memoryMode = parsed.memoryMode;
       if (
@@ -74,6 +77,10 @@ export function loadConfig(): MemoryConfig {
       if (isNonNegativeNumber(parsed.flushRecentMessages)) config.flushRecentMessages = parsed.flushRecentMessages;
       if (typeof parsed.autoConsolidate === "boolean") config.autoConsolidate = parsed.autoConsolidate;
       if (typeof parsed.correctionDetection === "boolean") config.correctionDetection = parsed.correctionDetection;
+      if (isStringArray(parsed.correctionStrongPatterns)) config.correctionStrongPatterns = parsed.correctionStrongPatterns;
+      if (isStringArray(parsed.correctionWeakPatterns)) config.correctionWeakPatterns = parsed.correctionWeakPatterns;
+      if (isStringArray(parsed.correctionNegativePatterns)) config.correctionNegativePatterns = parsed.correctionNegativePatterns;
+      if (isStringArray(parsed.correctionDirectiveWords)) config.correctionDirectiveWords = parsed.correctionDirectiveWords;
       if (typeof parsed.failureInjectionEnabled === "boolean") config.failureInjectionEnabled = parsed.failureInjectionEnabled;
       if (typeof parsed.failureInjectionMaxAgeDays === "number") config.failureInjectionMaxAgeDays = parsed.failureInjectionMaxAgeDays;
       if (typeof parsed.failureInjectionMaxEntries === "number") config.failureInjectionMaxEntries = parsed.failureInjectionMaxEntries;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -182,6 +182,33 @@ export const CORRECTION_NEGATIVE_PATTERNS: RegExp[] = [
   /^stop.{0,5}(there|here|for now)/i,
 ];
 
+/** Directive words required after weak correction patterns */
+export const CORRECTION_DIRECTIVE_WORDS: string[] = [
+  "use",
+  "don't",
+  "dont",
+  "do",
+  "try",
+  "make",
+  "run",
+  "install",
+  "add",
+  "remove",
+  "delete",
+  "change",
+  "fix",
+  "put",
+  "set",
+  "write",
+  "go",
+  "stop",
+  "start",
+  "the",
+  "that",
+  "this",
+  "it",
+];
+
 // ─── Correction save prompt ───
 export const CORRECTION_SAVE_PROMPT = `The user just corrected you. Review what went wrong and save the correction to persistent memory.
 

--- a/src/handlers/correction-detector.ts
+++ b/src/handlers/correction-detector.ts
@@ -20,6 +20,7 @@ import {
   CORRECTION_STRONG_PATTERNS,
   CORRECTION_WEAK_PATTERNS,
   CORRECTION_NEGATIVE_PATTERNS,
+  CORRECTION_DIRECTIVE_WORDS,
   ENTRY_DELIMITER,
 } from "../constants.js";
 import type { MemoryConfig } from "../types.js";
@@ -38,23 +39,71 @@ function extractCorrectionDirective(text: string): string {
   return cleaned || text;
 }
 
+function compileCorrectionPatterns(
+  configured: string[] | undefined,
+  defaults: RegExp[],
+): RegExp[] {
+  if (configured === undefined) return defaults;
+
+  const patterns: RegExp[] = [];
+  for (const source of configured) {
+    try {
+      patterns.push(new RegExp(source, "i"));
+    } catch {
+      // Ignore invalid configured regex entries; valid entries still apply.
+    }
+  }
+  return patterns;
+}
+
+function escapeRegexLiteral(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function hasDirectiveWord(remainder: string, words: string[]): boolean {
+  if (words.length === 0) return false;
+  const source = words.map(escapeRegexLiteral).join("|");
+  return new RegExp(`\\b(${source})\\b`, "i").test(remainder);
+}
+
 /**
  * Check if a user message is a correction using the two-pass filter.
  * Returns true if the message should trigger an immediate save.
  */
-export function isCorrection(text: string): boolean {
+type CorrectionPatternConfig = Pick<MemoryConfig,
+  "correctionStrongPatterns" |
+  "correctionWeakPatterns" |
+  "correctionNegativePatterns" |
+  "correctionDirectiveWords"
+>;
+
+export function isCorrection(text: string, config?: CorrectionPatternConfig): boolean {
+  const negativePatterns = compileCorrectionPatterns(
+    config?.correctionNegativePatterns,
+    CORRECTION_NEGATIVE_PATTERNS,
+  );
+  const strongPatterns = compileCorrectionPatterns(
+    config?.correctionStrongPatterns,
+    CORRECTION_STRONG_PATTERNS,
+  );
+  const weakPatterns = compileCorrectionPatterns(
+    config?.correctionWeakPatterns,
+    CORRECTION_WEAK_PATTERNS,
+  );
+  const directiveWords = config?.correctionDirectiveWords ?? CORRECTION_DIRECTIVE_WORDS;
+
   // Check negative patterns first — suppress even if positive matches
-  for (const pattern of CORRECTION_NEGATIVE_PATTERNS) {
+  for (const pattern of negativePatterns) {
     if (pattern.test(text)) return false;
   }
 
   // Check strong patterns — always trigger
-  for (const pattern of CORRECTION_STRONG_PATTERNS) {
+  for (const pattern of strongPatterns) {
     if (pattern.test(text)) return true;
   }
 
   // Check weak patterns — only trigger if followed by a directive clause
-  for (const pattern of CORRECTION_WEAK_PATTERNS) {
+  for (const pattern of weakPatterns) {
     if (pattern.test(text)) {
       // Look for a directive after the weak pattern match
       // Directive = a verb or "the/that/this" in the remainder of the text
@@ -62,7 +111,7 @@ export function isCorrection(text: string): boolean {
       if (match && match.index === 0) {
         const remainder = text.slice(match[0].length).trim();
         // Simple heuristic: remainder contains something directive-ish
-        if (/\b(use|don'?t|do|try|make|run|install|add|remove|delete|change|fix|put|set|write|go|stop|start|the|that|this|it)\b/i.test(remainder)) {
+        if (hasDirectiveWord(remainder, directiveWords)) {
           return true;
         }
       }
@@ -91,7 +140,7 @@ export function setupCorrectionDetector(
     if (event.message.role !== "user") return;
     const text = getMessageText(event.message);
     if (!text) return;
-    if (isCorrection(text)) {
+    if (isCorrection(text, config)) {
       pendingCorrection = true;
     }
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,14 @@ export interface MemoryConfig {
   autoConsolidate: boolean;
   /** Detect user corrections and trigger immediate memory save. Default: true */
   correctionDetection: boolean;
+  /** Override strong correction regex sources. Missing = defaults; [] = none. */
+  correctionStrongPatterns?: string[];
+  /** Override weak correction regex sources. Missing = defaults; [] = none. */
+  correctionWeakPatterns?: string[];
+  /** Override negative correction regex sources. Missing = defaults; [] = none. */
+  correctionNegativePatterns?: string[];
+  /** Override directive words used after weak correction patterns. Missing = defaults; [] = none. */
+  correctionDirectiveWords?: string[];
   /** Inject recent failure memories into the system prompt. Default: true */
   failureInjectionEnabled: boolean;
   /** Maximum age in days for injected failure memories. Default: 7 */

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,13 +1,19 @@
-import { describe, it } from "node:test";
+import { describe, it, afterEach } from "node:test";
 import assert from "node:assert";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import { loadConfig, DEFAULT_CONFIG_PATH } from "../src/config.js";
+import { loadConfig } from "../src/config.js";
+
+const TEST_CONFIG_PATH = path.join(os.tmpdir(), `hermes-memory-config-test-${process.pid}.json`);
+
+afterEach(() => {
+  fs.rmSync(TEST_CONFIG_PATH, { force: true });
+});
 
 describe("loadConfig", () => {
   it("returns defaults when no config file exists", () => {
-    const config = loadConfig();
+    const config = loadConfig(TEST_CONFIG_PATH);
     assert.strictEqual(config.memoryMode, "policy-only");
     assert.strictEqual(config.memoryPolicyStyle, "full");
     assert.strictEqual(config.memoryPolicyCustomText, undefined);
@@ -28,8 +34,8 @@ describe("loadConfig", () => {
 
   it("overrides defaults when config file exists", () => {
     // Write a config file
-    fs.mkdirSync(path.dirname(DEFAULT_CONFIG_PATH), { recursive: true });
-    fs.writeFileSync(DEFAULT_CONFIG_PATH, JSON.stringify({
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({
       memoryCharLimit: 3000,
       memoryMode: "legacy-inject",
       memoryPolicyStyle: "custom",
@@ -42,7 +48,7 @@ describe("loadConfig", () => {
       failureInjectionMaxEntries: 2,
       projectsMemoryDir: "my-memory",
     }));
-    const config = loadConfig();
+    const config = loadConfig(TEST_CONFIG_PATH);
     assert.strictEqual(config.memoryMode, "legacy-inject");
     assert.strictEqual(config.memoryPolicyStyle, "custom");
     assert.strictEqual(config.memoryPolicyCustomText, "<memory-policy>Custom</memory-policy>");
@@ -57,14 +63,12 @@ describe("loadConfig", () => {
     // Unset values use defaults
     assert.strictEqual(config.userCharLimit, 5000);
     assert.strictEqual(config.reviewEnabled, true);
-    // Clean up
-    fs.rmSync(DEFAULT_CONFIG_PATH);
   });
 
   it("handles partial config (missing keys use defaults)", () => {
-    fs.mkdirSync(path.dirname(DEFAULT_CONFIG_PATH), { recursive: true });
-    fs.writeFileSync(DEFAULT_CONFIG_PATH, JSON.stringify({ reviewEnabled: false }));
-    const config = loadConfig();
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({ reviewEnabled: false }));
+    const config = loadConfig(TEST_CONFIG_PATH);
     assert.strictEqual(config.reviewEnabled, false);
     assert.strictEqual(config.memoryMode, "policy-only");
     assert.strictEqual(config.memoryPolicyStyle, "full");
@@ -75,18 +79,17 @@ describe("loadConfig", () => {
     assert.strictEqual(config.failureInjectionMaxAgeDays, 7);
     assert.strictEqual(config.failureInjectionMaxEntries, 5);
     assert.strictEqual(config.projectsMemoryDir, "projects-memory");
-    fs.rmSync(DEFAULT_CONFIG_PATH);
   });
 
   it("handles partial config with all boolean overrides", () => {
-    fs.mkdirSync(path.dirname(DEFAULT_CONFIG_PATH), { recursive: true });
-    fs.writeFileSync(DEFAULT_CONFIG_PATH, JSON.stringify({
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({
       reviewEnabled: false,
       flushOnCompact: false,
       flushOnShutdown: false,
       flushMinTurns: 20,
     }));
-    const config = loadConfig();
+    const config = loadConfig(TEST_CONFIG_PATH);
     assert.strictEqual(config.reviewEnabled, false);
     assert.strictEqual(config.flushOnCompact, false);
     assert.strictEqual(config.flushOnShutdown, false);
@@ -94,109 +97,130 @@ describe("loadConfig", () => {
     assert.strictEqual(config.memoryCharLimit, 5000);
     assert.strictEqual(config.userCharLimit, 5000);
     assert.strictEqual(config.nudgeInterval, 10);
-    fs.rmSync(DEFAULT_CONFIG_PATH);
   });
 
   it("accepts review and flush recent-message limits independently", () => {
-    fs.mkdirSync(path.dirname(DEFAULT_CONFIG_PATH), { recursive: true });
-    fs.writeFileSync(DEFAULT_CONFIG_PATH, JSON.stringify({
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({
       reviewRecentMessages: 12,
       flushRecentMessages: 34,
     }));
-    const config = loadConfig();
+    const config = loadConfig(TEST_CONFIG_PATH);
     assert.strictEqual(config.reviewRecentMessages, 12);
     assert.strictEqual(config.flushRecentMessages, 34);
-    fs.rmSync(DEFAULT_CONFIG_PATH);
   });
 
   it("ignores invalid recent-message limits", () => {
-    fs.mkdirSync(path.dirname(DEFAULT_CONFIG_PATH), { recursive: true });
-    fs.writeFileSync(DEFAULT_CONFIG_PATH, JSON.stringify({
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({
       reviewRecentMessages: -1,
       flushRecentMessages: "5",
     }));
-    const config = loadConfig();
+    const config = loadConfig(TEST_CONFIG_PATH);
     assert.strictEqual(config.reviewRecentMessages, 0);
     assert.strictEqual(config.flushRecentMessages, 0);
-    fs.rmSync(DEFAULT_CONFIG_PATH);
   });
 
   it("handles empty file gracefully (falls back to defaults)", () => {
-    fs.mkdirSync(path.dirname(DEFAULT_CONFIG_PATH), { recursive: true });
-    fs.writeFileSync(DEFAULT_CONFIG_PATH, "");
-    const config = loadConfig();
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(TEST_CONFIG_PATH, "");
+    const config = loadConfig(TEST_CONFIG_PATH);
     assert.strictEqual(config.reviewEnabled, true);
-    fs.rmSync(DEFAULT_CONFIG_PATH);
   });
 
   it("handles malformed JSON (falls back to defaults)", () => {
-    fs.mkdirSync(path.dirname(DEFAULT_CONFIG_PATH), { recursive: true });
-    fs.writeFileSync(DEFAULT_CONFIG_PATH, "{ bad json }");
-    const config = loadConfig();
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(TEST_CONFIG_PATH, "{ bad json }");
+    const config = loadConfig(TEST_CONFIG_PATH);
     assert.strictEqual(config.memoryCharLimit, 5000);
     assert.strictEqual(config.reviewEnabled, true);
-    fs.rmSync(DEFAULT_CONFIG_PATH);
   });
 
   it("ignores unknown keys in config file", () => {
-    fs.mkdirSync(path.dirname(DEFAULT_CONFIG_PATH), { recursive: true });
-    fs.writeFileSync(DEFAULT_CONFIG_PATH, JSON.stringify({
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({
       unknownKey: "value",
       anotherKey: 123,
       memoryCharLimit: 1000,
     }));
-    const config = loadConfig();
+    const config = loadConfig(TEST_CONFIG_PATH);
     assert.strictEqual(config.memoryCharLimit, 1000);
     assert.strictEqual(config.memoryMode, "policy-only");
     assert.strictEqual(config.reviewEnabled, true);
-    fs.rmSync(DEFAULT_CONFIG_PATH);
   });
 
   it("ignores invalid memoryMode values", () => {
-    fs.mkdirSync(path.dirname(DEFAULT_CONFIG_PATH), { recursive: true });
-    fs.writeFileSync(DEFAULT_CONFIG_PATH, JSON.stringify({
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({
       memoryMode: "invalid",
     }));
-    const config = loadConfig();
+    const config = loadConfig(TEST_CONFIG_PATH);
     assert.strictEqual(config.memoryMode, "policy-only");
-    fs.rmSync(DEFAULT_CONFIG_PATH);
   });
 
   it("accepts valid memoryPolicyStyle values", () => {
-    fs.mkdirSync(path.dirname(DEFAULT_CONFIG_PATH), { recursive: true });
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
 
     for (const style of ["full", "compact", "custom", "none"] as const) {
-      fs.writeFileSync(DEFAULT_CONFIG_PATH, JSON.stringify({ memoryPolicyStyle: style }));
-      const config = loadConfig();
+      fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({ memoryPolicyStyle: style }));
+      const config = loadConfig(TEST_CONFIG_PATH);
       assert.strictEqual(config.memoryPolicyStyle, style);
     }
-
-    fs.rmSync(DEFAULT_CONFIG_PATH);
   });
 
   it("ignores invalid memoryPolicyStyle values", () => {
-    fs.mkdirSync(path.dirname(DEFAULT_CONFIG_PATH), { recursive: true });
-    fs.writeFileSync(DEFAULT_CONFIG_PATH, JSON.stringify({
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({
       memoryPolicyStyle: "invalid",
     }));
-    const config = loadConfig();
+    const config = loadConfig(TEST_CONFIG_PATH);
     assert.strictEqual(config.memoryPolicyStyle, "full");
-    fs.rmSync(DEFAULT_CONFIG_PATH);
   });
 
   it("accepts string memoryPolicyCustomText and ignores non-string values", () => {
-    fs.mkdirSync(path.dirname(DEFAULT_CONFIG_PATH), { recursive: true });
-    fs.writeFileSync(DEFAULT_CONFIG_PATH, JSON.stringify({
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({
       memoryPolicyCustomText: "custom policy",
     }));
-    let config = loadConfig();
+    let config = loadConfig(TEST_CONFIG_PATH);
     assert.strictEqual(config.memoryPolicyCustomText, "custom policy");
 
-    fs.writeFileSync(DEFAULT_CONFIG_PATH, JSON.stringify({
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({
       memoryPolicyCustomText: 123,
     }));
-    config = loadConfig();
+    config = loadConfig(TEST_CONFIG_PATH);
     assert.strictEqual(config.memoryPolicyCustomText, undefined);
-    fs.rmSync(DEFAULT_CONFIG_PATH);
+  });
+
+  it("accepts correction pattern string arrays including empty arrays", () => {
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({
+      correctionStrongPatterns: ["^custom strong"],
+      correctionWeakPatterns: [],
+      correctionNegativePatterns: ["^custom negative"],
+      correctionDirectiveWords: ["shipit"],
+    }));
+
+    const config = loadConfig(TEST_CONFIG_PATH);
+    assert.deepStrictEqual(config.correctionStrongPatterns, ["^custom strong"]);
+    assert.deepStrictEqual(config.correctionWeakPatterns, []);
+    assert.deepStrictEqual(config.correctionNegativePatterns, ["^custom negative"]);
+    assert.deepStrictEqual(config.correctionDirectiveWords, ["shipit"]);
+  });
+
+  it("ignores invalid correction pattern array values", () => {
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({
+      correctionStrongPatterns: "^custom strong",
+      correctionWeakPatterns: ["^custom weak", 123],
+      correctionNegativePatterns: [false],
+      correctionDirectiveWords: { word: "shipit" },
+    }));
+
+    const config = loadConfig(TEST_CONFIG_PATH);
+    assert.strictEqual(config.correctionStrongPatterns, undefined);
+    assert.strictEqual(config.correctionWeakPatterns, undefined);
+    assert.strictEqual(config.correctionNegativePatterns, undefined);
+    assert.strictEqual(config.correctionDirectiveWords, undefined);
   });
 });

--- a/tests/handlers/correction-detector.test.ts
+++ b/tests/handlers/correction-detector.test.ts
@@ -166,6 +166,54 @@ describe("isCorrection", () => {
       assert.strictEqual(isCorrection("No Worries"), false);
     });
   });
+
+  describe("custom pattern config", () => {
+    it("matches custom strong patterns", () => {
+      assert.strictEqual(
+        isCorrection("custom correction", { correctionStrongPatterns: ["^custom correction$"] }),
+        true,
+      );
+    });
+
+    it("uses custom negative patterns to suppress matches", () => {
+      assert.strictEqual(
+        isCorrection("custom correction", {
+          correctionStrongPatterns: ["^custom"],
+          correctionNegativePatterns: ["^custom correction$"],
+        }),
+        false,
+      );
+    });
+
+    it("uses custom directive words for weak patterns", () => {
+      assert.strictEqual(
+        isCorrection("no, shipit now", { correctionDirectiveWords: ["shipit"] }),
+        true,
+      );
+      assert.strictEqual(
+        isCorrection("no, use yarn", { correctionDirectiveWords: ["shipit"] }),
+        false,
+      );
+    });
+
+    it("ignores invalid custom regex entries and keeps valid entries", () => {
+      assert.strictEqual(
+        isCorrection("custom correction", { correctionStrongPatterns: ["bad(", "^custom"] }),
+        true,
+      );
+    });
+
+    it("treats explicit empty or all-invalid pattern arrays as empty", () => {
+      assert.strictEqual(
+        isCorrection("don't do that", { correctionStrongPatterns: [] }),
+        false,
+      );
+      assert.strictEqual(
+        isCorrection("don't do that", { correctionStrongPatterns: ["bad("] }),
+        false,
+      );
+    });
+  });
 });
 
 // ─── Handler behavior tests ───


### PR DESCRIPTION
## Summary

   - Add optional config fields for correction detector patterns:
     - `correctionStrongPatterns`
     - `correctionWeakPatterns`
     - `correctionNegativePatterns`
     - `correctionDirectiveWords`
   - Preserve existing defaults when fields are omitted.
   - Use replace semantics for configured arrays; invalid regex entries are ignored individually.
   - While extending config tests, sandbox them with an injected temp config path so they no longer
 write to `~/.pi/agent/hermes-memory-config.json`.

   ## Tests

   - `npx tsx --test tests/config.test.ts`
   - `npx tsx --test tests/handlers/correction-detector.test.ts`
   - `npm run check`