### PR TITLE
feat(skills): add interactive /memory-skills manager modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ This means skills build up naturally over time without you having to ask.
 | Command | What it does |
 |---|---|
 | `/memory-insights` | Shows everything stored in memory and user profile |
-| `/memory-skills` | Lists global and active-project skills with their ids |
+| `/memory-skills` | Opens an interactive skills manager for search, multi-select, move, and delete |
 | `/memory-consolidate` | Manually trigger memory consolidation to free space |
 | `/memory-interview` | Answer a few questions to pre-fill your user profile |
 | `/memory-switch-project` | List all project memories and their entry counts |
@@ -350,25 +350,34 @@ This means skills build up naturally over time without you having to ask.
 3. codes primarily in TypeScript
 ```
 
-### `/memory-skills` Output
+### `/memory-skills` Manager
 
-```
-╔══════════════════════════════════════════════╗
-║            🧠 Procedural Skills             ║
-╚══════════════════════════════════════════════╝
+`/memory-skills` now opens an interactive TUI modal for skill management.
 
-Global Skills
-─────────────
-📄 debug-typescript-errors
-   Step-by-step approach to debugging TS errors in monorepos
-   id: global:debug-typescript-errors
+Features:
+- fuzzy search by skill name
+- single-list view with scope badges (`[G]` global, `[P]` project)
+- multi-select with spacebar
+- batch move to global or current project
+- batch delete with one confirmation
+- inline action summaries for partial success/conflicts
 
-Project Skills (pi-hermes-memory)
-────────────────────────────────
-📄 deploy-checklist
-   Pre-deploy verification steps for this project
-   id: project:pi-hermes-memory:deploy-checklist
-```
+Keybindings:
+- `↑` / `↓` — move focus
+- `space` — toggle selection
+- `/` — focus search
+- `tab` — switch between search and list
+- `g` — move selected skills to global
+- `p` — move selected skills to project
+- `d` — delete selected skills
+- `a` — select all filtered skills
+- `n` — clear selection
+- `esc` — close the modal
+
+Move behavior:
+- moves are **conflict-safe**
+- if the destination already contains the same slug, the conflicting skill stays in place
+- batch moves use partial-success semantics: non-conflicting skills move, blocked skills are reported in the summary
 
 ## Configuration
 
@@ -471,8 +480,9 @@ The `sessions.db` SQLite database stores session history and extended memory ent
 - **Older Markdown memories may need backfill**: If you saved memories before the SQLite mirror existed or search looks stale, run `/memory-sync-markdown`.
 - **Core memory limits still apply**: SQLite search mirroring does not bypass the 5,000-char core Markdown limit. If consolidation cannot free space, the write fails instead of becoming SQLite-only memory invisibly.
 - **System prompts are invisible**: Pi's TUI does not display the system prompt. Use `/memory-preview-context` to inspect whether policy-only or legacy memory injection is active.
-- **Project skill visibility depends on Pi discovery cycles**: project skills are exposed through `resources_discover` using the active project's `skills/` path. If a new skill doesn't show up immediately in a running session, trigger a reload/new session so Pi refreshes discovered resources.
-- **Skills are agent-generated**: Skills are created by the agent based on its experience. They may not always be perfectly structured. You can edit or delete them in `~/.pi/agent/skills/` or the active project's `skills/` folder.
+- **Project skill visibility depends on Pi discovery cycles**: project skills are exposed through `resources_discover` using the active project's `skills/` path. If a moved or newly created project skill doesn't show up immediately in a running session, trigger a reload/new session so Pi refreshes discovered resources.
+- **Project move requires active project context**: in `/memory-skills`, the `p` hotkey is disabled when Pi is not currently in a detected project directory.
+- **Skills are agent-generated**: Skills are created by the agent based on its experience. They may not always be perfectly structured. You can move, delete, or still edit them directly in `~/.pi/agent/skills/` or the active project's `skills/` folder.
 
 ## Architecture
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.7.7",
       "license": "MIT",
       "dependencies": {
+        "@earendil-works/pi-tui": "^0.74.0",
         "better-sqlite3": "^12.9.0"
       },
       "devDependencies": {
@@ -941,7 +942,6 @@
       "version": "0.74.0",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.74.0.tgz",
       "integrity": "sha512-1aIfXZp7D/z+1VlZX8BZcs6pgO8rjmil7kwyhctNDsWvce3Yfl8GVgu4eq+I0Mjhr8Cj+ipBiv9CLIzdoyCOIQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime-types": "^2.1.4",
@@ -2447,7 +2447,6 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
       "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2686,7 +2685,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -3227,7 +3225,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
       "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3533,7 +3530,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.1.tgz",
       "integrity": "sha512-0Ie6CfD026dNfWSosDw9dPxPzO9Rlyo0N8m5r05S8YjytIpuilzMFDMY4IDy/8xQsTwpuVinhncD+S8n3bcYZQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3562,7 +3558,6 @@
       "version": "15.0.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -3575,7 +3570,6 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3585,7 +3579,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hermes-memory",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-tui": "^0.74.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "typescript": "^6.0.3"
   },
   "dependencies": {
+    "@earendil-works/pi-tui": "^0.74.0",
     "better-sqlite3": "^12.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "🧠 Persistent memory + 🔍 session search + 🛡️ secret scanning for Pi. Token-aware policy-only memory by default, SQLite FTS5 search, auto-consolidation, procedural skills. 368 tests. Ported from Hermes agent.",
   "type": "module",
   "main": "src/index.ts",

--- a/src/handlers/skills-command.ts
+++ b/src/handlers/skills-command.ts
@@ -1,58 +1,764 @@
 /**
- * Skills command — /memory-skills lists all agent-created skills.
+ * Skills command — /memory-skills opens an interactive skills manager.
  */
 
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext, Theme } from "@earendil-works/pi-coding-agent";
 import { SkillStore } from "../store/skill-store.js";
+import type { SkillIndex, SkillResult, SkillScope } from "../types.js";
+import {
+  Input,
+  Key,
+  fuzzyFilter,
+  matchesKey,
+  truncateToWidth,
+  visibleWidth,
+  wrapTextWithAnsi,
+  type Focusable,
+  type TUI,
+} from "@earendil-works/pi-tui";
+
+export const MEMORY_SKILLS_KEYMAP = {
+  moveGlobal: "g",
+  moveProject: "p",
+  deleteSelected: "d",
+  selectAllFiltered: "a",
+  clearSelection: "n",
+  focusSearch: "/",
+  toggleSelection: "space",
+  switchFocus: "tab",
+  close: "esc",
+} as const;
+
+export interface SkillModalRow {
+  skillId: string;
+  scope: SkillScope;
+  name: string;
+  displayName: string;
+  description: string;
+  path: string;
+  projectName?: string;
+  selected: boolean;
+  searchText: string;
+}
+
+export interface SkillBatchActionResult {
+  skills: SkillIndex[];
+  summaryLines: string[];
+  retainSelectedSkillIds?: string[];
+  focusSkillId?: string;
+}
+
+export function formatSkillsList(skills: SkillIndex[], projectName: string | null): string {
+  const globalSkills = skills.filter((skill) => skill.scope === "global");
+  const projectSkills = skills.filter((skill) => skill.scope === "project");
+
+  const lines: string[] = [];
+  lines.push("");
+  lines.push("  ╔══════════════════════════════════════════════╗");
+  lines.push("  ║            🧠 Procedural Skills             ║");
+  lines.push("  ╚══════════════════════════════════════════════╝");
+  lines.push("");
+
+  if (skills.length === 0) {
+    lines.push("  (no skills created yet)");
+    lines.push("");
+    lines.push("  Skills are auto-created after complex tasks,");
+    lines.push("  or you can ask the agent to create one.");
+    return lines.join("\n");
+  }
+
+  if (globalSkills.length > 0) {
+    lines.push("  Global Skills");
+    lines.push("  ─────────────");
+    for (const skill of globalSkills) {
+      lines.push(`  📄 ${skill.displayName || skill.name}`);
+      lines.push(`     ${skill.description}`);
+      lines.push(`     id: ${skill.skillId}`);
+      lines.push(`     path: ${skill.path}`);
+      lines.push("");
+    }
+  }
+
+  if (projectSkills.length > 0) {
+    lines.push(`  Project Skills${projectName ? ` (${projectName})` : ""}`);
+    lines.push("  ──────────────");
+    for (const skill of projectSkills) {
+      lines.push(`  📄 ${skill.displayName || skill.name}`);
+      lines.push(`     ${skill.description}`);
+      lines.push(`     id: ${skill.skillId}`);
+      lines.push(`     path: ${skill.path}`);
+      lines.push("");
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export function buildSkillRows(skills: SkillIndex[], selectedSkillIds = new Set<string>()): SkillModalRow[] {
+  return skills.map((skill) => ({
+    skillId: skill.skillId,
+    scope: skill.scope,
+    name: skill.name,
+    displayName: skill.displayName || skill.name,
+    description: skill.description,
+    path: skill.path,
+    projectName: skill.projectName,
+    selected: selectedSkillIds.has(skill.skillId),
+    searchText: `${skill.displayName || skill.name} ${skill.name}`.trim(),
+  }));
+}
+
+export function filterSkillRows(rows: SkillModalRow[], query: string): SkillModalRow[] {
+  const trimmed = query.trim();
+  if (!trimmed) return rows;
+  return fuzzyFilter(rows, trimmed, (row) => row.searchText);
+}
+
+export function getSelectedSkillIds(rows: SkillModalRow[]): string[] {
+  return rows.filter((row) => row.selected).map((row) => row.skillId);
+}
+
+function summarizeAction(
+  actionVerb: string,
+  targetLabel: string,
+  successes: SkillResult[],
+  unchanged: SkillResult[],
+  blocked: Array<{ skillId: string; error: string }>,
+): string[] {
+  const lines: string[] = [];
+  const changed = successes.filter((result) => result.message?.includes(actionVerb) || result.skillId);
+
+  if (actionVerb === "moved") {
+    lines.push(`Moved ${successes.length} skill${successes.length === 1 ? "" : "s"} to ${targetLabel}.`);
+  } else if (actionVerb === "deleted") {
+    lines.push(`Deleted ${successes.length} skill${successes.length === 1 ? "" : "s"}.`);
+  } else {
+    lines.push(`${changed.length} skill action(s) completed.`);
+  }
+
+  if (unchanged.length > 0) {
+    lines.push(`${unchanged.length} already matched the target scope.`);
+  }
+
+  if (blocked.length > 0) {
+    lines.push(`Blocked ${blocked.length} skill${blocked.length === 1 ? "" : "s"}:`);
+    for (const item of blocked.slice(0, 4)) {
+      lines.push(`- ${item.skillId}: ${item.error}`);
+    }
+    if (blocked.length > 4) {
+      lines.push(`- …and ${blocked.length - 4} more`);
+    }
+  }
+
+  return lines;
+}
+
+type SkillMoveStore = Pick<SkillStore, "move" | "loadIndex" | "getProjectName">;
+type SkillDeleteStore = Pick<SkillStore, "delete" | "loadIndex">;
+export type ConfirmDialog = (title: string, message: string) => Promise<boolean>;
+
+export async function moveSelectedSkills(
+  store: SkillMoveStore,
+  skillIds: string[],
+  targetScope: SkillScope,
+): Promise<SkillBatchActionResult> {
+  const dedupedSkillIds = Array.from(new Set(skillIds));
+  const currentSkills = await store.loadIndex();
+
+  if (dedupedSkillIds.length === 0) {
+    return {
+      skills: currentSkills,
+      summaryLines: ["Select one or more skills first."],
+    };
+  }
+
+  if (targetScope === "project" && !store.getProjectName()) {
+    return {
+      skills: currentSkills,
+      summaryLines: ["Move to project is unavailable: no active project detected."],
+      retainSelectedSkillIds: dedupedSkillIds,
+    };
+  }
+
+  const successes: SkillResult[] = [];
+  const unchanged: SkillResult[] = [];
+  const blocked: Array<{ skillId: string; error: string }> = [];
+
+  for (const skillId of dedupedSkillIds) {
+    try {
+      const result = await store.move(skillId, targetScope);
+      if (result.success) {
+        if (result.skillId === skillId && result.scope === targetScope) {
+          unchanged.push(result);
+        } else {
+          successes.push(result);
+        }
+      } else {
+        blocked.push({ skillId, error: result.error || "Unknown move failure." });
+      }
+    } catch (error) {
+      blocked.push({
+        skillId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  const refreshedSkills = await store.loadIndex();
+  const focusSkillId = blocked[0]?.skillId
+    ?? successes[0]?.skillId
+    ?? unchanged[0]?.skillId;
+
+  return {
+    skills: refreshedSkills,
+    summaryLines: summarizeAction("moved", targetScope, successes, unchanged, blocked),
+    retainSelectedSkillIds: blocked.map((item) => item.skillId),
+    focusSkillId,
+  };
+}
+
+export async function deleteSelectedSkills(
+  store: SkillDeleteStore,
+  skillIds: string[],
+): Promise<SkillBatchActionResult> {
+  const dedupedSkillIds = Array.from(new Set(skillIds));
+  const currentSkills = await store.loadIndex();
+
+  if (dedupedSkillIds.length === 0) {
+    return {
+      skills: currentSkills,
+      summaryLines: ["Select one or more skills first."],
+    };
+  }
+
+  const successes: SkillResult[] = [];
+  const blocked: Array<{ skillId: string; error: string }> = [];
+
+  for (const skillId of dedupedSkillIds) {
+    try {
+      const result = await store.delete(skillId);
+      if (result.success) {
+        successes.push(result);
+      } else {
+        blocked.push({ skillId, error: result.error || "Unknown delete failure." });
+      }
+    } catch (error) {
+      blocked.push({
+        skillId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  const refreshedSkills = await store.loadIndex();
+
+  return {
+    skills: refreshedSkills,
+    summaryLines: summarizeAction("deleted", "delete", successes, [], blocked),
+    retainSelectedSkillIds: blocked.map((item) => item.skillId),
+    focusSkillId: blocked[0]?.skillId,
+  };
+}
+
+export async function confirmDeleteSelectedSkills(
+  confirm: ConfirmDialog,
+  store: SkillDeleteStore,
+  skillIds: string[],
+): Promise<SkillBatchActionResult> {
+  const currentSkills = await store.loadIndex();
+  if (skillIds.length === 0) {
+    return { skills: currentSkills, summaryLines: ["Select one or more skills first."] };
+  }
+
+  const confirmed = await confirm(
+    "Delete selected skills?",
+    `Delete ${skillIds.length} selected skill${skillIds.length === 1 ? "" : "s"}? This cannot be undone.`,
+  );
+
+  if (!confirmed) {
+    return {
+      skills: currentSkills,
+      summaryLines: ["Delete cancelled."],
+      retainSelectedSkillIds: skillIds,
+      focusSkillId: skillIds[0],
+    };
+  }
+
+  return deleteSelectedSkills(store, skillIds);
+}
+
+interface SkillsManagerCallbacks {
+  moveSelected: (scope: SkillScope, skillIds: string[]) => Promise<SkillBatchActionResult>;
+  deleteSelected: (skillIds: string[]) => Promise<SkillBatchActionResult>;
+  close: () => void;
+  projectName: string | null;
+}
+
+export class SkillsManagerModal implements Focusable {
+  private _focused = false;
+
+  get focused(): boolean {
+    return this._focused;
+  }
+
+  set focused(value: boolean) {
+    this._focused = value;
+    this.syncSearchFocus();
+  }
+
+  private readonly searchInput = new Input();
+  private rows: SkillModalRow[];
+  private selectedIndex = 0;
+  private query = "";
+  private focusArea: "search" | "list" = "list";
+  private busy = false;
+  private closed = false;
+  private pendingDeleteConfirm: { skillIds: string[] } | null = null;
+  private summaryLines: string[] = [
+    "Select skills with space, then move with g/p or delete with d.",
+  ];
+
+  constructor(
+    private readonly tui: TUI,
+    private readonly theme: Theme,
+    initialRows: SkillModalRow[],
+    private readonly callbacks: SkillsManagerCallbacks,
+  ) {
+    this.rows = initialRows;
+    this.syncSearchFocus();
+  }
+
+  invalidate(): void {
+    this.searchInput.invalidate();
+  }
+
+  private get filteredRows(): SkillModalRow[] {
+    return filterSkillRows(this.rows, this.query);
+  }
+
+  private getCurrentRow(): SkillModalRow | null {
+    const rows = this.filteredRows;
+    if (rows.length === 0) return null;
+    return rows[Math.min(this.selectedIndex, rows.length - 1)] ?? null;
+  }
+
+  private getSelectedIds(): string[] {
+    return getSelectedSkillIds(this.rows);
+  }
+
+  private syncSearchFocus(): void {
+    this.searchInput.focused = this.focused && this.focusArea === "search";
+  }
+
+  private syncQueryFromInput(): void {
+    this.query = this.searchInput.getValue();
+    const rows = this.filteredRows;
+    if (rows.length === 0) {
+      this.selectedIndex = 0;
+    } else {
+      this.selectedIndex = Math.min(this.selectedIndex, rows.length - 1);
+    }
+  }
+
+  private setFocusArea(area: "search" | "list"): void {
+    this.focusArea = area;
+    this.syncSearchFocus();
+    this.tui.requestRender();
+  }
+
+  private setRows(skills: SkillIndex[], retainSelectedSkillIds: string[] = [], focusSkillId?: string): void {
+    this.rows = buildSkillRows(skills, new Set(retainSelectedSkillIds));
+    this.syncQueryFromInput();
+
+    const rows = this.filteredRows;
+    if (rows.length === 0) {
+      this.selectedIndex = 0;
+      return;
+    }
+
+    if (focusSkillId) {
+      const focusIndex = rows.findIndex((row) => row.skillId === focusSkillId);
+      if (focusIndex >= 0) {
+        this.selectedIndex = focusIndex;
+        return;
+      }
+    }
+
+    this.selectedIndex = Math.min(this.selectedIndex, rows.length - 1);
+  }
+
+  private toggleSelected(skillId: string): void {
+    const row = this.rows.find((entry) => entry.skillId === skillId);
+    if (!row) return;
+    row.selected = !row.selected;
+  }
+
+  private toggleCurrentSelection(): void {
+    const row = this.getCurrentRow();
+    if (!row) return;
+    this.toggleSelected(row.skillId);
+    this.summaryLines = [
+      `${row.selected ? "Selected" : "Cleared"} ${row.displayName}.`,
+    ];
+    this.tui.requestRender();
+  }
+
+  private selectAllFiltered(): void {
+    const rows = this.filteredRows;
+    for (const row of rows) {
+      row.selected = true;
+    }
+    this.summaryLines = [
+      `Selected ${rows.length} visible skill${rows.length === 1 ? "" : "s"}.`,
+    ];
+    this.tui.requestRender();
+  }
+
+  private clearSelection(): void {
+    for (const row of this.rows) {
+      row.selected = false;
+    }
+    this.summaryLines = ["Cleared all selections."];
+    this.tui.requestRender();
+  }
+
+  private async runMove(targetScope: SkillScope): Promise<void> {
+    const selectedIds = this.getSelectedIds();
+    await this.runAsyncAction(this.callbacks.moveSelected(targetScope, selectedIds));
+  }
+
+  private promptDelete(): void {
+    const selectedIds = this.getSelectedIds();
+    if (selectedIds.length === 0) {
+      this.summaryLines = ["Select one or more skills first."];
+      this.tui.requestRender();
+      return;
+    }
+
+    this.pendingDeleteConfirm = { skillIds: selectedIds };
+    this.summaryLines = [
+      `Delete ${selectedIds.length} selected skill${selectedIds.length === 1 ? "" : "s"}? Press y to confirm or n to cancel.`,
+    ];
+    this.tui.requestRender();
+  }
+
+  private async runDeleteConfirmed(skillIds: string[]): Promise<void> {
+    await this.runAsyncAction(this.callbacks.deleteSelected(skillIds));
+  }
+
+  private closeModal(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.callbacks.close();
+  }
+
+  private async runAsyncAction(action: Promise<SkillBatchActionResult>): Promise<void> {
+    if (this.closed) return;
+
+    this.busy = true;
+    this.summaryLines = ["Applying skill changes…"];
+    this.tui.requestRender();
+
+    try {
+      const result = await action;
+      if (this.closed) return;
+      this.setRows(result.skills, result.retainSelectedSkillIds, result.focusSkillId);
+      this.summaryLines = result.summaryLines;
+    } catch (error) {
+      if (!this.closed) {
+        this.summaryLines = [error instanceof Error ? error.message : String(error)];
+      }
+    } finally {
+      this.busy = false;
+      if (!this.closed) {
+        this.tui.requestRender();
+      }
+    }
+  }
+
+  private moveSelection(delta: number): void {
+    const rows = this.filteredRows;
+    if (rows.length === 0) return;
+    const next = this.selectedIndex + delta;
+    this.selectedIndex = Math.max(0, Math.min(next, rows.length - 1));
+    this.tui.requestRender();
+  }
+
+  private pageSelection(delta: number): void {
+    const pageSize = Math.max(5, this.getMaxVisibleRows() - 1);
+    this.moveSelection(delta * pageSize);
+  }
+
+  private getMaxVisibleRows(): number {
+    return Math.max(6, Math.min(14, this.tui.terminal.rows - 18));
+  }
+
+  private focusSearchWithOptionalInput(data?: string): void {
+    this.setFocusArea("search");
+    if (data) {
+      this.searchInput.handleInput(data);
+      this.syncQueryFromInput();
+      this.tui.requestRender();
+    }
+  }
+
+  private isPrintableInput(data: string): boolean {
+    return data.length === 1 && data >= " " && data !== "\x7f";
+  }
+
+  handleInput(data: string): void {
+    if (this.closed) return;
+
+    if (this.busy) {
+      if (matchesKey(data, Key.escape)) this.closeModal();
+      return;
+    }
+
+    if (this.pendingDeleteConfirm) {
+      if (data === "y" || data === "Y") {
+        const pending = this.pendingDeleteConfirm;
+        this.pendingDeleteConfirm = null;
+        void this.runDeleteConfirmed(pending.skillIds);
+        return;
+      }
+
+      if (data === "n" || data === "N" || matchesKey(data, Key.escape)) {
+        this.pendingDeleteConfirm = null;
+        this.summaryLines = ["Delete cancelled."];
+        this.tui.requestRender();
+      }
+      return;
+    }
+
+    if (matchesKey(data, Key.escape)) {
+      this.closeModal();
+      return;
+    }
+
+    if (this.focusArea === "search") {
+      if (matchesKey(data, Key.tab) || matchesKey(data, Key.down)) {
+        this.setFocusArea("list");
+        return;
+      }
+
+      this.searchInput.handleInput(data);
+      this.syncQueryFromInput();
+      this.tui.requestRender();
+      return;
+    }
+
+    if (matchesKey(data, Key.tab) || matchesKey(data, Key.slash)) {
+      this.focusSearchWithOptionalInput();
+      return;
+    }
+    if (matchesKey(data, Key.up)) {
+      this.moveSelection(-1);
+      return;
+    }
+    if (matchesKey(data, Key.down)) {
+      this.moveSelection(1);
+      return;
+    }
+    if (matchesKey(data, Key.pageUp)) {
+      this.pageSelection(-1);
+      return;
+    }
+    if (matchesKey(data, Key.pageDown)) {
+      this.pageSelection(1);
+      return;
+    }
+    if (matchesKey(data, Key.home)) {
+      this.selectedIndex = 0;
+      this.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, Key.end)) {
+      this.selectedIndex = Math.max(0, this.filteredRows.length - 1);
+      this.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, Key.space)) {
+      this.toggleCurrentSelection();
+      return;
+    }
+    if (data === MEMORY_SKILLS_KEYMAP.selectAllFiltered) {
+      this.selectAllFiltered();
+      return;
+    }
+    if (data === MEMORY_SKILLS_KEYMAP.clearSelection) {
+      this.clearSelection();
+      return;
+    }
+    if (data === MEMORY_SKILLS_KEYMAP.moveGlobal) {
+      void this.runMove("global");
+      return;
+    }
+    if (data === MEMORY_SKILLS_KEYMAP.moveProject) {
+      void this.runMove("project");
+      return;
+    }
+    if (data === MEMORY_SKILLS_KEYMAP.deleteSelected) {
+      this.promptDelete();
+      return;
+    }
+    if (this.isPrintableInput(data) && !["g", "p", "d", "a", "n"].includes(data)) {
+      this.focusSearchWithOptionalInput(data);
+    }
+  }
+
+  private renderFramedLine(content: string, width: number): string {
+    const innerWidth = Math.max(10, width - 4);
+    const padded = truncateToWidth(content, innerWidth, "");
+    const spaces = Math.max(0, innerWidth - visibleWidth(padded));
+    return `${this.theme.fg("borderAccent", "│")} ${padded}${" ".repeat(spaces)} ${this.theme.fg("borderAccent", "│")}`;
+  }
+
+  private renderWrappedSection(lines: string[], width: number): string[] {
+    const rendered: string[] = [];
+    const innerWidth = Math.max(10, width - 4);
+    for (const line of lines) {
+      const wrapped = wrapTextWithAnsi(line, innerWidth);
+      if (wrapped.length === 0) {
+        rendered.push(this.renderFramedLine("", width));
+        continue;
+      }
+      for (const part of wrapped) {
+        rendered.push(this.renderFramedLine(part, width));
+      }
+    }
+    return rendered;
+  }
+
+  render(width: number): string[] {
+    const safeWidth = Math.max(60, width);
+    const top = this.theme.fg("borderAccent", `┌${"─".repeat(Math.max(1, safeWidth - 2))}┐`);
+    const bottom = this.theme.fg("borderAccent", `└${"─".repeat(Math.max(1, safeWidth - 2))}┘`);
+    const lines: string[] = [top];
+
+    const projectName = this.callbacks.projectName ? ` · project: ${this.callbacks.projectName}` : "";
+    const title = this.theme.fg("accent", this.theme.bold(`🧠 Procedural Skills${projectName}`));
+    lines.push(this.renderFramedLine(title, safeWidth));
+
+    const searchHint = this.focusArea === "search"
+      ? this.theme.fg("accent", "search")
+      : this.theme.fg("dim", "search");
+    const searchLine = this.searchInput.render(Math.max(10, safeWidth - 17))[0] ?? "";
+    lines.push(this.renderFramedLine(`${searchHint}: ${searchLine}`, safeWidth));
+
+    const filteredRows = this.filteredRows;
+    const selectedCount = this.getSelectedIds().length;
+    lines.push(this.renderFramedLine(
+      this.theme.fg(
+        "dim",
+        `${filteredRows.length} visible · ${this.rows.length} total · ${selectedCount} selected${this.busy ? " · working…" : ""}`,
+      ),
+      safeWidth,
+    ));
+
+    lines.push(this.renderFramedLine("", safeWidth));
+
+    if (filteredRows.length === 0) {
+      const emptyMessage = this.rows.length === 0 ? "No skills found yet." : "No skills match the current search.";
+      lines.push(this.renderFramedLine(this.theme.fg("warning", emptyMessage), safeWidth));
+      lines.push(this.renderFramedLine("", safeWidth));
+    } else {
+      const maxVisible = this.getMaxVisibleRows();
+      const start = Math.max(0, Math.min(this.selectedIndex - Math.floor(maxVisible / 2), filteredRows.length - maxVisible));
+      const end = Math.min(filteredRows.length, start + maxVisible);
+      const visibleRows = filteredRows.slice(start, end);
+
+      for (let i = 0; i < visibleRows.length; i++) {
+        const row = visibleRows[i]!;
+        const absoluteIndex = start + i;
+        const cursor = absoluteIndex === this.selectedIndex ? this.theme.fg("accent", "›") : " ";
+        const check = row.selected ? this.theme.fg("accent", "[x]") : this.theme.fg("dim", "[ ]");
+        const scope = row.scope === "global"
+          ? this.theme.fg("accent", "[G]")
+          : this.theme.fg("warning", "[P]");
+        const baseText = `${cursor} ${check} ${scope} ${row.displayName}`;
+        const lineText = absoluteIndex === this.selectedIndex
+          ? this.theme.bg("selectedBg", truncateToWidth(baseText, Math.max(10, safeWidth - 4), ""))
+          : truncateToWidth(baseText, Math.max(10, safeWidth - 4), "");
+        lines.push(this.renderFramedLine(lineText, safeWidth));
+      }
+
+      if (start > 0 || end < filteredRows.length) {
+        lines.push(this.renderFramedLine(this.theme.fg("dim", `Showing ${start + 1}-${end} of ${filteredRows.length}`), safeWidth));
+      }
+
+      lines.push(this.renderFramedLine("", safeWidth));
+      const currentRow = this.getCurrentRow();
+      if (currentRow) {
+        lines.push(this.renderFramedLine(this.theme.fg("accent", `Focused: ${currentRow.displayName}`), safeWidth));
+        lines.push(...this.renderWrappedSection([
+          currentRow.description || "(no description)",
+          this.theme.fg("dim", currentRow.skillId),
+        ], safeWidth));
+      }
+    }
+
+    lines.push(this.renderFramedLine("", safeWidth));
+    lines.push(this.renderFramedLine(this.theme.fg("accent", "Last action"), safeWidth));
+    lines.push(...this.renderWrappedSection(this.summaryLines, safeWidth));
+    lines.push(this.renderFramedLine("", safeWidth));
+
+    const help = this.pendingDeleteConfirm
+      ? "Confirm delete: y yes · n no · esc cancel"
+      : this.callbacks.projectName
+        ? "↑↓ move · space select · / search · tab switch · g global · p project · d delete · a all · n none · esc close"
+        : "↑↓ move · space select · / search · tab switch · g global · p project (disabled) · d delete · a all · n none · esc close";
+    lines.push(this.renderFramedLine(this.theme.fg("dim", help), safeWidth));
+    lines.push(bottom);
+    return lines;
+  }
+}
 
 export function registerSkillsCommand(pi: ExtensionAPI, store: SkillStore): void {
   pi.registerCommand("memory-skills", {
-    description: "List all agent-created skills (procedural memory)",
-    handler: async (_args, ctx) => {
+    description: "Manage global and active-project procedural skills",
+    handler: async (_args, ctx: ExtensionCommandContext) => {
       const skills = await store.loadIndex();
-      const globalSkills = skills.filter((skill) => skill.scope === "global");
-      const projectSkills = skills.filter((skill) => skill.scope === "project");
       const projectName = store.getProjectName();
 
-      const lines: string[] = [];
-      lines.push("");
-      lines.push("  ╔══════════════════════════════════════════════╗");
-      lines.push("  ║            🧠 Procedural Skills             ║");
-      lines.push("  ╚══════════════════════════════════════════════╝");
-      lines.push("");
-
-      if (skills.length === 0) {
-        lines.push("  (no skills created yet)");
-        lines.push("");
-        lines.push("  Skills are auto-created after complex tasks,");
-        lines.push("  or you can ask the agent to create one.");
-      } else {
-        if (globalSkills.length > 0) {
-          lines.push("  Global Skills");
-          lines.push("  ─────────────");
-          for (const skill of globalSkills) {
-            lines.push(`  📄 ${skill.displayName || skill.name}`);
-            lines.push(`     ${skill.description}`);
-            lines.push(`     id: ${skill.skillId}`);
-            lines.push(`     path: ${skill.path}`);
-            lines.push("");
-          }
-        }
-
-        if (projectSkills.length > 0) {
-          lines.push(`  Project Skills${projectName ? ` (${projectName})` : ""}`);
-          lines.push("  ──────────────");
-          for (const skill of projectSkills) {
-            lines.push(`  📄 ${skill.displayName || skill.name}`);
-            lines.push(`     ${skill.description}`);
-            lines.push(`     id: ${skill.skillId}`);
-            lines.push(`     path: ${skill.path}`);
-            lines.push("");
-          }
-        }
+      if (!ctx.hasUI || typeof ctx.ui.custom !== "function") {
+        ctx.ui.notify(formatSkillsList(skills, projectName), "info");
+        return;
       }
 
-      ctx.ui.notify(lines.join("\n"), "info");
+      const initialRows = buildSkillRows(skills);
+
+      try {
+        await ctx.ui.custom<void>(
+          (tui, theme, _keybindings, done) => new SkillsManagerModal(
+            tui,
+            theme,
+            initialRows,
+            {
+              moveSelected: (scope, skillIds) => moveSelectedSkills(store, skillIds, scope),
+              deleteSelected: (skillIds) => deleteSelectedSkills(store, skillIds),
+              close: () => done(undefined),
+              projectName,
+            },
+          ),
+          {
+            overlay: true,
+            overlayOptions: {
+              anchor: "center",
+              width: "88%",
+              minWidth: 72,
+              maxHeight: "85%",
+              margin: 1,
+            },
+          },
+        );
+      } catch {
+        const latestSkills = await store.loadIndex();
+        ctx.ui.notify(
+          "Interactive skills manager unavailable in this runtime; showing read-only list fallback.",
+          "warning",
+        );
+        ctx.ui.notify(formatSkillsList(latestSkills, projectName), "info");
+      }
     },
   });
 }

--- a/src/store/skill-store.ts
+++ b/src/store/skill-store.ts
@@ -336,6 +336,143 @@ export class SkillStore {
     };
   }
 
+  async move(skillId: string, targetScope: SkillScope): Promise<SkillResult> {
+    const doc = await this.loadSkill(skillId);
+    if (!doc) return { success: false, error: `Skill '${skillId}' not found.` };
+
+    const parsed = parseSkillId(skillId);
+    if (!parsed) return { success: false, error: `Skill '${skillId}' is invalid.` };
+
+    if (doc.scope === targetScope) {
+      return {
+        success: true,
+        message: `Skill '${doc.displayName || doc.name}' is already ${targetScope}.`,
+        fileName: doc.fileName,
+        skillId: doc.skillId,
+        scope: doc.scope,
+        path: doc.path,
+      };
+    }
+
+    const targetRoot = this.getScopeRoot(targetScope);
+    if (!targetRoot) {
+      return { success: false, error: "Project skills require an active project." };
+    }
+
+    const targetSkillId = buildSkillId(targetScope, parsed.slug, this.projectName);
+    const targetPath = path.join(targetRoot, parsed.slug, "SKILL.md");
+    if (await exists(targetPath)) {
+      return {
+        success: false,
+        error: `Cannot move '${doc.displayName || doc.name}' to ${targetScope}: ${targetSkillId} already exists.`,
+        conflictType: "scope-conflict",
+        similarSkillIds: [targetSkillId],
+        suggestedAction: "rename",
+      };
+    }
+
+    if (targetScope === "global") {
+      const similarSkillIds = await this.findSimilarGlobalSkillIds(parsed.slug, doc.description);
+      if (similarSkillIds.length > 0) {
+        const targetId = similarSkillIds[0];
+        return {
+          success: false,
+          error: `Cannot move '${doc.displayName || doc.name}' to global: a similar global skill already exists (${targetId}).`,
+          conflictType: "similar",
+          similarSkillIds,
+          suggestedAction: "patch",
+        };
+      }
+
+      const collidingNameSkillIds = await this.findNameCollisionGlobalSkillIds(parsed.slug, doc.description);
+      if (collidingNameSkillIds.length > 0) {
+        const targetId = collidingNameSkillIds[0];
+        return {
+          success: false,
+          error: `Cannot move '${doc.displayName || doc.name}' to global: a near-name global skill already exists (${targetId}) with different intent.`,
+          conflictType: "name-collision",
+          similarSkillIds: collidingNameSkillIds,
+          suggestedAction: "rename",
+        };
+      }
+    }
+
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+
+    // Same-filesystem move: use rename first for atomicity and to avoid duplicate windows.
+    try {
+      await fs.rename(doc.path, targetPath);
+
+      if (path.basename(doc.path) === "SKILL.md") {
+        await this.removeEmptyParents(path.dirname(doc.path), this.getScopeRoot(doc.scope));
+      }
+
+      return {
+        success: true,
+        message: `Skill '${doc.displayName || doc.name}' moved to ${targetScope}.`,
+        fileName: path.basename(targetPath),
+        skillId: targetSkillId,
+        scope: targetScope,
+        path: targetPath,
+      };
+    } catch (renameError) {
+      const code = (renameError as NodeJS.ErrnoException)?.code;
+      if (code !== "EXDEV") {
+        return {
+          success: false,
+          error: `Move to ${targetScope} failed before copy for skill '${skillId}'. Source path: ${doc.path}. Destination path: ${targetPath}. Error: ${renameError instanceof Error ? renameError.message : String(renameError)}`,
+        };
+      }
+      // Cross-device fallback below.
+    }
+
+    // Cross-device fallback: copy then remove source.
+    await this.atomicWrite(targetPath, formatFrontmatter({
+      name: parsed.slug,
+      displayName: doc.displayName,
+      description: doc.description,
+      version: doc.version,
+      created: doc.created,
+      updated: doc.updated,
+      body: doc.body,
+    }));
+
+    try {
+      await fs.unlink(doc.path);
+      if (path.basename(doc.path) === "SKILL.md") {
+        await this.removeEmptyParents(path.dirname(doc.path), this.getScopeRoot(doc.scope));
+      }
+    } catch (error) {
+      // Best-effort rollback: remove the destination copy if source removal fails,
+      // so we do not silently leave duplicate skills across scopes.
+      let rollbackFailed = false;
+      try {
+        await fs.unlink(targetPath);
+        if (path.basename(targetPath) === "SKILL.md") {
+          await this.removeEmptyParents(path.dirname(targetPath), this.getScopeRoot(targetScope));
+        }
+      } catch {
+        rollbackFailed = true;
+      }
+
+      return {
+        success: false,
+        error: rollbackFailed
+          ? `Move to ${targetScope} failed while removing source skill '${skillId}', and rollback also failed. Source path: ${doc.path}. Destination path: ${targetPath}. Error: ${error instanceof Error ? error.message : String(error)}`
+          : `Move to ${targetScope} failed while removing source skill '${skillId}'. Rolled back destination copy. Source path: ${doc.path}. Destination path: ${targetPath}. Error: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+
+    return {
+      success: true,
+      message: `Skill '${doc.displayName || doc.name}' moved to ${targetScope}.`,
+      fileName: path.basename(targetPath),
+      skillId: targetSkillId,
+      scope: targetScope,
+      path: targetPath,
+    };
+  }
+
   async delete(skillId: string): Promise<SkillResult> {
     const doc = await this.loadSkill(skillId);
     if (!doc) return { success: false, error: `Skill '${skillId}' not found.` };

--- a/src/types.ts
+++ b/src/types.ts
@@ -142,7 +142,7 @@ export interface SkillResult {
   skillId?: string;
   scope?: SkillScope;
   path?: string;
-  conflictType?: "duplicate" | "similar" | "name-collision";
+  conflictType?: "duplicate" | "similar" | "name-collision" | "scope-conflict";
   similarSkillIds?: string[];
   suggestedAction?: "patch" | "edit" | "rename";
 }

--- a/tests/handlers/skills-command.test.ts
+++ b/tests/handlers/skills-command.test.ts
@@ -1,0 +1,482 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildSkillRows,
+  confirmDeleteSelectedSkills,
+  deleteSelectedSkills,
+  filterSkillRows,
+  moveSelectedSkills,
+  registerSkillsCommand,
+  SkillsManagerModal,
+  type SkillBatchActionResult,
+} from "../../src/handlers/skills-command.js";
+import type { SkillIndex, SkillResult } from "../../src/types.js";
+
+const SAMPLE_SKILLS: SkillIndex[] = [
+  {
+    skillId: "global:debug-typescript-errors",
+    scope: "global",
+    fileName: "SKILL.md",
+    path: "/tmp/global/debug-typescript-errors/SKILL.md",
+    name: "debug-typescript-errors",
+    displayName: "Debug TypeScript Errors",
+    description: "Trace compiler issues step by step",
+  },
+  {
+    skillId: "project:demo-project:deploy-checklist",
+    scope: "project",
+    fileName: "SKILL.md",
+    path: "/tmp/project/deploy-checklist/SKILL.md",
+    projectName: "demo-project",
+    name: "deploy-checklist",
+    displayName: "Deploy Checklist",
+    description: "Project release checklist",
+  },
+];
+
+describe("skills command helpers", () => {
+  it("buildSkillRows preserves selected ids", () => {
+    const rows = buildSkillRows(SAMPLE_SKILLS, new Set(["project:demo-project:deploy-checklist"]));
+
+    assert.strictEqual(rows.length, 2);
+    assert.strictEqual(rows[0].selected, false);
+    assert.strictEqual(rows[1].selected, true);
+    assert.strictEqual(rows[0].searchText.includes("Debug TypeScript Errors"), true);
+  });
+
+  it("filterSkillRows uses fuzzy skill-name matching", () => {
+    const rows = buildSkillRows(SAMPLE_SKILLS);
+    const filtered = filterSkillRows(rows, "dbg ts err");
+
+    assert.strictEqual(filtered.length, 1);
+    assert.strictEqual(filtered[0].skillId, "global:debug-typescript-errors");
+  });
+
+  it("moveSelectedSkills blocks project moves without an active project", async () => {
+    const store = {
+      getProjectName: () => null,
+      loadIndex: async () => SAMPLE_SKILLS,
+      move: async () => ({ success: true } as SkillResult),
+    };
+
+    const result = await moveSelectedSkills(store as any, ["global:debug-typescript-errors"], "project");
+
+    assert.strictEqual(result.summaryLines[0], "Move to project is unavailable: no active project detected.");
+    assert.deepStrictEqual(result.retainSelectedSkillIds, ["global:debug-typescript-errors"]);
+  });
+
+  it("moveSelectedSkills keeps partial successes and retains blocked selection", async () => {
+    const moves = new Map<string, SkillResult>([
+      [
+        "global:debug-typescript-errors",
+        {
+          success: true,
+          skillId: "project:demo-project:debug-typescript-errors",
+          scope: "project",
+          message: "Skill 'Debug TypeScript Errors' moved to project.",
+        },
+      ],
+      [
+        "project:demo-project:deploy-checklist",
+        {
+          success: false,
+          error: "Destination already exists.",
+          conflictType: "scope-conflict",
+        },
+      ],
+    ]);
+
+    const refreshed: SkillIndex[] = [
+      {
+        ...SAMPLE_SKILLS[1],
+        skillId: "project:demo-project:debug-typescript-errors",
+        name: "debug-typescript-errors",
+        displayName: "Debug TypeScript Errors",
+        path: "/tmp/project/debug-typescript-errors/SKILL.md",
+        description: "Trace compiler issues step by step",
+      },
+      SAMPLE_SKILLS[1],
+    ];
+
+    const store = {
+      getProjectName: () => "demo-project",
+      loadIndex: async () => refreshed,
+      move: async (skillId: string) => moves.get(skillId)!,
+    };
+
+    const result = await moveSelectedSkills(
+      store as any,
+      ["global:debug-typescript-errors", "project:demo-project:deploy-checklist"],
+      "project",
+    );
+
+    assert.ok(result.summaryLines[0].includes("Moved 1 skill"));
+    assert.ok(result.summaryLines.some((line) => line.includes("Blocked 1 skill")));
+    assert.deepStrictEqual(result.retainSelectedSkillIds, ["project:demo-project:deploy-checklist"]);
+    assert.strictEqual(result.focusSkillId, "project:demo-project:deploy-checklist");
+    assert.strictEqual(result.skills.length, 2);
+  });
+
+  it("deleteSelectedSkills reports blocked deletes and refreshes skills", async () => {
+    const store = {
+      loadIndex: async () => [SAMPLE_SKILLS[1]],
+      delete: async (skillId: string) => skillId === SAMPLE_SKILLS[0].skillId
+        ? { success: true, skillId, scope: "global" as const }
+        : { success: false, error: "Skill missing." },
+    };
+
+    const result = await deleteSelectedSkills(
+      store as any,
+      [SAMPLE_SKILLS[0].skillId, SAMPLE_SKILLS[1].skillId],
+    );
+
+    assert.ok(result.summaryLines[0].includes("Deleted 1 skill"));
+    assert.ok(result.summaryLines.some((line) => line.includes("Blocked 1 skill")));
+    assert.deepStrictEqual(result.retainSelectedSkillIds, [SAMPLE_SKILLS[1].skillId]);
+  });
+
+  it("moveSelectedSkills treats thrown move errors as blocked items", async () => {
+    const store = {
+      getProjectName: () => "demo-project",
+      loadIndex: async () => SAMPLE_SKILLS,
+      move: async (skillId: string) => {
+        if (skillId === SAMPLE_SKILLS[0].skillId) {
+          throw new Error("permission denied");
+        }
+        return { success: true, skillId: "global:deploy-checklist", scope: "global" as const };
+      },
+    };
+
+    const result = await moveSelectedSkills(store as any, [SAMPLE_SKILLS[0].skillId, SAMPLE_SKILLS[1].skillId], "global");
+
+    assert.ok(result.summaryLines.some((line) => line.includes("Blocked 1 skill")));
+    assert.ok(result.summaryLines.some((line) => line.includes("permission denied")));
+    assert.deepStrictEqual(result.retainSelectedSkillIds, [SAMPLE_SKILLS[0].skillId]);
+  });
+
+  it("deleteSelectedSkills treats thrown delete errors as blocked items", async () => {
+    const store = {
+      loadIndex: async () => SAMPLE_SKILLS,
+      delete: async (skillId: string) => {
+        if (skillId === SAMPLE_SKILLS[1].skillId) {
+          throw new Error("unlink denied");
+        }
+        return { success: true, skillId, scope: "global" as const };
+      },
+    };
+
+    const result = await deleteSelectedSkills(store as any, [SAMPLE_SKILLS[0].skillId, SAMPLE_SKILLS[1].skillId]);
+
+    assert.ok(result.summaryLines.some((line) => line.includes("Blocked 1 skill")));
+    assert.ok(result.summaryLines.some((line) => line.includes("unlink denied")));
+    assert.deepStrictEqual(result.retainSelectedSkillIds, [SAMPLE_SKILLS[1].skillId]);
+  });
+
+  it("confirmDeleteSelectedSkills keeps selection when user cancels", async () => {
+    let prompts = 0;
+    const store = {
+      loadIndex: async () => SAMPLE_SKILLS,
+      delete: async () => ({ success: true }),
+    };
+
+    const result = await confirmDeleteSelectedSkills(
+      async () => {
+        prompts++;
+        return false;
+      },
+      store as any,
+      [SAMPLE_SKILLS[0].skillId],
+    );
+
+    assert.strictEqual(prompts, 1);
+    assert.deepStrictEqual(result.retainSelectedSkillIds, [SAMPLE_SKILLS[0].skillId]);
+    assert.strictEqual(result.summaryLines[0], "Delete cancelled.");
+  });
+});
+
+function createModalHarness() {
+  let renderCount = 0;
+  return {
+    tui: {
+      requestRender: () => {
+        renderCount++;
+      },
+      terminal: { rows: 42 },
+    },
+    theme: {
+      fg: (_color: string, text: string) => text,
+      bg: (_color: string, text: string) => text,
+      bold: (text: string) => text,
+    },
+    getRenderCount: () => renderCount,
+  };
+}
+
+function nextTick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("SkillsManagerModal", () => {
+  it("toggles selection and sends selected ids for move action", async () => {
+    const harness = createModalHarness();
+    const captured: Array<{ scope: string; skillIds: string[] }> = [];
+
+    const modal = new SkillsManagerModal(
+      harness.tui as any,
+      harness.theme as any,
+      buildSkillRows(SAMPLE_SKILLS),
+      {
+        moveSelected: async (scope, skillIds) => {
+          captured.push({ scope, skillIds });
+          return { skills: SAMPLE_SKILLS, summaryLines: ["done"] };
+        },
+        deleteSelected: async () => ({ skills: SAMPLE_SKILLS, summaryLines: ["done"] }),
+        close: () => undefined,
+        projectName: "demo-project",
+      },
+    );
+
+    modal.handleInput(" ");
+    modal.handleInput("g");
+    await nextTick();
+
+    assert.strictEqual(captured.length, 1);
+    assert.strictEqual(captured[0].scope, "global");
+    assert.deepStrictEqual(captured[0].skillIds, ["global:debug-typescript-errors"]);
+  });
+
+  it("supports slash search and typed filtering", () => {
+    const harness = createModalHarness();
+    const modal = new SkillsManagerModal(
+      harness.tui as any,
+      harness.theme as any,
+      buildSkillRows(SAMPLE_SKILLS),
+      {
+        moveSelected: async () => ({ skills: SAMPLE_SKILLS, summaryLines: ["done"] }),
+        deleteSelected: async () => ({ skills: SAMPLE_SKILLS, summaryLines: ["done"] }),
+        close: () => undefined,
+        projectName: "demo-project",
+      },
+    );
+
+    modal.handleInput("/");
+    modal.handleInput("z");
+    modal.handleInput("z");
+
+    const output = modal.render(100).join("\n");
+    assert.ok(output.includes("No skills match the current search."));
+  });
+
+  it("redirects printable keys to search from list focus", () => {
+    const harness = createModalHarness();
+    const modal = new SkillsManagerModal(
+      harness.tui as any,
+      harness.theme as any,
+      buildSkillRows(SAMPLE_SKILLS),
+      {
+        moveSelected: async () => ({ skills: SAMPLE_SKILLS, summaryLines: ["done"] }),
+        deleteSelected: async () => ({ skills: SAMPLE_SKILLS, summaryLines: ["done"] }),
+        close: () => undefined,
+        projectName: "demo-project",
+      },
+    );
+
+    modal.handleInput("z");
+    const output = modal.render(100).join("\n");
+    assert.ok(output.includes("No skills match the current search."));
+  });
+
+  it("uses in-modal delete confirmation and cancels with n", () => {
+    const harness = createModalHarness();
+    let deleteCalls = 0;
+
+    const modal = new SkillsManagerModal(
+      harness.tui as any,
+      harness.theme as any,
+      buildSkillRows(SAMPLE_SKILLS),
+      {
+        moveSelected: async () => ({ skills: SAMPLE_SKILLS, summaryLines: ["done"] }),
+        deleteSelected: async () => {
+          deleteCalls++;
+          return { skills: SAMPLE_SKILLS, summaryLines: ["deleted"] };
+        },
+        close: () => undefined,
+        projectName: "demo-project",
+      },
+    );
+
+    modal.handleInput(" ");
+    modal.handleInput("d");
+    let output = modal.render(100).join("\n");
+    assert.ok(output.includes("Press y to confirm or n to cancel"));
+
+    modal.handleInput("n");
+    output = modal.render(100).join("\n");
+    assert.ok(output.includes("Delete cancelled."));
+    assert.strictEqual(deleteCalls, 0);
+  });
+
+  it("confirms delete in-modal with y", async () => {
+    const harness = createModalHarness();
+    const capturedDeletes: string[][] = [];
+
+    const modal = new SkillsManagerModal(
+      harness.tui as any,
+      harness.theme as any,
+      buildSkillRows(SAMPLE_SKILLS),
+      {
+        moveSelected: async () => ({ skills: SAMPLE_SKILLS, summaryLines: ["done"] }),
+        deleteSelected: async (skillIds) => {
+          capturedDeletes.push(skillIds);
+          return { skills: [SAMPLE_SKILLS[1]], summaryLines: ["deleted"] };
+        },
+        close: () => undefined,
+        projectName: "demo-project",
+      },
+    );
+
+    modal.handleInput(" ");
+    modal.handleInput("d");
+    modal.handleInput("y");
+    await nextTick();
+
+    assert.strictEqual(capturedDeletes.length, 1);
+    assert.deepStrictEqual(capturedDeletes[0], ["global:debug-typescript-errors"]);
+  });
+
+  it("stops rendering updates after close during async actions", async () => {
+    const harness = createModalHarness();
+    let resolveMove: ((result: SkillBatchActionResult) => void) | null = null;
+    let closeCount = 0;
+
+    const modal = new SkillsManagerModal(
+      harness.tui as any,
+      harness.theme as any,
+      buildSkillRows(SAMPLE_SKILLS),
+      {
+        moveSelected: async () => {
+          return await new Promise<SkillBatchActionResult>((resolve) => {
+            resolveMove = resolve;
+          });
+        },
+        deleteSelected: async () => ({ skills: SAMPLE_SKILLS, summaryLines: ["done"] }),
+        close: () => {
+          closeCount++;
+        },
+        projectName: "demo-project",
+      },
+    );
+
+    modal.handleInput("g");
+    modal.handleInput("\u001b");
+    assert.strictEqual(closeCount, 1);
+
+    const renderCountBeforeResolve = harness.getRenderCount();
+    resolveMove?.({ skills: SAMPLE_SKILLS, summaryLines: ["moved"] });
+    await nextTick();
+
+    assert.strictEqual(harness.getRenderCount(), renderCountBeforeResolve);
+  });
+});
+
+describe("registerSkillsCommand", () => {
+  it("falls back to notify output when custom UI is unavailable", async () => {
+    const commands: Array<{ name: string; handler: Function }> = [];
+    const notifications: Array<{ message: string; severity: string }> = [];
+    const pi = {
+      registerCommand: (name: string, opts: { handler: Function }) => {
+        commands.push({ name, handler: opts.handler });
+      },
+    };
+    const store = {
+      loadIndex: async () => SAMPLE_SKILLS,
+      getProjectName: () => "demo-project",
+    };
+
+    registerSkillsCommand(pi as any, store as any);
+    assert.strictEqual(commands.length, 1);
+
+    await commands[0].handler({}, {
+      hasUI: false,
+      ui: {
+        notify: (message: string, severity: string) => notifications.push({ message, severity }),
+      },
+    });
+
+    assert.strictEqual(notifications.length, 1);
+    assert.strictEqual(notifications[0].severity, "info");
+    assert.ok(notifications[0].message.includes("Procedural Skills"));
+  });
+
+  it("opens a custom modal when interactive UI is available", async () => {
+    const commands: Array<{ name: string; handler: Function }> = [];
+    let customInvoked = false;
+    const pi = {
+      registerCommand: (name: string, opts: { handler: Function }) => {
+        commands.push({ name, handler: opts.handler });
+      },
+    };
+    const store = {
+      loadIndex: async () => SAMPLE_SKILLS,
+      getProjectName: () => "demo-project",
+      move: async () => ({ success: true } as SkillResult),
+      delete: async () => ({ success: true } as SkillResult),
+    };
+
+    registerSkillsCommand(pi as any, store as any);
+
+    await commands[0].handler({}, {
+      hasUI: true,
+      ui: {
+        custom: async (
+          factory: Function,
+          options: { overlay?: boolean },
+        ) => {
+          customInvoked = true;
+          assert.strictEqual(options.overlay, true);
+          // factory invocation is unnecessary for this contract-level test
+          return undefined;
+        },
+        confirm: async () => true,
+        notify: () => undefined,
+      },
+    });
+
+    assert.strictEqual(customInvoked, true);
+  });
+
+  it("falls back to read-only notify output when custom modal throws", async () => {
+    const commands: Array<{ name: string; handler: Function }> = [];
+    const notifications: Array<{ message: string; severity: string }> = [];
+    const pi = {
+      registerCommand: (name: string, opts: { handler: Function }) => {
+        commands.push({ name, handler: opts.handler });
+      },
+    };
+    const store = {
+      loadIndex: async () => SAMPLE_SKILLS,
+      getProjectName: () => "demo-project",
+      move: async () => ({ success: true } as SkillResult),
+      delete: async () => ({ success: true } as SkillResult),
+    };
+
+    registerSkillsCommand(pi as any, store as any);
+
+    await commands[0].handler({}, {
+      hasUI: true,
+      ui: {
+        custom: async () => {
+          throw new Error("UI backend unavailable");
+        },
+        confirm: async () => true,
+        notify: (message: string, severity: string) => notifications.push({ message, severity }),
+      },
+    });
+
+    assert.strictEqual(notifications.length, 2);
+    assert.strictEqual(notifications[0].severity, "warning");
+    assert.ok(notifications[0].message.includes("read-only list fallback"));
+    assert.strictEqual(notifications[1].severity, "info");
+    assert.ok(notifications[1].message.includes("Procedural Skills"));
+  });
+});

--- a/tests/store/skill-store.test.ts
+++ b/tests/store/skill-store.test.ts
@@ -330,6 +330,55 @@ describe("SkillStore", { concurrency: 1 }, () => {
     });
   });
 
+  describe("move()", () => {
+    it("moves a global skill into the active project scope", async () => {
+      const store = await makeStore();
+      const created = await store.create("move-me", "Reusable process", "## Procedure\n1. Do it", "global");
+
+      const result = await store.move(created.skillId!, "project");
+      assert.ok(result.success, `move failed: ${result.error}`);
+      assert.strictEqual(result.skillId, "project:demo-project:move-me");
+      await assert.rejects(fs.access(path.join(GLOBAL_SKILLS_DIR, "move-me", "SKILL.md")));
+      await fs.access(path.join(PROJECT_SKILLS_DIR, "move-me", "SKILL.md"));
+    });
+
+    it("moves a project skill into global scope", async () => {
+      const store = await makeStore();
+      const created = await store.create("repo-runbook", "Project process", "## Procedure\n1. Run it", "project");
+
+      const result = await store.move(created.skillId!, "global");
+      assert.ok(result.success, `move failed: ${result.error}`);
+      assert.strictEqual(result.skillId, "global:repo-runbook");
+      await assert.rejects(fs.access(path.join(PROJECT_SKILLS_DIR, "repo-runbook", "SKILL.md")));
+      await fs.access(path.join(GLOBAL_SKILLS_DIR, "repo-runbook", "SKILL.md"));
+    });
+
+    it("blocks move when destination scope already has the same slug", async () => {
+      const store = await makeStore();
+      const globalSkill = await store.create("same-name", "global skill", "body", "global");
+      const projectSkill = await store.create("same-name", "project skill", "body", "project");
+
+      const result = await store.move(globalSkill.skillId!, "project");
+      assert.ok(!result.success);
+      assert.strictEqual(result.conflictType, "scope-conflict");
+      assert.ok(result.error?.includes("already exists"));
+
+      const globalDoc = await store.loadSkill(globalSkill.skillId!);
+      const projectDoc = await store.loadSkill(projectSkill.skillId!);
+      assert.ok(globalDoc);
+      assert.ok(projectDoc);
+    });
+
+    it("returns an error when moving to project scope without an active project", async () => {
+      const store = await makeStore(false);
+      const created = await store.create("global-skill", "desc", "body", "global");
+
+      const result = await store.move(created.skillId!, "project");
+      assert.ok(!result.success);
+      assert.ok(result.error?.includes("active project"));
+    });
+  });
+
   describe("delete()", () => {
     it("removes the skill file from disk", async () => {
       const store = await makeStore();


### PR DESCRIPTION
## Summary

This PR upgrades `/memory-skills` from read-only output into an interactive TUI manager and adds cross-scope move support.

### What’s included
- Interactive `/memory-skills` modal with:
  - fuzzy search
  - `[G]` / `[P]` scope badges
  - multi-select via space
  - batch move to global (`g`) or project (`p`)
  - batch delete (`d`) with **in-modal** `y/n` confirmation
- Conflict-safe batch behavior:
  - partial success is allowed
  - blocked items stay selected with inline summaries
- New `SkillStore.move(skillId, targetScope)` API for global↔project transfers
- Command fallback to read-only notify output when custom UI is unavailable
- Tests for modal behavior, action helpers, command fallback, and move semantics

## Why

This improves day-to-day skill hygiene and avoids manual file operations when users need to rebalance skills between project and global scope.

## Validation

- `npm test`
- `npm run check`

## Related

- Follow-up to issue #32
