### PR TITLE
fix(memory): sync FIFO evictions to SQLite

### DIFF
--- a/src/store/sqlite-memory-store.ts
+++ b/src/store/sqlite-memory-store.ts
@@ -67,6 +67,11 @@ export interface SqliteMemoryRemoveResult {
   removed: number;
 }
 
+export interface SqliteMemoryRemoveOptions {
+  target: 'memory' | 'user' | 'failure';
+  project?: string | null;
+}
+
 export interface ParsedMarkdownMemoryEntry extends SqliteMemorySyncInput {}
 
 function today(): string {
@@ -481,16 +486,49 @@ export function replaceSyncedMemories(
 export function removeSyncedMemories(
   dbManager: DatabaseManager,
   oldText: string,
-  options: {
-    target: 'memory' | 'user' | 'failure';
-    project?: string | null;
-  },
+  options: SqliteMemoryRemoveOptions,
 ): SqliteMemoryRemoveResult {
   const db = dbManager.getDb();
   const params: unknown[] = [];
   const conditions = buildScopeConditions(params, options.target, options.project ?? undefined);
   conditions.push(`content LIKE ? ESCAPE '\\'`);
   params.push(`%${escapeLikePattern(oldText)}%`);
+
+  const matchingIds = db.prepare(`
+    SELECT id
+    FROM memories
+    WHERE ${conditions.join(' AND ')}
+  `).all(...params) as Array<{ id: number }>;
+
+  if (matchingIds.length === 0) {
+    return { matched: 0, removed: 0 };
+  }
+
+  const deleteParams = matchingIds.map((row) => row.id);
+  const placeholders = deleteParams.map(() => '?').join(', ');
+  const result = db.prepare(`DELETE FROM memories WHERE id IN (${placeholders})`).run(...deleteParams);
+
+  return {
+    matched: matchingIds.length,
+    removed: result.changes,
+  };
+}
+
+/**
+ * Exact removal for Markdown entries whose full content is known.
+ * Used for FIFO eviction cleanup, where substring matching could remove
+ * unrelated SQLite mirror rows that merely contain the evicted text.
+ */
+export function removeExactSyncedMemories(
+  dbManager: DatabaseManager,
+  content: string,
+  options: SqliteMemoryRemoveOptions,
+): SqliteMemoryRemoveResult {
+  const db = dbManager.getDb();
+  const params: unknown[] = [];
+  const conditions = buildScopeConditions(params, options.target, options.project ?? undefined);
+  conditions.push('content = ?');
+  params.push(content.trim());
 
   const matchingIds = db.prepare(`
     SELECT id

--- a/src/tools/memory-tool.ts
+++ b/src/tools/memory-tool.ts
@@ -11,6 +11,7 @@ import { MemoryStore } from "../store/memory-store.js";
 import { DatabaseManager } from "../store/db.js";
 import {
   formatFailureMemoryContent,
+  removeExactSyncedMemories,
   removeSyncedMemories,
   replaceSyncedMemories,
   syncMemoryEntry,
@@ -159,6 +160,31 @@ async function syncRemoveFromSqlite(
   }
 }
 
+async function syncEvictionsFromSqlite(
+  rawTarget: "memory" | "user" | "project" | "failure",
+  evictedEntries: string[] | undefined,
+  dbManager: DatabaseManager | null,
+  projectName?: string | null,
+): Promise<void> {
+  if (!dbManager) return;
+  if (!evictedEntries || evictedEntries.length === 0) return;
+
+  const sqliteTarget = sqliteTargetFor(rawTarget);
+  const sqliteProject = sqliteProjectFor(rawTarget, projectName);
+
+  for (const entry of evictedEntries) {
+    try {
+      removeExactSyncedMemories(dbManager, entry, {
+        target: sqliteTarget,
+        project: sqliteProject,
+      });
+    } catch {
+      // FIFO already updated the Markdown source of truth. SQLite is only a
+      // best-effort search mirror, so eviction cleanup must not fail the write.
+    }
+  }
+}
+
 export function registerMemoryTool(
   pi: ExtensionAPI,
   store: MemoryStore,
@@ -247,6 +273,7 @@ export function registerMemoryTool(
           } else {
             result = await store_.add(target, content);
             if (result.success) {
+              await syncEvictionsFromSqlite(rawTarget, result.evicted_entries, dbManager, projectName);
               syncWarning = await syncAddToSqlite(rawTarget, content, undefined, undefined, dbManager, projectName);
             }
           }

--- a/tests/tools/memory-tool.test.ts
+++ b/tests/tools/memory-tool.test.ts
@@ -9,7 +9,7 @@ import path from "node:path";
 import { registerMemoryTool } from "../../src/tools/memory-tool.js";
 import { MemoryStore } from "../../src/store/memory-store.js";
 import { DatabaseManager } from "../../src/store/db.js";
-import { getMemories } from "../../src/store/sqlite-memory-store.js";
+import { getMemories, syncMemoryEntry } from "../../src/store/sqlite-memory-store.js";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
 describe("registerMemoryTool", () => {
@@ -148,6 +148,87 @@ describe("registerMemoryTool", () => {
     const results = getMemories(dbManager, { target: 'memory', project: null });
     assert.strictEqual(results.length, 1);
     assert.strictEqual(results[0].content, 'Entry one');
+  });
+
+  it("removes FIFO-evicted entries from the SQLite mirror", async () => {
+    let capturedResult: any;
+    const mockPi = {
+      registerTool: (def: any) => {
+        capturedResult = def;
+      },
+    } as unknown as ExtensionAPI;
+
+    syncMemoryEntry(dbManager, {
+      content: "Older entry",
+      target: "memory",
+      project: null,
+    });
+    syncMemoryEntry(dbManager, {
+      content: "Older entry with extra detail",
+      target: "memory",
+      project: null,
+    });
+
+    const mockStore = {
+      add: () => ({
+        success: true,
+        target: "memory",
+        entries: ["New entry"],
+        usage: "90% — 4500/5000 chars",
+        entry_count: 1,
+        message: "Memory updated. Rotated 1 older entry to stay within the limit.",
+        evicted_entries: ["Older entry"],
+        evicted_count: 1,
+      }),
+    } as unknown as MemoryStore;
+
+    registerMemoryTool(mockPi, mockStore, null, dbManager);
+    const result = await capturedResult.execute("tc-1", { action: "add", target: "memory", content: "New entry" }, undefined as any, undefined as any, undefined as any);
+
+    assert.match(result.content[0].text, /Rotated active memory entries:/);
+    const rows = getMemories(dbManager, { target: "memory", project: null });
+    assert.deepStrictEqual(rows.map((row) => row.content).sort(), ["New entry", "Older entry with extra detail"].sort());
+  });
+
+  it("uses project scope when removing FIFO-evicted SQLite entries", async () => {
+    let capturedResult: any;
+    const mockPi = {
+      registerTool: (def: any) => {
+        capturedResult = def;
+      },
+    } as unknown as ExtensionAPI;
+
+    syncMemoryEntry(dbManager, {
+      content: "Shared wording",
+      target: "memory",
+      project: null,
+    });
+    syncMemoryEntry(dbManager, {
+      content: "Shared wording",
+      target: "memory",
+      project: "project-a",
+    });
+
+    const mockProjectStore = {
+      add: () => ({
+        success: true,
+        target: "memory",
+        entries: ["Project replacement"],
+        usage: "90% — 4500/5000 chars",
+        entry_count: 1,
+        message: "Memory updated. Rotated 1 older entry to stay within the limit.",
+        evicted_entries: ["Shared wording"],
+        evicted_count: 1,
+      }),
+    } as unknown as MemoryStore;
+
+    registerMemoryTool(mockPi, {} as MemoryStore, mockProjectStore, dbManager, "project-a");
+    await capturedResult.execute("tc-1", { action: "add", target: "project", content: "Project replacement" }, undefined as any, undefined as any, undefined as any);
+
+    const globalRows = getMemories(dbManager, { target: "memory", project: null });
+    const projectRows = getMemories(dbManager, { target: "memory", project: "project-a" });
+    assert.deepStrictEqual(globalRows.map((row) => row.content), ["Shared wording"]);
+    assert.deepStrictEqual(projectRows.map((row) => row.content), ["Project replacement"]);
   });
 
   it("maps project target to SQLite project scope", async () => {


### PR DESCRIPTION
## Summary

   Sync FIFO-evicted memory entries to the SQLite `memory_search` mirror.

   When `memoryOverflowStrategy: "fifo-evict"` rotates older Markdown entries out of active
 memory, the memory tool now best-effort removes those exact entries from SQLite as well.

   ## Notes

   - Markdown remains the source of truth.
   - SQLite cleanup is best-effort and never fails a successful memory write.
   - Missing SQLite rows are ignored quietly.
   - Eviction cleanup uses exact content matching to avoid removing substring-related
 entries.

   ## Testing

   - `npm run check`
   - `npm test`