### PR TITLE
feat(session-search): add opt-in JSONL anchor mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ This lets Pi discover project skills as native skills without copying them into 
 
 ### Session History Search
 
-The extension indexes your Pi session history into a SQLite database with FTS5 full-text search. The agent can search across all past conversations using the `session_search` tool:
+By default, the extension indexes your Pi session history into a SQLite database with FTS5 full-text search. The agent can search across all past conversations using the `session_search` tool:
 
 | Tool | What it does |
 |---|---|---|
@@ -259,6 +259,8 @@ Session history is indexed automatically on session shutdown. To bulk-import exi
 ```
 /memory-index-sessions
 ```
+
+For users who prefer source anchors over snippets, `sessionSearch.variant` can be set to `anchors`. In that opt-in mode, the same `session_search` tool reads session JSONL files directly and accepts a Markdown request with fields such as `from`, `to`, `cwd`, and `limit`, plus `all`, `any`, and `exclude` lists. It returns plain text with `count`, an optional `message`, and compact `path:startLine-endLine` style anchors with short reasons instead of summaries or previews.
 
 ### Extended Memory Store
 
@@ -392,6 +394,7 @@ Create `~/.pi/agent/hermes-memory-config.json`:
   "projectCharLimit": 5000,
   "memoryDir": "~/.pi/agent/memory",
   "projectsMemoryDir": "projects-memory",
+  "sessionSearch": { "variant": "legacy" },
   "nudgeInterval": 10,
   "nudgeToolCalls": 15,
   "reviewRecentMessages": 0,
@@ -420,6 +423,7 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 | `projectCharLimit` | `5000` | Max characters in project-scoped MEMORY.md |
 | `memoryDir` | `~/.pi/agent/memory` | Custom directory for memory files |
 | `projectsMemoryDir` | `projects-memory` | Subdirectory under `~/.pi/agent/` for project-scoped memory |
+| `sessionSearch` | `{ "variant": "legacy" }` | Session search implementation: `legacy` keeps the existing SQLite/FTS snippet search; `anchors` uses the opt-in Markdown request surface and returns compact JSONL line-range anchors from `~/.pi/agent/sessions/` |
 | `nudgeInterval` | `10` | Turns between auto-reviews |
 | `nudgeToolCalls` | `15` | Tool calls between auto-reviews (OR with turns) |
 | `reviewRecentMessages` | `0` | Recent messages included in background review (`0` = all) |

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import type { MemoryConfig, MemoryOverflowStrategy } from "./types.js";
+import type { MemoryConfig, MemoryOverflowStrategy, SessionSearchVariant } from "./types.js";
 import {
   DEFAULT_MEMORY_CHAR_LIMIT,
   DEFAULT_USER_CHAR_LIMIT,
@@ -18,9 +18,14 @@ import {
 } from "./constants.js";
 
 const MEMORY_OVERFLOW_STRATEGIES: readonly MemoryOverflowStrategy[] = ["auto-consolidate", "reject", "fifo-evict"];
+const SESSION_SEARCH_VARIANTS: readonly SessionSearchVariant[] = ["legacy", "anchors"];
 
 function isMemoryOverflowStrategy(value: unknown): value is MemoryOverflowStrategy {
   return typeof value === "string" && MEMORY_OVERFLOW_STRATEGIES.includes(value as MemoryOverflowStrategy);
+}
+
+function isSessionSearchVariant(value: unknown): value is SessionSearchVariant {
+  return typeof value === "string" && SESSION_SEARCH_VARIANTS.includes(value as SessionSearchVariant);
 }
 
 const DEFAULT_CONFIG: MemoryConfig = {
@@ -45,6 +50,7 @@ const DEFAULT_CONFIG: MemoryConfig = {
   consolidationTimeoutMs: DEFAULT_CONSOLIDATION_TIMEOUT_MS,
   nudgeToolCalls: DEFAULT_NUDGE_TOOL_CALLS,
   projectsMemoryDir: DEFAULT_PROJECTS_MEMORY_DIR,
+  sessionSearch: { variant: "legacy" },
 };
 
 export const DEFAULT_CONFIG_PATH = path.join(
@@ -107,6 +113,13 @@ export function loadConfig(configPath = DEFAULT_CONFIG_PATH): MemoryConfig {
       if (typeof parsed.projectCharLimit === "number") config.projectCharLimit = parsed.projectCharLimit;
       if (typeof parsed.memoryDir === "string") config.memoryDir = parsed.memoryDir;
       if (typeof parsed.projectsMemoryDir === "string") config.projectsMemoryDir = parsed.projectsMemoryDir;
+      if (
+        typeof parsed.sessionSearch === "object" &&
+        parsed.sessionSearch !== null &&
+        isSessionSearchVariant(parsed.sessionSearch.variant)
+      ) {
+        config.sessionSearch = { variant: parsed.sessionSearch.variant };
+      }
       if (hasMemoryOverflowStrategy) {
         config.autoConsolidate = config.memoryOverflowStrategy === "auto-consolidate";
       } else if (hasLegacyAutoConsolidate) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,7 +174,7 @@ export default function (pi: ExtensionAPI) {
   registerPreviewContextCommand(pi, store, projectStore, projectName, config);
 
   // ── 11. SQLite session search + extended memory ──
-  registerSessionSearchTool(pi, dbManager);
+  registerSessionSearchTool(pi, dbManager, config.sessionSearch ?? { variant: "legacy" });
   registerMemorySearchTool(pi, dbManager);
   registerIndexSessionsCommand(pi);
 

--- a/src/store/session-anchor-search.ts
+++ b/src/store/session-anchor-search.ts
@@ -1,0 +1,472 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+const DEFAULT_MAX_FILES = 5000;
+const DEFAULT_MAX_LINES = 500000;
+const LIST_FIELDS = new Set(["all", "any", "exclude"]);
+const VALUE_FIELDS = new Set(["from", "to", "cwd", "limit"]);
+
+export interface SessionAnchorRange {
+  path: string;
+  startLine: number;
+  endLine: number;
+  sessionId?: string;
+  cwd?: string;
+  startTime?: string;
+  endTime?: string;
+  score?: number;
+  reason: string;
+}
+
+export interface SessionAnchorSearchResult {
+  success: boolean;
+  ranges: SessionAnchorRange[];
+  message?: string;
+}
+
+export interface SessionAnchorSearchOptions {
+  sessionsDir?: string;
+  maxFiles?: number;
+  maxLines?: number;
+}
+
+interface ParsedAnchorRequest {
+  from?: Date;
+  to?: Date;
+  cwd?: string;
+  limit: number;
+  all: string[];
+  any: string[];
+  exclude: string[];
+  hasTimeConstraint: boolean;
+  hasTextConstraint: boolean;
+}
+
+interface LineHit {
+  path: string;
+  lineNumber: number;
+  sessionId?: string;
+  cwd?: string;
+  timestamp?: string;
+  timestampMs?: number;
+  text: string;
+  score: number;
+  reason: string;
+}
+
+interface PendingRange {
+  path: string;
+  startLine: number;
+  endLine: number;
+  sessionId?: string;
+  cwd?: string;
+  startTime?: string;
+  endTime?: string;
+  score: number;
+  reason: string;
+  text: string;
+}
+
+export function searchSessionAnchors(
+  markdown: string,
+  options: SessionAnchorSearchOptions = {},
+): SessionAnchorSearchResult {
+  const parsed = parseMarkdownRequest(markdown);
+  if (!parsed.success) {
+    return { success: false, ranges: [], message: parsed.message };
+  }
+
+  if (!options.sessionsDir) {
+    return { success: false, ranges: [], message: "sessionsDir is required" };
+  }
+
+  if (!fs.existsSync(options.sessionsDir)) {
+    return { success: false, ranges: [], message: `sessionsDir does not exist: ${options.sessionsDir}` };
+  }
+
+  const files = findJsonlFiles(options.sessionsDir).sort();
+  const maxFiles = options.maxFiles ?? DEFAULT_MAX_FILES;
+  const maxLines = options.maxLines ?? DEFAULT_MAX_LINES;
+  if (files.length > maxFiles) {
+    return {
+      success: false,
+      ranges: [],
+      message: `Request too broad: ${files.length} session files exceed the configured scan cap of ${maxFiles}. Add from/to, cwd, all, or any constraints.`,
+    };
+  }
+
+  const ranges: PendingRange[] = [];
+  let scannedLines = 0;
+
+  for (const file of files) {
+    const remainingLines = maxLines - scannedLines;
+    const fileResult = searchJsonlFile(file, parsed.request, remainingLines, scannedLines, maxLines);
+    if (!fileResult.success) {
+      return { success: false, ranges: [], message: fileResult.message };
+    }
+    scannedLines += fileResult.scannedLines;
+    ranges.push(...fileResult.ranges);
+  }
+
+  const filtered = ranges.filter((range) => !containsAny(range.text, parsed.request.exclude));
+  const sorted = sortRanges(filtered, parsed.request.hasTextConstraint);
+  const limited = sorted.slice(0, parsed.request.limit).map(({ text: _text, ...range }) => range);
+
+  return {
+    success: true,
+    ranges: limited,
+    message: limited.length === 0 ? "No matching session anchors found." : undefined,
+  };
+}
+
+function parseMarkdownRequest(markdown: string): { success: true; request: ParsedAnchorRequest } | { success: false; message: string } {
+  if (!markdown || markdown.trim().length === 0) {
+    return { success: false, message: "markdown is required" };
+  }
+
+  const fields = new Map<string, string>();
+  const lists: Record<"all" | "any" | "exclude", string[]> = { all: [], any: [], exclude: [] };
+  const seen = new Set<string>();
+  let currentList: "all" | "any" | "exclude" | null = null;
+
+  const lines = markdown.split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+
+    const fieldMatch = /^([A-Za-z][A-Za-z0-9_-]*):\s*(.*)$/.exec(trimmed);
+    if (fieldMatch) {
+      const field = fieldMatch[1];
+      const value = fieldMatch[2];
+
+      if (!VALUE_FIELDS.has(field) && !LIST_FIELDS.has(field)) {
+        return {
+          success: false,
+          message: `Invalid field '${field}'. Supported fields: from, to, cwd, limit, all, any, exclude.`,
+        };
+      }
+      if (seen.has(field)) {
+        return { success: false, message: `Duplicate field '${field}'. Keep one value.` };
+      }
+      seen.add(field);
+
+      if (LIST_FIELDS.has(field)) {
+        if (value.trim().length > 0) {
+          return { success: false, message: `Invalid list section '${field}'. Use '${field}:' followed by '- item' lines.` };
+        }
+        currentList = field as "all" | "any" | "exclude";
+      } else {
+        fields.set(field, value.trim());
+        currentList = null;
+      }
+      continue;
+    }
+
+    const listMatch = /^-\s+(.*)$/.exec(trimmed);
+    if (listMatch && currentList) {
+      const term = listMatch[1].trim();
+      if (term.length === 0) {
+        return { success: false, message: `Empty term in '${currentList}'. Remove it or provide text.` };
+      }
+      lists[currentList].push(term);
+      continue;
+    }
+
+    if (listMatch && !currentList) {
+      return { success: false, message: "List item found outside all, any, or exclude section." };
+    }
+
+    return { success: false, message: `Invalid markdown line: ${trimmed}` };
+  }
+
+  const limitValue = fields.get("limit");
+  let limit = DEFAULT_LIMIT;
+  if (limitValue !== undefined) {
+    if (!/^\d+$/.test(limitValue)) {
+      return { success: false, message: "Invalid limit. Use a positive integer." };
+    }
+    const parsedLimit = Number(limitValue);
+    if (!Number.isSafeInteger(parsedLimit) || parsedLimit <= 0) {
+      return { success: false, message: "Invalid limit. Use a positive integer." };
+    }
+    limit = Math.min(parsedLimit, MAX_LIMIT);
+  }
+
+  const fromValue = fields.get("from");
+  const toValue = fields.get("to");
+  const from = fromValue === undefined ? undefined : parseDateTime(fromValue, "from");
+  if (from === null) return { success: false, message: "Invalid from. Use YYYY-MM-DD or an ISO timestamp." };
+  const to = toValue === undefined ? undefined : parseDateTime(toValue, "to");
+  if (to === null) return { success: false, message: "Invalid to. Use YYYY-MM-DD or an ISO timestamp." };
+  if (from && to && from.getTime() > to.getTime()) {
+    return { success: false, message: "Invalid time window. 'from' must be before or equal to 'to'." };
+  }
+
+  const cwd = fields.get("cwd");
+  if (fields.has("cwd") && (!cwd || cwd.trim().length === 0)) {
+    return { success: false, message: "Invalid cwd. Provide a non-empty path." };
+  }
+  const all = lists.all;
+  const any = lists.any;
+  const exclude = lists.exclude;
+  const hasTimeConstraint = Boolean(from || to);
+  const hasCwdConstraint = Boolean(cwd);
+  const hasTextConstraint = all.length > 0 || any.length > 0;
+
+  if (!hasTimeConstraint && !hasCwdConstraint && !hasTextConstraint) {
+    return {
+      success: false,
+      message: "Request needs at least one constraint: provide from/to, cwd, all, or any.",
+    };
+  }
+  return {
+    success: true,
+    request: { from, to, cwd, limit, all, any, exclude, hasTimeConstraint, hasTextConstraint },
+  };
+}
+
+function parseDateTime(value: string, boundary: "from" | "to"): Date | null {
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (dateOnly) {
+    const year = Number(dateOnly[1]);
+    const month = Number(dateOnly[2]);
+    const day = Number(dateOnly[3]);
+    const date = boundary === "from"
+      ? new Date(year, month - 1, day, 0, 0, 0, 0)
+      : new Date(year, month - 1, day, 23, 59, 59, 999);
+    if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+      return null;
+    }
+    return date;
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function findJsonlFiles(dir: string): string[] {
+  const files: string[] = [];
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...findJsonlFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function searchJsonlFile(
+  filePath: string,
+  request: ParsedAnchorRequest,
+  maxLines: number,
+  scannedBefore: number,
+  scanCap: number,
+): { success: true; ranges: PendingRange[]; scannedLines: number } | { success: false; message: string } {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const lines = content.split(/\r?\n/);
+  const hits: LineHit[] = [];
+  let currentSessionId: string | undefined;
+  let currentCwd: string | undefined;
+
+  let scannedLines = 0;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (line.trim().length === 0) continue;
+
+    scannedLines += 1;
+    if (scannedLines > maxLines) {
+      return {
+        success: false,
+        message: `Request too broad: scanned ${scannedBefore + scannedLines} session lines, exceeding the configured scan cap of ${scanCap}. Add from/to, cwd, all, or any constraints.`,
+      };
+    }
+
+    let event: unknown;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      return { success: false, message: `Invalid JSON in ${filePath}:${index + 1}` };
+    }
+
+    const sessionId = getSessionId(event) ?? currentSessionId;
+    if (sessionId) currentSessionId = sessionId;
+
+    const cwd = getCwd(event) ?? currentCwd;
+    if (cwd) currentCwd = cwd;
+
+    if (request.cwd && cwd !== request.cwd) continue;
+
+    const timestamp = getTimestamp(event);
+    const timestampMs = timestamp ? Date.parse(timestamp) : undefined;
+    const hasValidTimestamp = timestampMs !== undefined && !Number.isNaN(timestampMs);
+    if (request.hasTimeConstraint) {
+      if (!hasValidTimestamp) continue;
+      if (request.from && timestampMs < request.from.getTime()) continue;
+      if (request.to && timestampMs > request.to.getTime()) continue;
+    }
+
+    const text = textualizeEvent(event);
+    const termScore = scoreTerms(text, request);
+    const matchesTerms = request.hasTextConstraint ? termScore > 0 : true;
+    if (!matchesTerms) continue;
+
+    if (!request.hasTextConstraint && !hasValidTimestamp) continue;
+
+    hits.push({
+      path: filePath,
+      lineNumber: index + 1,
+      sessionId,
+      cwd,
+      timestamp: hasValidTimestamp ? timestamp : undefined,
+      timestampMs: hasValidTimestamp ? timestampMs : undefined,
+      text,
+      score: request.hasTextConstraint ? termScore : 1,
+      reason: buildReason(request, text),
+    });
+  }
+
+  return { success: true, ranges: mergeAdjacentHits(hits), scannedLines };
+}
+
+function mergeAdjacentHits(hits: LineHit[]): PendingRange[] {
+  const ranges: PendingRange[] = [];
+
+  for (const hit of hits) {
+    const last = ranges.at(-1);
+    if (last && last.path === hit.path && last.endLine + 1 === hit.lineNumber && last.reason === hit.reason) {
+      last.endLine = hit.lineNumber;
+      last.score += hit.score;
+      last.text += "\n" + hit.text;
+      last.sessionId ??= hit.sessionId;
+      last.cwd ??= hit.cwd;
+      if (!last.startTime && hit.timestamp) last.startTime = hit.timestamp;
+      if (hit.timestamp) last.endTime = hit.timestamp;
+      continue;
+    }
+
+    ranges.push({
+      path: hit.path,
+      startLine: hit.lineNumber,
+      endLine: hit.lineNumber,
+      sessionId: hit.sessionId,
+      cwd: hit.cwd,
+      startTime: hit.timestamp,
+      endTime: hit.timestamp,
+      score: hit.score,
+      reason: hit.reason,
+      text: hit.text,
+    });
+  }
+
+  return ranges;
+}
+
+function sortRanges(ranges: PendingRange[], textConstrained: boolean): PendingRange[] {
+  return [...ranges].sort((a, b) => {
+    if (textConstrained && b.score !== a.score) return b.score - a.score;
+    const timeCompare = Date.parse(a.startTime ?? "") - Date.parse(b.startTime ?? "");
+    if (!Number.isNaN(timeCompare) && timeCompare !== 0) return timeCompare;
+    const pathCompare = a.path.localeCompare(b.path);
+    if (pathCompare !== 0) return pathCompare;
+    return a.startLine - b.startLine;
+  });
+}
+
+function scoreTerms(text: string, request: ParsedAnchorRequest): number {
+  const lower = text.toLocaleLowerCase();
+  const matchedAll = request.all.filter((term) => lower.includes(term.toLocaleLowerCase()));
+  const matchedAny = request.any.filter((term) => lower.includes(term.toLocaleLowerCase()));
+
+  if (request.all.length > 0 && matchedAll.length !== request.all.length) return 0;
+  if (request.any.length > 0 && matchedAny.length === 0) return 0;
+
+  if (request.all.length === 0 && request.any.length === 0) return 1;
+  return matchedAll.length * 2 + matchedAny.length;
+}
+
+function buildReason(request: ParsedAnchorRequest, text: string): string {
+  if (!request.hasTextConstraint) {
+    if (request.hasTimeConstraint && request.cwd) return "cwd+time window";
+    if (request.hasTimeConstraint) return "time window";
+    return "cwd";
+  }
+
+  const lower = text.toLocaleLowerCase();
+  const parts: string[] = [];
+  if (request.all.length > 0) parts.push(`matched all: ${request.all.join(", ")}`);
+  const matchedAny = request.any.filter((term) => lower.includes(term.toLocaleLowerCase()));
+  if (matchedAny.length > 0) parts.push(`matched any: ${matchedAny.join(", ")}`);
+  return parts.join("; ");
+}
+
+function containsAny(text: string, terms: string[]): boolean {
+  const lower = text.toLocaleLowerCase();
+  return terms.some((term) => lower.includes(term.toLocaleLowerCase()));
+}
+
+function getTimestamp(event: unknown): string | undefined {
+  if (!isRecord(event)) return undefined;
+  if (typeof event.timestamp === "string") return event.timestamp;
+  if (isRecord(event.message) && typeof event.message.timestamp === "string") return event.message.timestamp;
+  return undefined;
+}
+
+function getSessionId(event: unknown): string | undefined {
+  if (!isRecord(event)) return undefined;
+  if (typeof event.sessionId === "string") return event.sessionId;
+  if (typeof event.session_id === "string") return event.session_id;
+  if (event.type === "session" && typeof event.id === "string") return event.id;
+  if (isRecord(event.session) && typeof event.session.id === "string") return event.session.id;
+  return undefined;
+}
+
+function getCwd(event: unknown): string | undefined {
+  if (!isRecord(event)) return undefined;
+  if (typeof event.cwd === "string") return event.cwd;
+  if (isRecord(event.session) && typeof event.session.cwd === "string") return event.session.cwd;
+  return undefined;
+}
+
+function textualizeEvent(event: unknown): string {
+  const parts: string[] = [];
+  collectStrings(event, parts);
+  return parts.join("\n");
+}
+
+const METADATA_TEXT_KEYS = new Set([
+  "type",
+  "id",
+  "parentId",
+  "sessionId",
+  "session_id",
+  "timestamp",
+  "cwd",
+  "role",
+  "customType",
+]);
+
+function collectStrings(value: unknown, parts: string[], key?: string): void {
+  if (typeof value === "string") {
+    if (!key || !METADATA_TEXT_KEYS.has(key)) parts.push(value);
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) collectStrings(item, parts, key);
+    return;
+  }
+
+  if (!isRecord(value)) return;
+  for (const [childKey, item] of Object.entries(value)) collectStrings(item, parts, childKey);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/tools/session-search-tool.ts
+++ b/src/tools/session-search-tool.ts
@@ -1,17 +1,122 @@
+import * as path from 'node:path';
+import * as os from 'node:os';
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { StringEnum } from "@earendil-works/pi-ai";
 import { DatabaseManager } from '../store/db.js';
 import { searchSessions, getIndexedMessageCount } from '../store/session-search.js';
+import { searchSessionAnchors } from '../store/session-anchor-search.js';
+import type { SessionAnchorRange, SessionAnchorSearchResult } from '../store/session-anchor-search.js';
+import type { SessionSearchConfig } from '../types.js';
 
 interface SearchResult {
   success: boolean;
   count?: number;
   message?: string;
   output?: string;
+  ranges?: SessionAnchorRange[];
 }
 
-export function registerSessionSearchTool(pi: ExtensionAPI, dbManager: DatabaseManager): void {
+interface SessionSearchToolOptions {
+  sessionsDir?: string;
+}
+
+const DEFAULT_SESSIONS_DIR = path.join(os.homedir(), '.pi', 'agent', 'sessions');
+
+export function registerSessionSearchTool(
+  pi: ExtensionAPI,
+  dbManager: DatabaseManager,
+  sessionSearchConfig: SessionSearchConfig = { variant: 'legacy' },
+  options: SessionSearchToolOptions = {},
+): void {
+  if (sessionSearchConfig.variant === 'anchors') {
+    registerAnchorSessionSearchTool(pi, options.sessionsDir ?? DEFAULT_SESSIONS_DIR);
+    return;
+  }
+
+  registerLegacySessionSearchTool(pi, dbManager);
+}
+
+function registerAnchorSessionSearchTool(pi: ExtensionAPI, sessionsDir: string): void {
+  pi.registerTool({
+    name: 'session_search',
+    label: 'Session Search',
+    description: `Search Pi session JSONL files in the opt-in anchor mode using a Markdown request.
+
+This mode accepts only a markdown request. Supported scalar fields are from, to, cwd, and limit. Supported list sections are all, any, and exclude: all terms must match, any requires at least one listed term, and exclude removes matching ranges. It returns compact JSONL line-range anchors, not summaries or previews. Output is plain text: count, optional message, then anchors as path:startLine-endLine with a short reason.
+
+Example:
+from: 2026-05-14
+to: 2026-05-15
+cwd: /path/to/project
+limit: 20
+
+all:
+- alpha
+
+any:
+- beta
+- gamma
+
+exclude:
+- delta`,
+    promptSnippet: 'Search past session JSONL files for compact source anchors',
+    promptGuidelines: [
+      'Use session_search with markdown only when the session search anchor mode is configured.',
+      'Request source anchors, not summaries or previews.',
+      'Use all for required terms, any for alternatives, and exclude for terms that must not appear in a returned range.',
+    ],
+    parameters: Type.Object({
+      markdown: Type.String({ description: 'Markdown request with optional from/to/cwd/limit fields and all/any/exclude lists.' }),
+    }),
+    execute: async (_id: string, args: { markdown: string }) => {
+      const markdown = args.markdown;
+
+      if (!markdown || markdown.trim().length === 0) {
+        const result: SearchResult = { success: false, message: 'markdown is required' };
+        return { content: [{ type: 'text' as const, text: result.message! }], details: result };
+      }
+
+      const searchResult = searchSessionAnchors(markdown, { sessionsDir });
+      if (!searchResult.success) {
+        const result: SearchResult = { success: false, message: searchResult.message ?? 'Anchor session search failed.' };
+        return { content: [{ type: 'text' as const, text: result.message! }], details: result };
+      }
+
+      const output = formatAnchorSearchOutput(searchResult);
+      const result: SearchResult = {
+        success: true,
+        count: searchResult.ranges.length,
+        message: searchResult.message,
+        output,
+        ranges: searchResult.ranges,
+      };
+      return { content: [{ type: 'text' as const, text: output }], details: result };
+    },
+  });
+}
+
+function formatAnchorSearchOutput(searchResult: SessionAnchorSearchResult): string {
+  const lines = [`count: ${searchResult.ranges.length}`];
+  if (searchResult.message) lines.push(`message: ${searchResult.message}`);
+  if (searchResult.ranges.length > 0) {
+    lines.push("anchors:");
+    for (const range of searchResult.ranges) {
+      const anchor = `${range.path}:${range.startLine}-${range.endLine}`;
+      const reason = compactReason(range.reason);
+      lines.push(reason ? `- ${anchor} — ${reason}` : `- ${anchor}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function compactReason(reason: string | undefined): string {
+  if (!reason) return "";
+  const oneLine = reason.replace(/\s+/g, " ").trim();
+  return oneLine.length <= 180 ? oneLine : `${oneLine.slice(0, 177)}...`;
+}
+
+function registerLegacySessionSearchTool(pi: ExtensionAPI, dbManager: DatabaseManager): void {
   pi.registerTool({
     name: 'session_search',
     label: 'Session Search',

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,13 @@ import type { TextContent } from "@earendil-works/pi-ai";
 
 export type MemoryOverflowStrategy = "auto-consolidate" | "reject" | "fifo-evict";
 
+export type SessionSearchVariant = "legacy" | "anchors";
+
+export interface SessionSearchConfig {
+  /** Session search implementation variant. Default: legacy */
+  variant: SessionSearchVariant;
+}
+
 export interface MemoryConfig {
   /** Prompt memory mode. Default: policy-only */
   memoryMode: "policy-only" | "legacy-inject";
@@ -37,6 +44,8 @@ export interface MemoryConfig {
   memoryDir?: string;
   /** Directory for project-scoped memory (relative to ~/.pi/agent). Default: "projects-memory" */
   projectsMemoryDir?: string;
+  /** Session search configuration. Default: { variant: "legacy" } */
+  sessionSearch?: SessionSearchConfig;
   /** Strategy when memory is full. Default: auto-consolidate */
   memoryOverflowStrategy?: MemoryOverflowStrategy;
   /** Legacy alias for memoryOverflowStrategy. Default: true */
@@ -61,10 +70,6 @@ export interface MemoryConfig {
   nudgeToolCalls: number;
   /** Maximum time in milliseconds for auto-consolidation to complete. Default: 60000 */
   consolidationTimeoutMs: number;
-  /** Enable session history search via SQLite FTS5. Default: true */
-  sessionSearchEnabled?: boolean;
-  /** Days to retain session history. Default: 90 */
-  sessionRetentionDays?: number;
 }
 
 export type MemoryCategory =

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -32,6 +32,7 @@ describe("loadConfig", () => {
     assert.strictEqual(config.failureInjectionMaxAgeDays, 7);
     assert.strictEqual(config.failureInjectionMaxEntries, 5);
     assert.strictEqual(config.projectsMemoryDir, "projects-memory");
+    assert.deepStrictEqual(config.sessionSearch, { variant: "legacy" });
   });
 
   it("overrides defaults when config file exists", () => {
@@ -203,6 +204,25 @@ describe("loadConfig", () => {
       assert.strictEqual(config.memoryOverflowStrategy, policy);
       assert.strictEqual(config.autoConsolidate, policy === "auto-consolidate");
     }
+  });
+
+  it("accepts valid sessionSearch variants", () => {
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+
+    for (const variant of ["legacy", "anchors"] as const) {
+      fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({ sessionSearch: { variant } }));
+      const config = loadConfig(TEST_CONFIG_PATH);
+      assert.deepStrictEqual(config.sessionSearch, { variant });
+    }
+  });
+
+  it("ignores invalid sessionSearch variants", () => {
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({
+      sessionSearch: { variant: "invalid" },
+    }));
+    const config = loadConfig(TEST_CONFIG_PATH);
+    assert.deepStrictEqual(config.sessionSearch, { variant: "legacy" });
   });
 
   it("ignores invalid memoryOverflowStrategy values", () => {

--- a/tests/store/session-anchor-search.test.ts
+++ b/tests/store/session-anchor-search.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, afterEach } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { searchSessionAnchors } from "../../src/store/session-anchor-search.js";
+
+let ROOT_DIR = "";
+
+function makeSessionsDir(): string {
+  ROOT_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "pi-session-anchor-search-test-"));
+  return ROOT_DIR;
+}
+
+function writeJsonl(relativePath: string, events: unknown[]): string {
+  const filePath = path.join(ROOT_DIR, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, events.map((event) => JSON.stringify(event)).join("\n") + "\n");
+  return filePath;
+}
+
+function message(timestamp: string, text: string, extra: Record<string, unknown> = {}): unknown {
+  return {
+    type: "message",
+    timestamp,
+    sessionId: "session-1",
+    cwd: "/work/project",
+    message: { role: "user", content: text },
+    ...extra,
+  };
+}
+
+afterEach(() => {
+  if (ROOT_DIR) fs.rmSync(ROOT_DIR, { recursive: true, force: true });
+  ROOT_DIR = "";
+});
+
+describe("searchSessionAnchors", () => {
+  it("accepts a minimal time window and caps limit", () => {
+    const sessionsDir = makeSessionsDir();
+    const events = Array.from({ length: 210 }, (_, index) => (
+      index % 2 === 0
+        ? message(`2026-05-15T12:${String(index % 60).padStart(2, "0")}:00.000Z`, `event ${index}`)
+        : message(`2026-05-14T12:${String(index % 60).padStart(2, "0")}:00.000Z`, `outside ${index}`)
+    ));
+    writeJsonl("session.jsonl", events);
+
+    const result = searchSessionAnchors("from: 2026-05-15\nto: 2026-05-15\nlimit: 200", { sessionsDir });
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.ranges.length, 100);
+    assert.strictEqual(result.ranges[0].startLine, 1);
+    assert.strictEqual(result.ranges[0].reason, "time window");
+  });
+
+  it("returns diagnostics for duplicate, unknown, empty, and unconstrained requests", () => {
+    const sessionsDir = makeSessionsDir();
+
+    assert.match(searchSessionAnchors("", { sessionsDir }).message ?? "", /markdown is required/);
+    assert.match(searchSessionAnchors("since: 2026-05-15", { sessionsDir }).message ?? "", /Invalid field 'since'/);
+    assert.match(searchSessionAnchors("from: 2026-05-15\nfrom: 2026-05-16", { sessionsDir }).message ?? "", /Duplicate field 'from'/);
+    assert.match(searchSessionAnchors("limit: 0", { sessionsDir }).message ?? "", /Invalid limit/);
+    assert.match(searchSessionAnchors("all:\n- ", { sessionsDir }).message ?? "", /Invalid markdown line|Empty term/);
+    assert.match(searchSessionAnchors("limit: 10", { sessionsDir }).message ?? "", /needs at least one constraint/);
+  });
+
+  it("measures broadness with scan caps instead of rejecting request shape", () => {
+    const sessionsDir = makeSessionsDir();
+    writeJsonl("one.jsonl", [
+      message("2026-05-15T10:00:00.000Z", "a"),
+      message("2026-05-15T11:00:00.000Z", "b"),
+    ]);
+    writeJsonl("two.jsonl", [message("2026-05-15T12:00:00.000Z", "a")]);
+
+    const shortTerm = searchSessionAnchors("any:\n- a", { sessionsDir });
+    assert.strictEqual(shortTerm.success, true);
+    assert.strictEqual(shortTerm.ranges.length, 2);
+
+    const fileCap = searchSessionAnchors("any:\n- a", { sessionsDir, maxFiles: 1 });
+    assert.strictEqual(fileCap.success, false);
+    assert.match(fileCap.message ?? "", /2 session files exceed/);
+
+    const lineCap = searchSessionAnchors("any:\n- a", { sessionsDir, maxLines: 1 });
+    assert.strictEqual(lineCap.success, false);
+    assert.match(lineCap.message ?? "", /scan cap/);
+  });
+
+  it("allows cwd-only requests as bounded source anchors", () => {
+    const sessionsDir = makeSessionsDir();
+    writeJsonl("session.jsonl", [
+      message("2026-05-15T10:00:00.000Z", "inside cwd"),
+      message("2026-05-15T11:00:00.000Z", "outside cwd", { cwd: "/other/project" }),
+    ]);
+
+    const result = searchSessionAnchors("cwd: /work/project", { sessionsDir });
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.ranges.length, 1);
+    assert.strictEqual(result.ranges[0].startLine, 1);
+    assert.strictEqual(result.ranges[0].reason, "cwd");
+  });
+
+  it("carries the real session event id onto matching message ranges", () => {
+    const sessionsDir = makeSessionsDir();
+    writeJsonl("session.jsonl", [
+      { type: "session", version: 1, id: "session-real", timestamp: "2026-05-15T09:00:00.000Z", cwd: "/work/project" },
+      { type: "message", id: "message-1", parentId: "session-real", timestamp: "2026-05-15T10:00:00.000Z", message: { role: "user", content: "needle" } },
+    ]);
+
+    const result = searchSessionAnchors("any:\n- needle", { sessionsDir });
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.ranges.length, 1);
+    assert.strictEqual(result.ranges[0].sessionId, "session-real");
+    assert.strictEqual(result.ranges[0].startLine, 2);
+  });
+
+  it("does not match metadata fields as text", () => {
+    const sessionsDir = makeSessionsDir();
+    writeJsonl("session.jsonl", [
+      message("2026-05-15T10:00:00.000Z", "actual content"),
+    ]);
+
+    const result = searchSessionAnchors("any:\n- /work/project", { sessionsDir });
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.ranges.length, 0);
+  });
+
+  it("returns contiguous timestamped ranges for time-window-only queries", () => {
+    const sessionsDir = makeSessionsDir();
+    const filePath = writeJsonl("session.jsonl", [
+      message("2026-05-14T12:00:00.000Z", "before"),
+      message("2026-05-15T10:00:00.000Z", "inside one"),
+      message("2026-05-15T11:00:00.000Z", "inside two"),
+      message("2026-05-16T12:00:00.000Z", "after"),
+    ]);
+
+    const result = searchSessionAnchors("from: 2026-05-15\nto: 2026-05-15", { sessionsDir });
+
+    assert.strictEqual(result.success, true);
+    assert.deepStrictEqual(result.ranges.map((range) => ({ path: range.path, startLine: range.startLine, endLine: range.endLine })), [
+      { path: filePath, startLine: 2, endLine: 3 },
+    ]);
+    assert.strictEqual(result.ranges[0].startTime, "2026-05-15T10:00:00.000Z");
+    assert.strictEqual(result.ranges[0].endTime, "2026-05-15T11:00:00.000Z");
+  });
+
+  it("matches all and any terms as case-insensitive literal substrings", () => {
+    const sessionsDir = makeSessionsDir();
+    writeJsonl("session.jsonl", [
+      message("2026-05-15T10:00:00.000Z", "Alpha beta phrase"),
+      message("2026-05-15T11:00:00.000Z", "Contains GAMMA only"),
+      message("2026-05-15T12:00:00.000Z", "nothing useful"),
+    ]);
+
+    const allResult = searchSessionAnchors("all:\n- alpha beta", { sessionsDir });
+    assert.strictEqual(allResult.success, true);
+    assert.strictEqual(allResult.ranges.length, 1);
+    assert.strictEqual(allResult.ranges[0].startLine, 1);
+    assert.strictEqual(allResult.ranges[0].reason, "matched all: alpha beta");
+
+    const anyResult = searchSessionAnchors("any:\n- gamma\n- delta", { sessionsDir });
+    assert.strictEqual(anyResult.success, true);
+    assert.strictEqual(anyResult.ranges.length, 1);
+    assert.strictEqual(anyResult.ranges[0].startLine, 2);
+    assert.strictEqual(anyResult.ranges[0].reason, "matched any: gamma");
+  });
+
+  it("removes ranges containing exclude terms", () => {
+    const sessionsDir = makeSessionsDir();
+    writeJsonl("session.jsonl", [
+      message("2026-05-15T10:00:00.000Z", "alpha keep"),
+      message("2026-05-15T10:30:00.000Z", "separator"),
+      message("2026-05-15T11:00:00.000Z", "alpha secret drop"),
+    ]);
+
+    const result = searchSessionAnchors("any:\n- alpha\nexclude:\n- secret", { sessionsDir });
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.ranges.length, 1);
+    assert.strictEqual(result.ranges[0].startLine, 1);
+  });
+
+  it("returns single-line hits as startLine equal to endLine", () => {
+    const sessionsDir = makeSessionsDir();
+    writeJsonl("nested/session.jsonl", [
+      message("2026-05-15T10:00:00.000Z", "first"),
+      message("2026-05-15T11:00:00.000Z", "needle"),
+    ]);
+
+    const result = searchSessionAnchors("any:\n- needle", { sessionsDir });
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.ranges.length, 1);
+    assert.strictEqual(result.ranges[0].startLine, 2);
+    assert.strictEqual(result.ranges[0].endLine, 2);
+  });
+
+  it("fails on invalid JSON lines with path and line", () => {
+    const sessionsDir = makeSessionsDir();
+    const filePath = path.join(sessionsDir, "bad.jsonl");
+    fs.writeFileSync(filePath, `${JSON.stringify(message("2026-05-15T10:00:00.000Z", "ok"))}\n{bad json}\n`);
+
+    const result = searchSessionAnchors("from: 2026-05-15", { sessionsDir });
+
+    assert.strictEqual(result.success, false);
+    assert.match(result.message ?? "", new RegExp(`${filePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}:2`));
+  });
+});

--- a/tests/tools/session-search-tool.test.ts
+++ b/tests/tools/session-search-tool.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, afterEach } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { registerSessionSearchTool } from "../../src/tools/session-search-tool.js";
+
+let ROOT_DIR = "";
+
+afterEach(() => {
+  if (ROOT_DIR) fs.rmSync(ROOT_DIR, { recursive: true, force: true });
+  ROOT_DIR = "";
+});
+
+function makeSessionsDir(): string {
+  ROOT_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "pi-session-search-tool-test-"));
+  return ROOT_DIR;
+}
+
+describe("registerSessionSearchTool", () => {
+  it("registers the legacy query schema by default", () => {
+    let captured: any;
+    const mockPi = {
+      registerTool: (def: any) => { captured = def; },
+    } as any;
+
+    registerSessionSearchTool(mockPi, {} as any);
+
+    const schema = JSON.stringify(captured.parameters);
+    assert.strictEqual(captured.name, "session_search");
+    assert.match(schema, /query/);
+    assert.doesNotMatch(schema, /markdown/);
+  });
+
+  it("registers and executes the anchor markdown-only schema when configured", async () => {
+    let captured: any;
+    const mockPi = {
+      registerTool: (def: any) => { captured = def; },
+    } as any;
+    const sessionsDir = makeSessionsDir();
+    const filePath = path.join(sessionsDir, "session.jsonl");
+    fs.writeFileSync(filePath, `${JSON.stringify({
+      type: "message",
+      timestamp: "2026-05-15T10:00:00.000Z",
+      sessionId: "session-1",
+      cwd: "/work/project",
+      message: { role: "user", content: "needle" },
+    })}\n`);
+
+    registerSessionSearchTool(mockPi, {} as any, { variant: "anchors" }, { sessionsDir });
+
+    const schema = JSON.stringify(captured.parameters);
+    assert.strictEqual(captured.name, "session_search");
+    assert.match(schema, /markdown/);
+    assert.doesNotMatch(schema, /query/);
+    assert.match(captured.description, /all terms must match/);
+    assert.match(captured.description, /any requires at least one listed term/);
+    assert.match(captured.description, /exclude removes matching ranges/);
+    assert.match(captured.description, /Output is plain text: count, optional message/);
+    assert.match(captured.description, /path:startLine-endLine with a short reason/);
+    assert.match(captured.description, /Example:\nfrom: 2026-05-14/);
+    assert.match(captured.promptGuidelines.join("\n"), /Use all for required terms/);
+
+    const empty = await captured.execute("tc-1", { markdown: "" });
+    assert.strictEqual(empty.details.success, false);
+    assert.strictEqual(empty.details.message, "markdown is required");
+
+    const result = await captured.execute("tc-2", { markdown: "any:\n- needle" });
+    assert.strictEqual(result.details.success, true);
+    assert.strictEqual(result.details.count, 1);
+    assert.deepStrictEqual(result.details.ranges.map((range: any) => ({
+      path: range.path,
+      startLine: range.startLine,
+      endLine: range.endLine,
+      reason: range.reason,
+    })), [{ path: filePath, startLine: 1, endLine: 1, reason: "matched any: needle" }]);
+    assert.strictEqual(result.details.output, result.content[0].text);
+    assert.match(result.content[0].text, /^count: 1\nanchors:\n-/);
+    assert.match(result.content[0].text, new RegExp(`${filePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}:1-1 — matched any: needle`));
+    assert.doesNotMatch(result.content[0].text, /"ranges"/);
+    assert.doesNotMatch(result.content[0].text, /"startLine"/);
+    assert.doesNotMatch(result.content[0].text, /"sessionId"/);
+  });
+});


### PR DESCRIPTION
 ## Summary

   Adds an opt-in source-anchored `session_search` implementation via:

   ```json
   {
     "sessionSearch": { "variant": "anchors" }
   }
 ```

 The existing SQLite/FTS implementation remains the default for compatibility. The new anchor mode is designed for higher-quality recall: it reads Pi session JSONL files
 directly, searches the actual event log, and returns compact source anchors that agents can inspect and reason from.

 Why

 The legacy SQLite/FTS search is useful for simple snippet lookup, but it can lose the shape of the original conversation: multi-day sessions, tool events, project cwd,
 timestamps, and exact line-addressable source context.

 Anchor mode keeps the search grounded in the real session files. It returns sorted JSONL ranges such as:

 ```text
   count: 2
   anchors:
   - /path/to/session.jsonl:42-47 — matched all: auth; matched any: migration
 ```

 These anchors preserve the original source context and make past decisions recoverable from the line-addressable session log.

 Design

 The new mode is intentionally small and data-oriented:

 - keeps legacy behavior unchanged by default
 - uses the existing session_search tool name
 - switches behavior only through config
 - accepts a single Markdown request field
 - searches JSONL session files directly
 - filters by event timestamps, not filenames
 - supports cwd, time windows, required/alternative/excluded terms
 - returns compact path:startLine-endLine anchors with short reasons
 - does not add a persistent index or broader recall architecture

 Request format

 Anchor mode accepts only:

 ```ts
   session_search({ markdown: string })
 ```

 Example:

 ```markdown
   from: 2026-05-14
   to: 2026-05-15
   cwd: /path/to/project
   limit: 20

   all:
   - required term

   any:
   - alternative term
   - another alternative

   exclude:
   - unwanted term
 ```

 Verification

 - npm test
 - npm run check
 - npm pack --dry-run
 - smoke-tested against real Pi session JSONL files
 - verified default legacy mode remains unchanged