### PR TITLE
feat(skills): show runtime-discovered skills in /memory-skills modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The extension stores memory at two levels:
 
 | Tier | Location | What goes here | Available when |
 |---|---|---|---|
-| **Global** | `~/.pi/agent/memory/` | Facts that apply everywhere — your name, preferences, OS, tools | Searchable via `memory_search` |
+| **Global** | `~/.pi/agent/pi-hermes-memory/` | Facts that apply everywhere — your name, preferences, OS, tools | Searchable via `memory_search` |
 | **Project** | `~/.pi/agent/projects-memory/<project>/` | Facts scoped to one codebase — architecture decisions, API quirks, team norms | Searchable when cwd matches the project |
 
 By default, full Markdown memories are **not** injected into the system prompt. The system prompt gets a full-detail `<memory-policy>` that tells the agent when to call `memory_search` and how to treat memory results. This keeps first-turn token usage low while preserving access to user, project, failure, correction, insight, preference, convention, and tool-quirk memories.
@@ -185,7 +185,7 @@ The agent also gets a `skill` tool for saving reusable procedures:
 
 Skills are stored in Pi-native locations:
 
-- Global skills: `~/.pi/agent/skills/<slug>/SKILL.md`
+- Global skills: `~/.pi/agent/pi-hermes-memory/skills/<slug>/SKILL.md`
 - Project skills: `~/.pi/agent/projects-memory/<project>/skills/<slug>/SKILL.md`
 
 The extension classifies new skills automatically:
@@ -241,7 +241,7 @@ This lets Pi discover project skills as native skills without copying them into 
 |---|---|---|---|
 | **memory** | `MEMORY.md` | Agent's notes — env facts, project conventions, tool quirks, lessons learned | 5,000 chars |
 | **user** | `USER.md` | User profile — name, preferences, communication style, habits | 5,000 chars |
-| **skills** | `~/.pi/agent/skills/<slug>/SKILL.md` or `projects-memory/<project>/skills/<slug>/SKILL.md` | Procedures — *how* to debug, deploy, test, or fix something | Unlimited |
+| **skills** | `~/.pi/agent/pi-hermes-memory/skills/<slug>/SKILL.md` or `projects-memory/<project>/skills/<slug>/SKILL.md` | Procedures — *how* to debug, deploy, test, or fix something | Unlimited |
 | **extended** | `sessions.db` | Searchable memories beyond the core limit | Unlimited |
 | **sessions** | `sessions.db` | Past conversation history (searchable via FTS5) | Unlimited |
 
@@ -392,7 +392,7 @@ Create `~/.pi/agent/hermes-memory-config.json`:
   "memoryCharLimit": 5000,
   "userCharLimit": 5000,
   "projectCharLimit": 5000,
-  "memoryDir": "~/.pi/agent/memory",
+  "memoryDir": "~/.pi/agent/pi-hermes-memory",
   "projectsMemoryDir": "projects-memory",
   "sessionSearch": { "variant": "legacy" },
   "nudgeInterval": 10,
@@ -421,7 +421,7 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 | `memoryCharLimit` | `5000` | Max characters in MEMORY.md |
 | `userCharLimit` | `5000` | Max characters in USER.md |
 | `projectCharLimit` | `5000` | Max characters in project-scoped MEMORY.md |
-| `memoryDir` | `~/.pi/agent/memory` | Custom directory for memory files |
+| `memoryDir` | `~/.pi/agent/pi-hermes-memory` | Custom directory for extension storage files |
 | `projectsMemoryDir` | `projects-memory` | Subdirectory under `~/.pi/agent/` for project-scoped memory |
 | `sessionSearch` | `{ "variant": "legacy" }` | Session search implementation: `legacy` keeps the existing SQLite/FTS snippet search; `anchors` uses the opt-in Markdown request surface and returns compact JSONL line-range anchors from `~/.pi/agent/sessions/` |
 | `nudgeInterval` | `10` | Turns between auto-reviews |
@@ -448,11 +448,16 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 
 ```
 ~/.pi/agent/
-├── skills/                ← Global Pi-native skills
-│   ├── debug-typescript-errors/
-│   │   └── SKILL.md
-│   └── testing-checklist/
-│       └── SKILL.md
+├── pi-hermes-memory/      ← Global extension storage root
+│   ├── MEMORY.md          ← Agent's personal notes (env facts, patterns, lessons)
+│   ├── USER.md            ← User profile (name, preferences, habits)
+│   ├── sessions.db        ← SQLite database (session history + extended memory)
+│   ├── skills/            ← Global extension-managed skills
+│   │   ├── debug-typescript-errors/
+│   │   │   └── SKILL.md
+│   │   └── testing-checklist/
+│   │       └── SKILL.md
+│   └── .skills-migrated-to-extension-storage
 ├── projects-memory/       ← ALL project-scoped memories (one subfolder per project)
 │   ├── my-project/
 │   │   ├── MEMORY.md
@@ -461,11 +466,6 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 │   │           └── SKILL.md
 │   └── another-project/
 │       └── MEMORY.md
-├── memory/                ← Global memory
-│   ├── MEMORY.md          ← Agent's personal notes (env facts, patterns, lessons)
-│   ├── USER.md            ← User profile (name, preferences, habits)
-│   ├── sessions.db        ← SQLite database (session history + extended memory)
-│   └── .skills-migrated-to-pi-native
 ├── hermes-memory-config.json
 └── ...
 ```
@@ -486,7 +486,7 @@ The `sessions.db` SQLite database stores session history and extended memory ent
 - **System prompts are invisible**: Pi's TUI does not display the system prompt. Use `/memory-preview-context` to inspect whether policy-only or legacy memory injection is active.
 - **Project skill visibility depends on Pi discovery cycles**: project skills are exposed through `resources_discover` using the active project's `skills/` path. If a moved or newly created project skill doesn't show up immediately in a running session, trigger a reload/new session so Pi refreshes discovered resources.
 - **Project move requires active project context**: in `/memory-skills`, the `p` hotkey is disabled when Pi is not currently in a detected project directory.
-- **Skills are agent-generated**: Skills are created by the agent based on its experience. They may not always be perfectly structured. You can move, delete, or still edit them directly in `~/.pi/agent/skills/` or the active project's `skills/` folder.
+- **Skills are agent-generated**: Skills are created by the agent based on its experience. They may not always be perfectly structured. You can move, delete, or still edit them directly in `~/.pi/agent/pi-hermes-memory/skills/` or the active project's `skills/` folder.
 
 ## Architecture
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hermes-memory",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-tui": "^0.74.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "🧠 Persistent memory + 🔍 session search + 🛡️ secret scanning for Pi. Token-aware policy-only memory by default, SQLite FTS5 search, auto-consolidation, procedural skills. 368 tests. Ported from Hermes agent.",
   "type": "module",
   "main": "src/index.ts",

--- a/src/extension-root-migration.ts
+++ b/src/extension-root-migration.ts
@@ -1,0 +1,101 @@
+import fs from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+export interface ExtensionRootMigrationResult {
+  moved: number;
+  merged: number;
+  skipped: number;
+  warnings: string[];
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function moveFileSafe(source: string, target: string): Promise<void> {
+  await fs.mkdir(path.dirname(target), { recursive: true });
+
+  try {
+    await fs.rename(source, target);
+    return;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException)?.code;
+    if (code !== "EXDEV") throw error;
+  }
+
+  await fs.copyFile(source, target);
+  await fs.unlink(source);
+}
+
+async function moveDirContents(sourceDir: string, targetDir: string, result: ExtensionRootMigrationResult): Promise<void> {
+  await fs.mkdir(targetDir, { recursive: true });
+
+  const entries = await fs.readdir(sourceDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const sourcePath = path.join(sourceDir, entry.name);
+    const targetPath = path.join(targetDir, entry.name);
+
+    if (!await pathExists(targetPath)) {
+      try {
+        await moveFileSafe(sourcePath, targetPath);
+        result.moved++;
+      } catch (error) {
+        result.warnings.push(`${sourcePath}: ${error instanceof Error ? error.message : String(error)}`);
+      }
+      continue;
+    }
+
+    if (entry.isDirectory()) {
+      await moveDirContents(sourcePath, targetPath, result);
+      result.merged++;
+      try {
+        const remaining = await fs.readdir(sourcePath);
+        if (remaining.length === 0) await fs.rmdir(sourcePath);
+      } catch {
+        // best effort
+      }
+      continue;
+    }
+
+    result.skipped++;
+  }
+}
+
+/**
+ * Move legacy extension assets from ~/.pi/agent/memory into
+ * ~/.pi/agent/pi-hermes-memory. Existing destination files win.
+ */
+export async function migrateExtensionRoot(
+  legacyRoot: string,
+  targetRoot: string,
+): Promise<ExtensionRootMigrationResult> {
+  const result: ExtensionRootMigrationResult = {
+    moved: 0,
+    merged: 0,
+    skipped: 0,
+    warnings: [],
+  };
+
+  if (path.resolve(legacyRoot) === path.resolve(targetRoot)) return result;
+  if (!existsSync(legacyRoot)) return result;
+
+  await fs.mkdir(targetRoot, { recursive: true });
+  await moveDirContents(legacyRoot, targetRoot, result);
+
+  try {
+    const remaining = await fs.readdir(legacyRoot);
+    if (remaining.length === 0) {
+      await fs.rmdir(legacyRoot);
+    }
+  } catch {
+    // best effort
+  }
+
+  return result;
+}

--- a/src/handlers/index-sessions.ts
+++ b/src/handlers/index-sessions.ts
@@ -34,7 +34,7 @@ export function registerIndexSessionsCommand(pi: ExtensionAPI): void {
 
         ctx.ui.notify(`📁 Found ${totalFiles} session files across ${projectDirs.length} projects\n⏳ Indexing...`, 'info');
 
-        const memoryDir = path.join(os.homedir(), '.pi', 'agent', 'memory');
+        const memoryDir = path.join(os.homedir(), '.pi', 'agent', 'pi-hermes-memory');
         const dbManager = new DatabaseManager(memoryDir);
 
         try {

--- a/src/handlers/skills-command.ts
+++ b/src/handlers/skills-command.ts
@@ -2,6 +2,9 @@
  * Skills command — /memory-skills opens an interactive skills manager.
  */
 
+import { createHash } from "node:crypto";
+import * as os from "node:os";
+import * as path from "node:path";
 import type { ExtensionAPI, ExtensionCommandContext, Theme } from "@earendil-works/pi-coding-agent";
 import { SkillStore } from "../store/skill-store.js";
 import type { SkillIndex, SkillResult, SkillScope } from "../types.js";
@@ -24,43 +27,192 @@ export const MEMORY_SKILLS_KEYMAP = {
   selectAllFiltered: "a",
   clearSelection: "n",
   focusSearch: "/",
+  openFilters: "f",
   toggleSelection: "space",
   switchFocus: "tab",
   close: "esc",
 } as const;
 
+export type SkillRowCategory = "G" | "P" | "E";
+
 export interface SkillModalRow {
   skillId: string;
-  scope: SkillScope;
+  scope?: SkillScope;
+  category: SkillRowCategory;
+  mutable: boolean;
   name: string;
   displayName: string;
   description: string;
   path: string;
+  displayPath: string;
   projectName?: string;
   selected: boolean;
   searchText: string;
 }
 
-export interface SkillBatchActionResult {
-  skills: SkillIndex[];
-  summaryLines: string[];
-  retainSelectedSkillIds?: string[];
-  focusSkillId?: string;
+interface LoadedSkillRow {
+  name: string;
+  displayName: string;
+  description: string;
+  path: string;
+  displayPath: string;
+  sourceScope?: string;
+  sourceOrigin?: string;
+  sourceLabel?: string;
 }
 
-export function formatSkillsList(skills: SkillIndex[], projectName: string | null): string {
-  const globalSkills = skills.filter((skill) => skill.scope === "global");
-  const projectSkills = skills.filter((skill) => skill.scope === "project");
+interface SkillCommandInfo {
+  name: string;
+  description?: string;
+  source?: string;
+  sourceInfo?: {
+    path?: string;
+    scope?: string;
+    source?: string;
+    origin?: string;
+    baseDir?: string;
+  };
+}
+
+interface SkillCategoryFilters {
+  global: boolean;
+  project: boolean;
+  external: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function getStringField(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+const DEFAULT_SKILL_FILTERS: SkillCategoryFilters = {
+  global: true,
+  project: true,
+  external: true,
+};
+
+function cloneFilters(filters: SkillCategoryFilters): SkillCategoryFilters {
+  return {
+    global: filters.global,
+    project: filters.project,
+    external: filters.external,
+  };
+}
+
+function ensureValidFilters(filters: SkillCategoryFilters): SkillCategoryFilters {
+  if (filters.global || filters.project || filters.external) return filters;
+  return { ...DEFAULT_SKILL_FILTERS };
+}
+
+function filtersLabel(filters: SkillCategoryFilters): string {
+  const active: string[] = [];
+  if (filters.global) active.push("[G]");
+  if (filters.project) active.push("[P]");
+  if (filters.external) active.push("[E]");
+  return active.length > 0 ? active.join(" ") : "(none)";
+}
+
+function normalizePathForKey(inputPath: string): string {
+  const resolved = path.resolve(inputPath);
+  const normalized = resolved.replace(/\\/g, "/");
+  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+export function formatSkillPath(inputPath: string): string {
+  const absolutePath = path.resolve(inputPath);
+  const home = os.homedir();
+  const relative = path.relative(home, absolutePath);
+  const underHome = relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+
+  if (!underHome) return absolutePath;
+  if (relative === "") return "~";
+  return `~${path.sep}${relative}`;
+}
+
+function categoryForScope(scope: SkillScope): SkillRowCategory {
+  return scope === "global" ? "G" : "P";
+}
+
+function createExternalSkillId(name: string, filePath: string): string {
+  const safeName = (name || "skill")
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "skill";
+  const hash = createHash("sha1").update(`${name}|${filePath}`).digest("hex").slice(0, 10);
+  return `external:${safeName}:${hash}`;
+}
+
+function matchesCategoryFilter(row: SkillModalRow, filters: SkillCategoryFilters): boolean {
+  if (row.category === "G") return filters.global;
+  if (row.category === "P") return filters.project;
+  return filters.external;
+}
+
+function categoryOrder(category: SkillRowCategory): number {
+  switch (category) {
+    case "G":
+      return 0;
+    case "P":
+      return 1;
+    case "E":
+      return 2;
+  }
+}
+
+export function collectLoadedSkillsFromCommands(commands: SkillCommandInfo[]): LoadedSkillRow[] {
+  const loaded: LoadedSkillRow[] = [];
+
+  for (const command of commands) {
+    if (!isRecord(command)) continue;
+    const source = getStringField(command.source);
+    if (source !== "skill") continue;
+
+    const commandName = getStringField(command.name)?.trim();
+    if (!commandName) continue;
+
+    const sourceInfo = isRecord(command.sourceInfo) ? command.sourceInfo : undefined;
+    const sourcePath = sourceInfo ? getStringField(sourceInfo.path)?.trim() : undefined;
+    if (!sourcePath) continue;
+
+    const rawName = commandName.startsWith("skill:")
+      ? commandName.slice("skill:".length)
+      : commandName;
+    const displayName = rawName || commandName;
+    const filePath = path.resolve(sourcePath);
+
+    loaded.push({
+      name: rawName || commandName,
+      displayName,
+      description: getStringField(command.description) || "",
+      path: filePath,
+      displayPath: formatSkillPath(filePath),
+      sourceScope: sourceInfo ? getStringField(sourceInfo.scope) : undefined,
+      sourceOrigin: sourceInfo ? getStringField(sourceInfo.origin) : undefined,
+      sourceLabel: sourceInfo ? getStringField(sourceInfo.source) : undefined,
+    });
+  }
+
+  return loaded.sort((a, b) => a.displayName.localeCompare(b.displayName));
+}
+
+export function formatSkillsList(rows: SkillModalRow[], projectName: string | null): string {
+  const globalSkills = rows.filter((row) => row.category === "G");
+  const projectSkills = rows.filter((row) => row.category === "P");
+  const externalSkills = rows.filter((row) => row.category === "E");
 
   const lines: string[] = [];
   lines.push("");
-  lines.push("  ╔══════════════════════════════════════════════╗");
-  lines.push("  ║            🧠 Procedural Skills             ║");
-  lines.push("  ╚══════════════════════════════════════════════╝");
+  lines.push("  ╔═══════════════════════════════════════════════════════════╗");
+  lines.push("  ║                    🧠 Procedural Skills                  ║");
+  lines.push("  ╚═══════════════════════════════════════════════════════════╝");
+  lines.push("  Legend: [G] global · [P] project · [E] external (read-only)");
   lines.push("");
 
-  if (skills.length === 0) {
-    lines.push("  (no skills created yet)");
+  if (rows.length === 0) {
+    lines.push("  (no skills found in this session)");
     lines.push("");
     lines.push("  Skills are auto-created after complex tasks,");
     lines.push("  or you can ask the agent to create one.");
@@ -68,25 +220,34 @@ export function formatSkillsList(skills: SkillIndex[], projectName: string | nul
   }
 
   if (globalSkills.length > 0) {
-    lines.push("  Global Skills");
-    lines.push("  ─────────────");
-    for (const skill of globalSkills) {
-      lines.push(`  📄 ${skill.displayName || skill.name}`);
-      lines.push(`     ${skill.description}`);
-      lines.push(`     id: ${skill.skillId}`);
-      lines.push(`     path: ${skill.path}`);
+    lines.push("  [G] Global Skills");
+    lines.push("  ─────────────────");
+    for (const row of globalSkills) {
+      lines.push(`  📄 ${row.displayName} (${row.displayPath})`);
+      lines.push(`     ${row.description || "(no description)"}`);
+      lines.push(`     id: ${row.skillId}`);
       lines.push("");
     }
   }
 
   if (projectSkills.length > 0) {
-    lines.push(`  Project Skills${projectName ? ` (${projectName})` : ""}`);
-    lines.push("  ──────────────");
-    for (const skill of projectSkills) {
-      lines.push(`  📄 ${skill.displayName || skill.name}`);
-      lines.push(`     ${skill.description}`);
-      lines.push(`     id: ${skill.skillId}`);
-      lines.push(`     path: ${skill.path}`);
+    lines.push(`  [P] Project Skills${projectName ? ` (${projectName})` : ""}`);
+    lines.push("  ─────────────────────────────────");
+    for (const row of projectSkills) {
+      lines.push(`  📄 ${row.displayName} (${row.displayPath})`);
+      lines.push(`     ${row.description || "(no description)"}`);
+      lines.push(`     id: ${row.skillId}`);
+      lines.push("");
+    }
+  }
+
+  if (externalSkills.length > 0) {
+    lines.push("  [E] External Skills (read-only)");
+    lines.push("  ───────────────────────────────");
+    for (const row of externalSkills) {
+      lines.push(`  📄 ${row.displayName} (${row.displayPath})`);
+      lines.push(`     ${row.description || "(no description)"}`);
+      lines.push(`     id: ${row.skillId}`);
       lines.push("");
     }
   }
@@ -95,17 +256,64 @@ export function formatSkillsList(skills: SkillIndex[], projectName: string | nul
 }
 
 export function buildSkillRows(skills: SkillIndex[], selectedSkillIds = new Set<string>()): SkillModalRow[] {
-  return skills.map((skill) => ({
-    skillId: skill.skillId,
-    scope: skill.scope,
-    name: skill.name,
-    displayName: skill.displayName || skill.name,
-    description: skill.description,
-    path: skill.path,
-    projectName: skill.projectName,
-    selected: selectedSkillIds.has(skill.skillId),
-    searchText: `${skill.displayName || skill.name} ${skill.name}`.trim(),
-  }));
+  return skills.map((skill) => {
+    const displayName = skill.displayName || skill.name;
+    const displayPath = formatSkillPath(skill.path);
+    return {
+      skillId: skill.skillId,
+      scope: skill.scope,
+      category: categoryForScope(skill.scope),
+      mutable: true,
+      name: skill.name,
+      displayName,
+      description: skill.description,
+      path: skill.path,
+      displayPath,
+      projectName: skill.projectName,
+      selected: selectedSkillIds.has(skill.skillId),
+      searchText: `${displayName} ${skill.name} ${skill.description || ""} ${skill.path} ${displayPath}`.trim(),
+    };
+  });
+}
+
+export function buildUnifiedSkillRows(
+  managedSkills: SkillIndex[],
+  loadedSkills: LoadedSkillRow[],
+  selectedSkillIds = new Set<string>(),
+): SkillModalRow[] {
+  const managedRows = buildSkillRows(managedSkills, selectedSkillIds);
+  const managedPathKeys = new Set(managedRows.map((row) => normalizePathForKey(row.path)));
+  const externalPathKeys = new Set<string>();
+
+  const externalRows: SkillModalRow[] = [];
+  for (const loaded of loadedSkills) {
+    const loadedKey = normalizePathForKey(loaded.path);
+    if (managedPathKeys.has(loadedKey)) continue;
+    if (externalPathKeys.has(loadedKey)) continue;
+    externalPathKeys.add(loadedKey);
+
+    const externalSkillId = createExternalSkillId(loaded.name, loaded.path);
+    externalRows.push({
+      skillId: externalSkillId,
+      scope: undefined,
+      category: "E",
+      mutable: false,
+      name: loaded.name,
+      displayName: loaded.displayName,
+      description: loaded.description,
+      path: loaded.path,
+      displayPath: loaded.displayPath,
+      selected: selectedSkillIds.has(externalSkillId),
+      searchText: `${loaded.displayName} ${loaded.name} ${loaded.description || ""} ${loaded.path} ${loaded.displayPath}`.trim(),
+    });
+  }
+
+  return [...managedRows, ...externalRows]
+    .sort((a, b) => {
+      const byCategory = categoryOrder(a.category) - categoryOrder(b.category);
+      if (byCategory !== 0) return byCategory;
+      return a.displayName.localeCompare(b.displayName);
+    });
 }
 
 export function filterSkillRows(rows: SkillModalRow[], query: string): SkillModalRow[] {
@@ -156,6 +364,13 @@ function summarizeAction(
 type SkillMoveStore = Pick<SkillStore, "move" | "loadIndex" | "getProjectName">;
 type SkillDeleteStore = Pick<SkillStore, "delete" | "loadIndex">;
 export type ConfirmDialog = (title: string, message: string) => Promise<boolean>;
+
+export interface SkillBatchActionResult {
+  skills: SkillIndex[];
+  summaryLines: string[];
+  retainSelectedSkillIds?: string[];
+  focusSkillId?: string;
+}
 
 export async function moveSelectedSkills(
   store: SkillMoveStore,
@@ -307,15 +522,20 @@ export class SkillsManagerModal implements Focusable {
   }
 
   private readonly searchInput = new Input();
+  private managedSkills: SkillIndex[];
+  private readonly loadedSkills: LoadedSkillRow[];
   private rows: SkillModalRow[];
   private selectedIndex = 0;
   private query = "";
-  private focusArea: "search" | "list" = "list";
+  private focusArea: "search" | "list" | "filters" = "list";
   private busy = false;
   private closed = false;
   private pendingDeleteConfirm: { skillIds: string[] } | null = null;
+  private activeFilters: SkillCategoryFilters = { ...DEFAULT_SKILL_FILTERS };
+  private pendingFilters: SkillCategoryFilters | null = null;
+  private filterCursor = 0;
   private summaryLines: string[] = [
-    "Select skills with space, then move with g/p or delete with d.",
+    "Select skills with space, then move with g/p or delete with d. Press f for filters.",
   ];
 
   constructor(
@@ -323,8 +543,39 @@ export class SkillsManagerModal implements Focusable {
     private readonly theme: Theme,
     initialRows: SkillModalRow[],
     private readonly callbacks: SkillsManagerCallbacks,
+    options?: {
+      managedSkills?: SkillIndex[];
+      loadedSkills?: LoadedSkillRow[];
+    },
   ) {
-    this.rows = initialRows;
+    const selectedSkillIds = new Set(initialRows.filter((row) => row.selected).map((row) => row.skillId));
+
+    this.loadedSkills = options?.loadedSkills
+      ?? initialRows
+        .filter((row) => row.category === "E")
+        .map((row) => ({
+          name: row.name,
+          displayName: row.displayName,
+          description: row.description,
+          path: row.path,
+          displayPath: row.displayPath,
+        }));
+
+    this.managedSkills = options?.managedSkills
+      ?? initialRows
+        .filter((row) => row.category !== "E" && row.scope)
+        .map((row) => ({
+          skillId: row.skillId,
+          scope: row.scope!,
+          fileName: path.basename(row.path),
+          path: row.path,
+          projectName: row.projectName,
+          name: row.name,
+          displayName: row.displayName,
+          description: row.description,
+        }));
+
+    this.rows = buildUnifiedSkillRows(this.managedSkills, this.loadedSkills, selectedSkillIds);
     this.syncSearchFocus();
   }
 
@@ -333,7 +584,8 @@ export class SkillsManagerModal implements Focusable {
   }
 
   private get filteredRows(): SkillModalRow[] {
-    return filterSkillRows(this.rows, this.query);
+    const categoryFiltered = this.rows.filter((row) => matchesCategoryFilter(row, this.activeFilters));
+    return filterSkillRows(categoryFiltered, this.query);
   }
 
   private getCurrentRow(): SkillModalRow | null {
@@ -342,8 +594,20 @@ export class SkillsManagerModal implements Focusable {
     return rows[Math.min(this.selectedIndex, rows.length - 1)] ?? null;
   }
 
+  private getSelectedRows(): SkillModalRow[] {
+    return this.rows.filter((row) => row.selected);
+  }
+
   private getSelectedIds(): string[] {
     return getSelectedSkillIds(this.rows);
+  }
+
+  private getFilterOptions(): Array<{ key: keyof SkillCategoryFilters; label: string }> {
+    return [
+      { key: "global", label: "Global [G]" },
+      { key: "project", label: "Project [P]" },
+      { key: "external", label: "External [E] (read-only)" },
+    ];
   }
 
   private syncSearchFocus(): void {
@@ -360,14 +624,15 @@ export class SkillsManagerModal implements Focusable {
     }
   }
 
-  private setFocusArea(area: "search" | "list"): void {
+  private setFocusArea(area: "search" | "list" | "filters"): void {
     this.focusArea = area;
     this.syncSearchFocus();
     this.tui.requestRender();
   }
 
-  private setRows(skills: SkillIndex[], retainSelectedSkillIds: string[] = [], focusSkillId?: string): void {
-    this.rows = buildSkillRows(skills, new Set(retainSelectedSkillIds));
+  private setRows(managedSkills: SkillIndex[], retainSelectedSkillIds: string[] = [], focusSkillId?: string): void {
+    this.managedSkills = managedSkills;
+    this.rows = buildUnifiedSkillRows(this.managedSkills, this.loadedSkills, new Set(retainSelectedSkillIds));
     this.syncQueryFromInput();
 
     const rows = this.filteredRows;
@@ -422,34 +687,156 @@ export class SkillsManagerModal implements Focusable {
     this.tui.requestRender();
   }
 
+  private appendExternalReadOnlySummary(
+    result: SkillBatchActionResult,
+    blockedExternalRows: SkillModalRow[],
+    verb: "move" | "delete",
+  ): SkillBatchActionResult {
+    if (blockedExternalRows.length === 0) return result;
+
+    const blockedIds = blockedExternalRows.map((row) => row.skillId);
+    const retainSet = new Set([...(result.retainSelectedSkillIds || []), ...blockedIds]);
+    const focusSkillId = result.focusSkillId || blockedIds[0];
+    const blockedLabel = blockedExternalRows.length === 1
+      ? `Blocked 1 external skill: ${blockedExternalRows[0]!.displayName} is read-only.`
+      : `Blocked ${blockedExternalRows.length} external skills: read-only (${verb} unavailable).`;
+
+    return {
+      ...result,
+      summaryLines: [...result.summaryLines, blockedLabel],
+      retainSelectedSkillIds: Array.from(retainSet),
+      focusSkillId,
+    };
+  }
+
+  private prepareMutableSelection(verb: "move" | "delete"):
+    | { proceed: false }
+    | { proceed: true; mutableIds: string[]; blockedExternalRows: SkillModalRow[] } {
+    const selectedRows = this.getSelectedRows();
+    if (selectedRows.length === 0) {
+      this.summaryLines = ["Select one or more skills first."];
+      this.tui.requestRender();
+      return { proceed: false };
+    }
+
+    const mutableRows = selectedRows.filter((row) => row.mutable);
+    const blockedExternalRows = selectedRows.filter((row) => !row.mutable);
+
+    if (mutableRows.length === 0 && blockedExternalRows.length > 0) {
+      this.summaryLines = [
+        `Blocked ${blockedExternalRows.length} external skill${blockedExternalRows.length === 1 ? "" : "s"}: read-only (${verb} unavailable).`,
+      ];
+      this.tui.requestRender();
+      return { proceed: false };
+    }
+
+    return {
+      proceed: true,
+      mutableIds: mutableRows.map((row) => row.skillId),
+      blockedExternalRows,
+    };
+  }
+
   private async runMove(targetScope: SkillScope): Promise<void> {
-    const selectedIds = this.getSelectedIds();
-    await this.runAsyncAction(this.callbacks.moveSelected(targetScope, selectedIds));
+    const selection = this.prepareMutableSelection("move");
+    if (!selection.proceed) return;
+
+    const action = this.callbacks.moveSelected(targetScope, selection.mutableIds)
+      .then((result) => this.appendExternalReadOnlySummary(result, selection.blockedExternalRows, "move"));
+
+    await this.runAsyncAction(action);
   }
 
   private promptDelete(): void {
-    const selectedIds = this.getSelectedIds();
-    if (selectedIds.length === 0) {
-      this.summaryLines = ["Select one or more skills first."];
-      this.tui.requestRender();
-      return;
-    }
+    const selection = this.prepareMutableSelection("delete");
+    if (!selection.proceed) return;
 
-    this.pendingDeleteConfirm = { skillIds: selectedIds };
+    this.pendingDeleteConfirm = { skillIds: selection.mutableIds };
+    const blockedCount = selection.blockedExternalRows.length;
     this.summaryLines = [
-      `Delete ${selectedIds.length} selected skill${selectedIds.length === 1 ? "" : "s"}? Press y to confirm or n to cancel.`,
+      `Delete ${selection.mutableIds.length} selected skill${selection.mutableIds.length === 1 ? "" : "s"}? Press y to confirm or n to cancel.${blockedCount > 0 ? ` (${blockedCount} external read-only item${blockedCount === 1 ? "" : "s"} will be skipped)` : ""}`,
     ];
     this.tui.requestRender();
   }
 
   private async runDeleteConfirmed(skillIds: string[]): Promise<void> {
-    await this.runAsyncAction(this.callbacks.deleteSelected(skillIds));
+    const blockedExternalRows = this.rows.filter((row) => row.selected && !row.mutable);
+    const action = this.callbacks.deleteSelected(skillIds)
+      .then((result) => this.appendExternalReadOnlySummary(result, blockedExternalRows, "delete"));
+
+    await this.runAsyncAction(action);
   }
 
   private closeModal(): void {
     if (this.closed) return;
     this.closed = true;
     this.callbacks.close();
+  }
+
+  private openFilterPanel(): void {
+    this.pendingFilters = cloneFilters(this.activeFilters);
+    this.filterCursor = 0;
+    this.setFocusArea("filters");
+    this.summaryLines = ["Filter panel open: space toggle · enter apply · esc cancel."];
+    this.tui.requestRender();
+  }
+
+  private applyFilterPanel(): void {
+    const candidate = ensureValidFilters(this.pendingFilters ? cloneFilters(this.pendingFilters) : cloneFilters(this.activeFilters));
+    const wasAllOff = this.pendingFilters
+      && !this.pendingFilters.global
+      && !this.pendingFilters.project
+      && !this.pendingFilters.external;
+
+    this.activeFilters = candidate;
+    this.pendingFilters = null;
+    this.syncQueryFromInput();
+    this.setFocusArea("list");
+    this.summaryLines = [
+      wasAllOff
+        ? "All categories were disabled; restored filters to [G] [P] [E]."
+        : `Applied filters: ${filtersLabel(this.activeFilters)}`,
+    ];
+    this.tui.requestRender();
+  }
+
+  private cancelFilterPanel(): void {
+    this.pendingFilters = null;
+    this.setFocusArea("list");
+    this.summaryLines = ["Filter changes cancelled."];
+    this.tui.requestRender();
+  }
+
+  private handleFilterInput(data: string): void {
+    const options = this.getFilterOptions();
+    const draft = this.pendingFilters ?? cloneFilters(this.activeFilters);
+    this.pendingFilters = draft;
+
+    if (matchesKey(data, Key.escape)) {
+      this.cancelFilterPanel();
+      return;
+    }
+    if (matchesKey(data, Key.up)) {
+      this.filterCursor = Math.max(0, this.filterCursor - 1);
+      this.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, Key.down)) {
+      this.filterCursor = Math.min(options.length - 1, this.filterCursor + 1);
+      this.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, Key.space)) {
+      const option = options[this.filterCursor];
+      if (option) {
+        draft[option.key] = !draft[option.key];
+      }
+      this.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, Key.enter)) {
+      this.applyFilterPanel();
+    }
   }
 
   private async runAsyncAction(action: Promise<SkillBatchActionResult>): Promise<void> {
@@ -490,7 +877,7 @@ export class SkillsManagerModal implements Focusable {
   }
 
   private getMaxVisibleRows(): number {
-    return Math.max(6, Math.min(14, this.tui.terminal.rows - 18));
+    return Math.max(6, Math.min(14, this.tui.terminal.rows - 22));
   }
 
   private focusSearchWithOptionalInput(data?: string): void {
@@ -530,6 +917,11 @@ export class SkillsManagerModal implements Focusable {
       return;
     }
 
+    if (this.focusArea === "filters") {
+      this.handleFilterInput(data);
+      return;
+    }
+
     if (matchesKey(data, Key.escape)) {
       this.closeModal();
       return;
@@ -544,6 +936,11 @@ export class SkillsManagerModal implements Focusable {
       this.searchInput.handleInput(data);
       this.syncQueryFromInput();
       this.tui.requestRender();
+      return;
+    }
+
+    if (data === MEMORY_SKILLS_KEYMAP.openFilters) {
+      this.openFilterPanel();
       return;
     }
 
@@ -601,7 +998,7 @@ export class SkillsManagerModal implements Focusable {
       this.promptDelete();
       return;
     }
-    if (this.isPrintableInput(data) && !["g", "p", "d", "a", "n"].includes(data)) {
+    if (this.isPrintableInput(data) && !["g", "p", "d", "a", "n", "f"].includes(data)) {
       this.focusSearchWithOptionalInput(data);
     }
   }
@@ -627,6 +1024,35 @@ export class SkillsManagerModal implements Focusable {
       }
     }
     return rendered;
+  }
+
+  private renderFilterPanel(width: number): string[] {
+    const panelWidth = Math.max(34, Math.min(width - 10, 58));
+    const top = this.theme.fg("borderAccent", `┌${"─".repeat(Math.max(1, panelWidth - 2))}┐`);
+    const bottom = this.theme.fg("borderAccent", `└${"─".repeat(Math.max(1, panelWidth - 2))}┘`);
+    const lines: string[] = [top];
+
+    lines.push(this.renderFramedLine(this.theme.fg("accent", this.theme.bold("Filters")), panelWidth));
+    lines.push(this.renderFramedLine(this.theme.fg("dim", "Space toggle · Enter apply · Esc cancel"), panelWidth));
+    lines.push(this.renderFramedLine("", panelWidth));
+
+    const draft = this.pendingFilters ?? this.activeFilters;
+    const options = this.getFilterOptions();
+    for (let i = 0; i < options.length; i++) {
+      const option = options[i]!;
+      const checked = draft[option.key] ? "[x]" : "[ ]";
+      const cursor = i === this.filterCursor ? this.theme.fg("accent", "›") : " ";
+      const text = `${cursor} ${checked} ${option.label}`;
+      const rendered = i === this.filterCursor
+        ? this.theme.bg("selectedBg", truncateToWidth(text, Math.max(10, panelWidth - 4), ""))
+        : truncateToWidth(text, Math.max(10, panelWidth - 4), "");
+      lines.push(this.renderFramedLine(rendered, panelWidth));
+    }
+
+    lines.push(this.renderFramedLine("", panelWidth));
+    lines.push(this.renderFramedLine(this.theme.fg("dim", `Draft: ${filtersLabel(draft)}`), panelWidth));
+    lines.push(bottom);
+    return lines;
   }
 
   render(width: number): string[] {
@@ -655,10 +1081,11 @@ export class SkillsManagerModal implements Focusable {
       safeWidth,
     ));
 
+    lines.push(this.renderFramedLine(this.theme.fg("dim", `Legend: [G] global · [P] project · [E] external (read-only) · filters: ${filtersLabel(this.activeFilters)}`), safeWidth));
     lines.push(this.renderFramedLine("", safeWidth));
 
     if (filteredRows.length === 0) {
-      const emptyMessage = this.rows.length === 0 ? "No skills found yet." : "No skills match the current search.";
+      const emptyMessage = this.rows.length === 0 ? "No skills found yet." : "No skills match the current filters/search.";
       lines.push(this.renderFramedLine(this.theme.fg("warning", emptyMessage), safeWidth));
       lines.push(this.renderFramedLine("", safeWidth));
     } else {
@@ -672,10 +1099,13 @@ export class SkillsManagerModal implements Focusable {
         const absoluteIndex = start + i;
         const cursor = absoluteIndex === this.selectedIndex ? this.theme.fg("accent", "›") : " ";
         const check = row.selected ? this.theme.fg("accent", "[x]") : this.theme.fg("dim", "[ ]");
-        const scope = row.scope === "global"
+        const category = row.category === "G"
           ? this.theme.fg("accent", "[G]")
-          : this.theme.fg("warning", "[P]");
-        const baseText = `${cursor} ${check} ${scope} ${row.displayName}`;
+          : row.category === "P"
+            ? this.theme.fg("warning", "[P]")
+            : this.theme.fg("dim", "[E]");
+
+        const baseText = `${cursor} ${check} ${category} ${row.displayName} (${row.displayPath})`;
         const lineText = absoluteIndex === this.selectedIndex
           ? this.theme.bg("selectedBg", truncateToWidth(baseText, Math.max(10, safeWidth - 4), ""))
           : truncateToWidth(baseText, Math.max(10, safeWidth - 4), "");
@@ -689,10 +1119,16 @@ export class SkillsManagerModal implements Focusable {
       lines.push(this.renderFramedLine("", safeWidth));
       const currentRow = this.getCurrentRow();
       if (currentRow) {
-        lines.push(this.renderFramedLine(this.theme.fg("accent", `Focused: ${currentRow.displayName}`), safeWidth));
+        const scopeLabel = currentRow.category === "E"
+          ? "external (read-only)"
+          : currentRow.scope === "project"
+            ? "project"
+            : "global";
+        lines.push(this.renderFramedLine(this.theme.fg("accent", `Focused: ${currentRow.displayName} · ${scopeLabel}`), safeWidth));
         lines.push(...this.renderWrappedSection([
           currentRow.description || "(no description)",
           this.theme.fg("dim", currentRow.skillId),
+          this.theme.fg("dim", currentRow.displayPath),
         ], safeWidth));
       }
     }
@@ -705,9 +1141,17 @@ export class SkillsManagerModal implements Focusable {
     const help = this.pendingDeleteConfirm
       ? "Confirm delete: y yes · n no · esc cancel"
       : this.callbacks.projectName
-        ? "↑↓ move · space select · / search · tab switch · g global · p project · d delete · a all · n none · esc close"
-        : "↑↓ move · space select · / search · tab switch · g global · p project (disabled) · d delete · a all · n none · esc close";
+        ? "↑↓ move · space select · / search · f filters · tab switch · g global · p project · d delete · a all · n none · esc close"
+        : "↑↓ move · space select · / search · f filters · tab switch · g global · p project (disabled) · d delete · a all · n none · esc close";
     lines.push(this.renderFramedLine(this.theme.fg("dim", help), safeWidth));
+
+    if (this.focusArea === "filters") {
+      lines.push(this.renderFramedLine("", safeWidth));
+      for (const panelLine of this.renderFilterPanel(Math.min(64, safeWidth - 6))) {
+        lines.push(this.renderFramedLine(panelLine, safeWidth));
+      }
+    }
+
     lines.push(bottom);
     return lines;
   }
@@ -715,17 +1159,28 @@ export class SkillsManagerModal implements Focusable {
 
 export function registerSkillsCommand(pi: ExtensionAPI, store: SkillStore): void {
   pi.registerCommand("memory-skills", {
-    description: "Manage global and active-project procedural skills",
+    description: "Manage global, active-project, and loaded external procedural skills",
     handler: async (_args, ctx: ExtensionCommandContext) => {
-      const skills = await store.loadIndex();
+      const getSkillCommands = (): SkillCommandInfo[] => {
+        try {
+          const getter = (ctx as unknown as { getCommands?: () => unknown }).getCommands;
+          if (typeof getter !== "function") return [];
+          const commands = getter.call(ctx);
+          return Array.isArray(commands) ? commands as SkillCommandInfo[] : [];
+        } catch {
+          return [];
+        }
+      };
+
+      const managedSkills = await store.loadIndex();
+      const loadedSkills = collectLoadedSkillsFromCommands(getSkillCommands());
+      const initialRows = buildUnifiedSkillRows(managedSkills, loadedSkills);
       const projectName = store.getProjectName();
 
       if (!ctx.hasUI || typeof ctx.ui.custom !== "function") {
-        ctx.ui.notify(formatSkillsList(skills, projectName), "info");
+        ctx.ui.notify(formatSkillsList(initialRows, projectName), "info");
         return;
       }
-
-      const initialRows = buildSkillRows(skills);
 
       try {
         await ctx.ui.custom<void>(
@@ -739,25 +1194,33 @@ export function registerSkillsCommand(pi: ExtensionAPI, store: SkillStore): void
               close: () => done(undefined),
               projectName,
             },
+            {
+              managedSkills,
+              loadedSkills,
+            },
           ),
           {
             overlay: true,
             overlayOptions: {
               anchor: "center",
-              width: "88%",
-              minWidth: 72,
-              maxHeight: "85%",
+              width: "92%",
+              minWidth: 76,
+              maxHeight: "88%",
               margin: 1,
             },
           },
         );
       } catch {
-        const latestSkills = await store.loadIndex();
+        const latestManagedSkills = await store.loadIndex();
+        const latestRows = buildUnifiedSkillRows(
+          latestManagedSkills,
+          collectLoadedSkillsFromCommands(getSkillCommands()),
+        );
         ctx.ui.notify(
           "Interactive skills manager unavailable in this runtime; showing read-only list fallback.",
           "warning",
         );
-        ctx.ui.notify(formatSkillsList(latestSkills, projectName), "info");
+        ctx.ui.notify(formatSkillsList(latestRows, projectName), "info");
       }
     },
   });

--- a/src/handlers/skills-command.ts
+++ b/src/handlers/skills-command.ts
@@ -1162,14 +1162,20 @@ export function registerSkillsCommand(pi: ExtensionAPI, store: SkillStore): void
     description: "Manage global, active-project, and loaded external procedural skills",
     handler: async (_args, ctx: ExtensionCommandContext) => {
       const getSkillCommands = (): SkillCommandInfo[] => {
-        try {
-          const getter = (ctx as unknown as { getCommands?: () => unknown }).getCommands;
-          if (typeof getter !== "function") return [];
-          const commands = getter.call(ctx);
-          return Array.isArray(commands) ? commands as SkillCommandInfo[] : [];
-        } catch {
-          return [];
-        }
+        const readCommands = (owner: unknown): SkillCommandInfo[] | null => {
+          try {
+            const getter = (owner as { getCommands?: () => unknown })?.getCommands;
+            if (typeof getter !== "function") return null;
+            const commands = getter.call(owner);
+            return Array.isArray(commands) ? commands as SkillCommandInfo[] : [];
+          } catch {
+            return null;
+          }
+        };
+
+        return readCommands(pi)
+          ?? readCommands(ctx)
+          ?? [];
       };
 
       const managedSkills = await store.loadIndex();

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,8 +83,17 @@ export default function (pi: ExtensionAPI) {
   const agentRoot = path.join(os.homedir(), ".pi", "agent");
   const legacyGlobalDir = path.join(agentRoot, "memory");
   const defaultGlobalDir = path.join(agentRoot, "pi-hermes-memory");
-  const globalDir = config.memoryDir ?? defaultGlobalDir;
 
+  const configuredMemoryDir = config.memoryDir?.trim();
+  const pointsToLegacyMemoryDir = configuredMemoryDir
+    ? path.resolve(configuredMemoryDir) === path.resolve(legacyGlobalDir)
+    : false;
+
+  const globalDir = !configuredMemoryDir || pointsToLegacyMemoryDir
+    ? defaultGlobalDir
+    : configuredMemoryDir;
+
+  const shouldMigrateExtensionRoot = !configuredMemoryDir || pointsToLegacyMemoryDir;
   let extensionRootMigrated = false;
 
   const store = new MemoryStore({ ...config, memoryDir: globalDir });
@@ -128,7 +137,7 @@ export default function (pi: ExtensionAPI) {
 
   // ── 1. Load memory from disk on session start ──
   pi.on("session_start", async (event, _ctx) => {
-    if (!config.memoryDir && !extensionRootMigrated) {
+    if (shouldMigrateExtensionRoot && !extensionRootMigrated) {
       try {
         await migrateExtensionRoot(legacyGlobalDir, globalDir);
       } catch {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,18 +51,20 @@ import { loadConfig } from "./config.js";
 import { detectProject, detectProjectSkills } from "./project.js";
 import { buildPromptContext } from "./prompt-context.js";
 import { migrateLegacyProjectMemoryDirs } from "./project-memory-migration.js";
+import { migrateExtensionRoot } from "./extension-root-migration.js";
 
 export function resolveProjectSkillDiscovery(
   skillStore: SkillStore,
   projectsMemoryDir: string | undefined,
   cwd?: string,
-): { skillPaths: string[] } | undefined {
+): { skillPaths: string[] } {
   const detected = detectProjectSkills(projectsMemoryDir, cwd);
   skillStore.setProjectContext(detected.name, detected.skillsDir);
-  if (!detected.skillsDir) return undefined;
-  return {
-    skillPaths: [detected.skillsDir],
-  };
+
+  const skillPaths = [skillStore.getGlobalSkillsDir()];
+  if (detected.skillsDir) skillPaths.push(detected.skillsDir);
+
+  return { skillPaths };
 }
 
 export function registerProjectSkillDiscoveryHandler(
@@ -78,17 +80,23 @@ export function registerProjectSkillDiscoveryHandler(
 export default function (pi: ExtensionAPI) {
   const config = loadConfig();
 
-  const globalDir = config.memoryDir ?? path.join(os.homedir(), ".pi", "agent", "memory");
   const agentRoot = path.join(os.homedir(), ".pi", "agent");
-  const store = new MemoryStore(config);
+  const legacyGlobalDir = path.join(agentRoot, "memory");
+  const defaultGlobalDir = path.join(agentRoot, "pi-hermes-memory");
+  const globalDir = config.memoryDir ?? defaultGlobalDir;
+
+  let extensionRootMigrated = false;
+
+  const store = new MemoryStore({ ...config, memoryDir: globalDir });
   const project = detectProject(config.projectsMemoryDir);
   const projectName = project.name ?? "";
   const skillStore = new SkillStore({
-    globalSkillsDir: path.join(agentRoot, "skills"),
+    globalSkillsDir: path.join(globalDir, "skills"),
     projectSkillsDir: project.memoryDir ? path.join(project.memoryDir, "skills") : null,
     projectName: project.name,
-    legacySkillsDir: path.join(globalDir, "skills"),
-    migrationSentinelPath: path.join(globalDir, ".skills-migrated-to-pi-native"),
+    legacySkillsDir: path.join(legacyGlobalDir, "skills"),
+    legacyPiGlobalSkillsDir: path.join(agentRoot, "skills"),
+    migrationSentinelPath: path.join(globalDir, ".skills-migrated-to-extension-storage"),
   });
   const dbManager = new DatabaseManager(globalDir);
 
@@ -120,6 +128,15 @@ export default function (pi: ExtensionAPI) {
 
   // ── 1. Load memory from disk on session start ──
   pi.on("session_start", async (event, _ctx) => {
+    if (!config.memoryDir && !extensionRootMigrated) {
+      try {
+        await migrateExtensionRoot(legacyGlobalDir, globalDir);
+      } catch {
+        // best effort migration only
+      }
+      extensionRootMigrated = true;
+    }
+
     refreshSkillProjectContext((event as { cwd?: string }).cwd);
     await skillStore.migrateLegacySkills();
     await skillStore.ensureDiscoveredRoots();

--- a/src/project-memory-migration.ts
+++ b/src/project-memory-migration.ts
@@ -23,7 +23,7 @@ function writeEntries(filePath: string, entries: string[]): void {
 }
 
 function isLegacyProjectDir(agentRoot: string, projectsMemoryDir: string, name: string): boolean {
-  if (name === "memory" || name === "skills" || name === projectsMemoryDir) return false;
+  if (name === "memory" || name === "pi-hermes-memory" || name === "skills" || name === projectsMemoryDir) return false;
   if (name.startsWith(".")) return false;
 
   const dir = path.join(agentRoot, name);

--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -46,7 +46,7 @@ export class MemoryStore {
   // ─── Path helpers ───
 
   private get memoryDir(): string {
-    return this.config.memoryDir ?? path.join(os.homedir(), ".pi", "agent", "memory");
+    return this.config.memoryDir ?? path.join(os.homedir(), ".pi", "agent", "pi-hermes-memory");
   }
 
   private pathFor(target: "memory" | "user" | "failure"): string {

--- a/src/store/skill-store.ts
+++ b/src/store/skill-store.ts
@@ -92,13 +92,16 @@ export class SkillStore {
   async migrateLegacySkills(): Promise<LegacySkillMigrationResult> {
     const result: LegacySkillMigrationResult = { migrated: 0, skipped: 0, warnings: [] };
 
+    // Always normalize flat markdown files under the global skills root,
+    // even when a previous migration sentinel already exists.
+    await this.migrateFlatMarkdownInGlobalSkillsDir(result);
+
     if (await exists(this.migrationSentinelPath)) return result;
 
     await fs.mkdir(path.dirname(this.migrationSentinelPath), { recursive: true });
 
     try {
       await this.migrateLegacyMarkdownSkills(result);
-      await this.migrateFlatMarkdownInGlobalSkillsDir(result);
       await this.migrateLegacyPiGlobalSkillDirs(result);
     } finally {
       if (result.warnings.length === 0) {

--- a/src/store/skill-store.ts
+++ b/src/store/skill-store.ts
@@ -98,6 +98,7 @@ export class SkillStore {
 
     try {
       await this.migrateLegacyMarkdownSkills(result);
+      await this.migrateFlatMarkdownInGlobalSkillsDir(result);
       await this.migrateLegacyPiGlobalSkillDirs(result);
     } finally {
       if (result.warnings.length === 0) {
@@ -145,6 +146,52 @@ export class SkillStore {
 
         await fs.mkdir(path.dirname(targetPath), { recursive: true });
         await this.atomicWrite(targetPath, formatFrontmatter(skillDoc));
+        result.migrated++;
+      } catch (error) {
+        result.warnings.push(`${file}: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+  }
+
+  private async migrateFlatMarkdownInGlobalSkillsDir(result: LegacySkillMigrationResult): Promise<void> {
+    if (!await exists(this.globalSkillsDir)) return;
+
+    const files = (await fs.readdir(this.globalSkillsDir))
+      .filter((file) => file.endsWith(".md") && file !== "SKILL.md")
+      .sort();
+
+    for (const file of files) {
+      const legacyPath = path.join(this.globalSkillsDir, file);
+      try {
+        const raw = await fs.readFile(legacyPath, "utf-8");
+        const parsed = parseFrontmatter(raw);
+        const fallbackSlug = slugify(path.basename(file, ".md"));
+        const slug = slugify(parsed.meta.name || fallbackSlug);
+        if (!slug) {
+          result.skipped++;
+          continue;
+        }
+
+        const targetPath = path.join(this.globalSkillsDir, slug, "SKILL.md");
+        if (await exists(targetPath)) {
+          await fs.rm(legacyPath, { force: true });
+          result.skipped++;
+          continue;
+        }
+
+        const skillDoc = {
+          name: slug,
+          displayName: parsed.meta.display_name?.trim() || parsed.meta.name?.trim() || undefined,
+          description: parsed.meta.description?.trim() || `Migrated legacy skill: ${slug}`,
+          version: Number.parseInt(parsed.meta.version || "1", 10) || 1,
+          created: parsed.meta.created || today(),
+          updated: parsed.meta.updated || today(),
+          body: parsed.body || `# ${slug}\n`,
+        };
+
+        await fs.mkdir(path.dirname(targetPath), { recursive: true });
+        await this.atomicWrite(targetPath, formatFrontmatter(skillDoc));
+        await fs.rm(legacyPath, { force: true });
         result.migrated++;
       } catch (error) {
         result.warnings.push(`${file}: ${error instanceof Error ? error.message : String(error)}`);

--- a/src/store/skill-store.ts
+++ b/src/store/skill-store.ts
@@ -1,7 +1,7 @@
 /**
  * SkillStore — procedural memory stored as Pi-native skills.
  *
- * Global skills live in ~/.pi/agent/skills/<slug>/SKILL.md.
+ * Global skills live in ~/.pi/agent/pi-hermes-memory/skills/<slug>/SKILL.md.
  * Project skills live in ~/.pi/agent/<projectsMemoryDir>/<project>/skills/<slug>/SKILL.md.
  */
 
@@ -27,6 +27,7 @@ interface SkillStoreOptions {
   projectSkillsDir?: string | null;
   projectName?: string | null;
   legacySkillsDir?: string;
+  legacyPiGlobalSkillsDir?: string;
   migrationSentinelPath?: string;
 }
 
@@ -50,6 +51,7 @@ export class SkillStore {
   private projectSkillsDir: string | null;
   private projectName: string | null;
   private legacySkillsDir: string;
+  private legacyPiGlobalSkillsDir: string;
   private migrationSentinelPath: string;
 
   constructor(options: SkillStoreOptions = {}) {
@@ -58,8 +60,9 @@ export class SkillStore {
     this.projectSkillsDir = options.projectSkillsDir ?? null;
     this.projectName = options.projectName ?? null;
     this.legacySkillsDir = options.legacySkillsDir ?? path.join(agentRoot, "memory", "skills");
+    this.legacyPiGlobalSkillsDir = options.legacyPiGlobalSkillsDir ?? path.join(agentRoot, "skills");
     this.migrationSentinelPath = options.migrationSentinelPath
-      ?? path.join(agentRoot, "memory", ".skills-migrated-to-pi-native");
+      ?? path.join(agentRoot, "pi-hermes-memory", ".skills-migrated-to-extension-storage");
   }
 
   getGlobalSkillsDir(): string {
@@ -94,47 +97,8 @@ export class SkillStore {
     await fs.mkdir(path.dirname(this.migrationSentinelPath), { recursive: true });
 
     try {
-      if (!await exists(this.legacySkillsDir)) return result;
-
-      const files = (await fs.readdir(this.legacySkillsDir))
-        .filter((file) => file.endsWith(".md"))
-        .sort();
-
-      for (const file of files) {
-        const legacyPath = path.join(this.legacySkillsDir, file);
-        try {
-          const raw = await fs.readFile(legacyPath, "utf-8");
-          const parsed = parseFrontmatter(raw);
-          const fallbackSlug = slugify(path.basename(file, ".md"));
-          const slug = slugify(parsed.meta.name || fallbackSlug);
-          if (!slug) {
-            result.skipped++;
-            continue;
-          }
-
-          const targetPath = path.join(this.globalSkillsDir, slug, "SKILL.md");
-          if (await exists(targetPath)) {
-            result.skipped++;
-            continue;
-          }
-
-          const skillDoc = {
-            name: slug,
-            displayName: parsed.meta.display_name?.trim() || parsed.meta.name?.trim() || undefined,
-            description: parsed.meta.description?.trim() || `Migrated legacy skill: ${slug}`,
-            version: Number.parseInt(parsed.meta.version || "1", 10) || 1,
-            created: parsed.meta.created || today(),
-            updated: parsed.meta.updated || today(),
-            body: parsed.body || `# ${slug}\n`,
-          };
-
-          await fs.mkdir(path.dirname(targetPath), { recursive: true });
-          await this.atomicWrite(targetPath, formatFrontmatter(skillDoc));
-          result.migrated++;
-        } catch (error) {
-          result.warnings.push(`${file}: ${error instanceof Error ? error.message : String(error)}`);
-        }
-      }
+      await this.migrateLegacyMarkdownSkills(result);
+      await this.migrateLegacyPiGlobalSkillDirs(result);
     } finally {
       if (result.warnings.length === 0) {
         await fs.writeFile(this.migrationSentinelPath, `${new Date().toISOString()}\n`, "utf-8");
@@ -142,6 +106,91 @@ export class SkillStore {
     }
 
     return result;
+  }
+
+  private async migrateLegacyMarkdownSkills(result: LegacySkillMigrationResult): Promise<void> {
+    if (!await exists(this.legacySkillsDir)) return;
+
+    const files = (await fs.readdir(this.legacySkillsDir))
+      .filter((file) => file.endsWith(".md"))
+      .sort();
+
+    for (const file of files) {
+      const legacyPath = path.join(this.legacySkillsDir, file);
+      try {
+        const raw = await fs.readFile(legacyPath, "utf-8");
+        const parsed = parseFrontmatter(raw);
+        const fallbackSlug = slugify(path.basename(file, ".md"));
+        const slug = slugify(parsed.meta.name || fallbackSlug);
+        if (!slug) {
+          result.skipped++;
+          continue;
+        }
+
+        const targetPath = path.join(this.globalSkillsDir, slug, "SKILL.md");
+        if (await exists(targetPath)) {
+          result.skipped++;
+          continue;
+        }
+
+        const skillDoc = {
+          name: slug,
+          displayName: parsed.meta.display_name?.trim() || parsed.meta.name?.trim() || undefined,
+          description: parsed.meta.description?.trim() || `Migrated legacy skill: ${slug}`,
+          version: Number.parseInt(parsed.meta.version || "1", 10) || 1,
+          created: parsed.meta.created || today(),
+          updated: parsed.meta.updated || today(),
+          body: parsed.body || `# ${slug}\n`,
+        };
+
+        await fs.mkdir(path.dirname(targetPath), { recursive: true });
+        await this.atomicWrite(targetPath, formatFrontmatter(skillDoc));
+        result.migrated++;
+      } catch (error) {
+        result.warnings.push(`${file}: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+  }
+
+  private async migrateLegacyPiGlobalSkillDirs(result: LegacySkillMigrationResult): Promise<void> {
+    if (path.resolve(this.legacyPiGlobalSkillsDir) === path.resolve(this.globalSkillsDir)) return;
+    if (!await exists(this.legacyPiGlobalSkillsDir)) return;
+
+    const entries = await fs.readdir(this.legacyPiGlobalSkillsDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name.startsWith(".")) continue;
+
+      const sourceDir = path.join(this.legacyPiGlobalSkillsDir, entry.name);
+      const sourceSkill = path.join(sourceDir, "SKILL.md");
+      if (!await exists(sourceSkill)) continue;
+
+      const targetDir = path.join(this.globalSkillsDir, entry.name);
+      const targetSkill = path.join(targetDir, "SKILL.md");
+      if (await exists(targetSkill)) {
+        result.skipped++;
+        continue;
+      }
+
+      try {
+        const raw = await fs.readFile(sourceSkill, "utf-8");
+        const parsed = parseFrontmatter(raw);
+        const hasExtensionManagedMeta = Boolean(parsed.meta.display_name)
+          && Boolean(parsed.meta.created)
+          && Boolean(parsed.meta.updated)
+          && /^\d+$/.test(parsed.meta.version ?? "");
+
+        if (!hasExtensionManagedMeta) {
+          result.skipped++;
+          continue;
+        }
+
+        await fs.mkdir(path.dirname(targetDir), { recursive: true });
+        await fs.rename(sourceDir, targetDir);
+        result.migrated++;
+      } catch (error) {
+        result.warnings.push(`${entry.name}: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
   }
 
   async loadIndex(scope?: SkillScope): Promise<SkillIndex[]> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,7 +40,7 @@ export interface MemoryConfig {
   flushMinTurns: number;
   /** Recent conversation messages included in session flush. 0 = all. Default: 0 */
   flushRecentMessages?: number;
-  /** Override memory directory. Default: ~/.pi/agent/memory */
+  /** Override extension storage directory. Default: ~/.pi/agent/pi-hermes-memory */
   memoryDir?: string;
   /** Directory for project-scoped memory (relative to ~/.pi/agent). Default: "projects-memory" */
   projectsMemoryDir?: string;

--- a/tests/extension-root-migration.test.ts
+++ b/tests/extension-root-migration.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { migrateExtensionRoot } from "../src/extension-root-migration.js";
+
+let tmpDir = "";
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "extension-root-migration-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("migrateExtensionRoot", () => {
+  it("moves legacy files into new extension root", async () => {
+    const legacy = path.join(tmpDir, "memory");
+    const target = path.join(tmpDir, "pi-hermes-memory");
+    fs.mkdirSync(path.join(legacy, "skills", "abc"), { recursive: true });
+    fs.writeFileSync(path.join(legacy, "MEMORY.md"), "legacy memory", "utf-8");
+    fs.writeFileSync(path.join(legacy, "skills", "abc", "SKILL.md"), "legacy skill", "utf-8");
+
+    const result = await migrateExtensionRoot(legacy, target);
+
+    assert.ok(fs.existsSync(path.join(target, "MEMORY.md")));
+    assert.ok(fs.existsSync(path.join(target, "skills", "abc", "SKILL.md")));
+    assert.strictEqual(result.warnings.length, 0);
+    assert.ok(result.moved >= 1);
+  });
+
+  it("does not overwrite existing target files", async () => {
+    const legacy = path.join(tmpDir, "memory");
+    const target = path.join(tmpDir, "pi-hermes-memory");
+    fs.mkdirSync(legacy, { recursive: true });
+    fs.mkdirSync(target, { recursive: true });
+
+    fs.writeFileSync(path.join(legacy, "MEMORY.md"), "legacy memory", "utf-8");
+    fs.writeFileSync(path.join(target, "MEMORY.md"), "new memory", "utf-8");
+
+    const result = await migrateExtensionRoot(legacy, target);
+
+    assert.strictEqual(fs.readFileSync(path.join(target, "MEMORY.md"), "utf-8"), "new memory");
+    assert.ok(result.skipped >= 1);
+  });
+});

--- a/tests/handlers/resources-discover.test.ts
+++ b/tests/handlers/resources-discover.test.ts
@@ -26,9 +26,10 @@ describe("resources_discover skill path resolution", () => {
     assert.ok(typeof handlers.resources_discover === "function");
 
     const result = await handlers.resources_discover({ cwd: "/tmp/demo-repo" }, {});
+    const expectedGlobal = "/tmp/global-skills";
     const expectedPath = path.join(os.homedir(), ".pi", "agent", "projects-memory", "demo-repo", "skills");
 
-    assert.deepStrictEqual(result, { skillPaths: [expectedPath] });
+    assert.deepStrictEqual(result, { skillPaths: [expectedGlobal, expectedPath] });
   });
 
   it("returns project skillPaths and updates skill store context", () => {
@@ -44,12 +45,12 @@ describe("resources_discover skill path resolution", () => {
     const resource = resolveProjectSkillDiscovery(store, "projects-memory", cwd);
     const expectedPath = path.join(os.homedir(), ".pi", "agent", "projects-memory", "demo-repo", "skills");
 
-    assert.deepStrictEqual(resource, { skillPaths: [expectedPath] });
+    assert.deepStrictEqual(resource, { skillPaths: ["/tmp/global-skills", expectedPath] });
     assert.strictEqual(store.getProjectName(), "demo-repo");
     assert.strictEqual(store.getProjectSkillsDir(), expectedPath);
   });
 
-  it("returns undefined when cwd is not a project", () => {
+  it("returns global skill path when cwd is not a project", () => {
     const store = new SkillStore({
       globalSkillsDir: "/tmp/global-skills",
       projectSkillsDir: "/tmp/old-project",
@@ -60,7 +61,7 @@ describe("resources_discover skill path resolution", () => {
 
     const resource = resolveProjectSkillDiscovery(store, "projects-memory", os.homedir());
 
-    assert.strictEqual(resource, undefined);
+    assert.deepStrictEqual(resource, { skillPaths: ["/tmp/global-skills"] });
     assert.strictEqual(store.getProjectName(), null);
     assert.strictEqual(store.getProjectSkillsDir(), null);
   });

--- a/tests/handlers/skills-command.test.ts
+++ b/tests/handlers/skills-command.test.ts
@@ -2,6 +2,8 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
   buildSkillRows,
+  buildUnifiedSkillRows,
+  collectLoadedSkillsFromCommands,
   confirmDeleteSelectedSkills,
   deleteSelectedSkills,
   filterSkillRows,
@@ -34,6 +36,27 @@ const SAMPLE_SKILLS: SkillIndex[] = [
   },
 ];
 
+const LOADED_SKILL_COMMANDS = [
+  {
+    name: "skill:debug-typescript-errors",
+    description: "Trace compiler issues step by step",
+    source: "skill",
+    sourceInfo: { path: "/tmp/global/debug-typescript-errors/SKILL.md" },
+  },
+  {
+    name: "skill:langgraph-fundamentals",
+    description: "LangGraph patterns",
+    source: "skill",
+    sourceInfo: { path: "/Users/demo/.agents/skills/langgraph-fundamentals/SKILL.md" },
+  },
+  {
+    name: "memory-skills",
+    description: "not a skill command",
+    source: "extension",
+    sourceInfo: { path: "/tmp/ignore" },
+  },
+] as const;
+
 describe("skills command helpers", () => {
   it("buildSkillRows preserves selected ids", () => {
     const rows = buildSkillRows(SAMPLE_SKILLS, new Set(["project:demo-project:deploy-checklist"]));
@@ -50,6 +73,42 @@ describe("skills command helpers", () => {
 
     assert.strictEqual(filtered.length, 1);
     assert.strictEqual(filtered[0].skillId, "global:debug-typescript-errors");
+  });
+
+  it("collectLoadedSkillsFromCommands returns loaded runtime skills only", () => {
+    const loaded = collectLoadedSkillsFromCommands(LOADED_SKILL_COMMANDS as any);
+
+    assert.strictEqual(loaded.length, 2);
+    assert.strictEqual(loaded[0]?.name, "debug-typescript-errors");
+    assert.strictEqual(loaded[1]?.name, "langgraph-fundamentals");
+  });
+
+  it("collectLoadedSkillsFromCommands ignores malformed and pathless commands", () => {
+    const loaded = collectLoadedSkillsFromCommands([
+      { source: "skill", name: "skill:valid", sourceInfo: { path: "/tmp/valid/SKILL.md" } },
+      { source: "skill", name: "skill:no-path", sourceInfo: {} },
+      { source: "skill", name: "skill:blank-path", sourceInfo: { path: "   " } },
+      { source: "skill", name: "   ", sourceInfo: { path: "/tmp/blank-name/SKILL.md" } },
+      { source: "skill", sourceInfo: { path: "/tmp/missing-name/SKILL.md" } },
+      { source: "skill", name: 123, sourceInfo: { path: "/tmp/invalid-name/SKILL.md" } },
+      { source: "extension", name: "memory-skills", sourceInfo: { path: "/tmp/ignore/SKILL.md" } },
+      null as any,
+    ] as any);
+
+    assert.strictEqual(loaded.length, 1);
+    assert.strictEqual(loaded[0]?.name, "valid");
+    assert.strictEqual(loaded[0]?.path, "/tmp/valid/SKILL.md");
+  });
+
+  it("buildUnifiedSkillRows merges managed and external skills", () => {
+    const loaded = collectLoadedSkillsFromCommands(LOADED_SKILL_COMMANDS as any);
+    const rows = buildUnifiedSkillRows(SAMPLE_SKILLS, loaded);
+
+    assert.strictEqual(rows.length, 3);
+    const external = rows.find((row) => row.category === "E");
+    assert.ok(external);
+    assert.strictEqual(external?.mutable, false);
+    assert.ok(external?.displayPath.includes(".agents"));
   });
 
   it("moveSelectedSkills blocks project moves without an active project", async () => {
@@ -264,7 +323,7 @@ describe("SkillsManagerModal", () => {
     modal.handleInput("z");
 
     const output = modal.render(100).join("\n");
-    assert.ok(output.includes("No skills match the current search."));
+    assert.ok(output.includes("No skills match the current filters/search."));
   });
 
   it("redirects printable keys to search from list focus", () => {
@@ -283,7 +342,7 @@ describe("SkillsManagerModal", () => {
 
     modal.handleInput("z");
     const output = modal.render(100).join("\n");
-    assert.ok(output.includes("No skills match the current search."));
+    assert.ok(output.includes("No skills match the current filters/search."));
   });
 
   it("uses in-modal delete confirmation and cancels with n", () => {
@@ -377,6 +436,72 @@ describe("SkillsManagerModal", () => {
 
     assert.strictEqual(harness.getRenderCount(), renderCountBeforeResolve);
   });
+
+  it("supports in-modal category filters", () => {
+    const harness = createModalHarness();
+    const loaded = collectLoadedSkillsFromCommands(LOADED_SKILL_COMMANDS as any);
+    const rows = buildUnifiedSkillRows(SAMPLE_SKILLS, loaded);
+
+    const modal = new SkillsManagerModal(
+      harness.tui as any,
+      harness.theme as any,
+      rows,
+      {
+        moveSelected: async () => ({ skills: SAMPLE_SKILLS, summaryLines: ["done"] }),
+        deleteSelected: async () => ({ skills: SAMPLE_SKILLS, summaryLines: ["done"] }),
+        close: () => undefined,
+        projectName: "demo-project",
+      },
+      { managedSkills: SAMPLE_SKILLS, loadedSkills: loaded },
+    );
+
+    modal.handleInput("f");
+    modal.handleInput(" "); // disable global
+    modal.handleInput("\u001b[B");
+    modal.handleInput(" "); // disable project
+    modal.handleInput("\r"); // apply
+
+    const output = modal.render(120).join("\n");
+    assert.ok(output.includes("langgraph-fundamentals"));
+    assert.ok(!output.includes("Deploy Checklist"));
+  });
+
+  it("blocks external skill mutations as read-only", async () => {
+    const harness = createModalHarness();
+    const loaded = collectLoadedSkillsFromCommands(LOADED_SKILL_COMMANDS as any);
+    const rows = buildUnifiedSkillRows(SAMPLE_SKILLS, loaded);
+    let moveCalls = 0;
+
+    const modal = new SkillsManagerModal(
+      harness.tui as any,
+      harness.theme as any,
+      rows,
+      {
+        moveSelected: async () => {
+          moveCalls++;
+          return { skills: SAMPLE_SKILLS, summaryLines: ["done"] };
+        },
+        deleteSelected: async () => ({ skills: SAMPLE_SKILLS, summaryLines: ["done"] }),
+        close: () => undefined,
+        projectName: "demo-project",
+      },
+      { managedSkills: SAMPLE_SKILLS, loadedSkills: loaded },
+    );
+
+    modal.handleInput("f");
+    modal.handleInput(" ");
+    modal.handleInput("\u001b[B");
+    modal.handleInput(" ");
+    modal.handleInput("\r");
+
+    modal.handleInput(" ");
+    modal.handleInput("g");
+    await nextTick();
+
+    const output = modal.render(120).join("\n");
+    assert.strictEqual(moveCalls, 0);
+    assert.ok(output.includes("read-only"));
+  });
 });
 
 describe("registerSkillsCommand", () => {
@@ -398,6 +523,37 @@ describe("registerSkillsCommand", () => {
 
     await commands[0].handler({}, {
       hasUI: false,
+      ui: {
+        notify: (message: string, severity: string) => notifications.push({ message, severity }),
+      },
+    });
+
+    assert.strictEqual(notifications.length, 1);
+    assert.strictEqual(notifications[0].severity, "info");
+    assert.ok(notifications[0].message.includes("Procedural Skills"));
+  });
+
+  it("gracefully handles getCommands errors without custom UI", async () => {
+    const commands: Array<{ name: string; handler: Function }> = [];
+    const notifications: Array<{ message: string; severity: string }> = [];
+    const pi = {
+      registerCommand: (name: string, opts: { handler: Function }) => {
+        commands.push({ name, handler: opts.handler });
+      },
+    };
+    const store = {
+      loadIndex: async () => SAMPLE_SKILLS,
+      getProjectName: () => "demo-project",
+    };
+
+    registerSkillsCommand(pi as any, store as any);
+    assert.strictEqual(commands.length, 1);
+
+    await commands[0].handler({}, {
+      hasUI: false,
+      getCommands: () => {
+        throw new Error("command registry unavailable");
+      },
       ui: {
         notify: (message: string, severity: string) => notifications.push({ message, severity }),
       },
@@ -445,6 +601,42 @@ describe("registerSkillsCommand", () => {
     assert.strictEqual(customInvoked, true);
   });
 
+  it("opens custom modal even when getCommands throws", async () => {
+    const commands: Array<{ name: string; handler: Function }> = [];
+    let customInvoked = false;
+    const pi = {
+      registerCommand: (name: string, opts: { handler: Function }) => {
+        commands.push({ name, handler: opts.handler });
+      },
+    };
+    const store = {
+      loadIndex: async () => SAMPLE_SKILLS,
+      getProjectName: () => "demo-project",
+      move: async () => ({ success: true } as SkillResult),
+      delete: async () => ({ success: true } as SkillResult),
+    };
+
+    registerSkillsCommand(pi as any, store as any);
+
+    await commands[0].handler({}, {
+      hasUI: true,
+      getCommands: () => {
+        throw new Error("command registry unavailable");
+      },
+      ui: {
+        custom: async (factory: Function, options: { overlay?: boolean }) => {
+          customInvoked = true;
+          assert.strictEqual(options.overlay, true);
+          return undefined;
+        },
+        confirm: async () => true,
+        notify: () => undefined,
+      },
+    });
+
+    assert.strictEqual(customInvoked, true);
+  });
+
   it("falls back to read-only notify output when custom modal throws", async () => {
     const commands: Array<{ name: string; handler: Function }> = [];
     const notifications: Array<{ message: string; severity: string }> = [];
@@ -464,6 +656,44 @@ describe("registerSkillsCommand", () => {
 
     await commands[0].handler({}, {
       hasUI: true,
+      ui: {
+        custom: async () => {
+          throw new Error("UI backend unavailable");
+        },
+        confirm: async () => true,
+        notify: (message: string, severity: string) => notifications.push({ message, severity }),
+      },
+    });
+
+    assert.strictEqual(notifications.length, 2);
+    assert.strictEqual(notifications[0].severity, "warning");
+    assert.ok(notifications[0].message.includes("read-only list fallback"));
+    assert.strictEqual(notifications[1].severity, "info");
+    assert.ok(notifications[1].message.includes("Procedural Skills"));
+  });
+
+  it("falls back to read-only list when both custom modal and getCommands fail", async () => {
+    const commands: Array<{ name: string; handler: Function }> = [];
+    const notifications: Array<{ message: string; severity: string }> = [];
+    const pi = {
+      registerCommand: (name: string, opts: { handler: Function }) => {
+        commands.push({ name, handler: opts.handler });
+      },
+    };
+    const store = {
+      loadIndex: async () => SAMPLE_SKILLS,
+      getProjectName: () => "demo-project",
+      move: async () => ({ success: true } as SkillResult),
+      delete: async () => ({ success: true } as SkillResult),
+    };
+
+    registerSkillsCommand(pi as any, store as any);
+
+    await commands[0].handler({}, {
+      hasUI: true,
+      getCommands: () => {
+        throw new Error("command registry unavailable");
+      },
       ui: {
         custom: async () => {
           throw new Error("UI backend unavailable");

--- a/tests/handlers/skills-command.test.ts
+++ b/tests/handlers/skills-command.test.ts
@@ -533,6 +533,35 @@ describe("registerSkillsCommand", () => {
     assert.ok(notifications[0].message.includes("Procedural Skills"));
   });
 
+  it("uses pi.getCommands runtime inventory for external skills", async () => {
+    const commands: Array<{ name: string; handler: Function }> = [];
+    const notifications: Array<{ message: string; severity: string }> = [];
+    const pi = {
+      registerCommand: (name: string, opts: { handler: Function }) => {
+        commands.push({ name, handler: opts.handler });
+      },
+      getCommands: () => LOADED_SKILL_COMMANDS,
+    };
+    const store = {
+      loadIndex: async () => SAMPLE_SKILLS,
+      getProjectName: () => "demo-project",
+    };
+
+    registerSkillsCommand(pi as any, store as any);
+
+    await commands[0].handler({}, {
+      hasUI: false,
+      ui: {
+        notify: (message: string, severity: string) => notifications.push({ message, severity }),
+      },
+    });
+
+    assert.strictEqual(notifications.length, 1);
+    assert.strictEqual(notifications[0].severity, "info");
+    assert.ok(notifications[0].message.includes("[E] External Skills"));
+    assert.ok(notifications[0].message.includes("langgraph-fundamentals"));
+  });
+
   it("gracefully handles getCommands errors without custom UI", async () => {
     const commands: Array<{ name: string; handler: Function }> = [];
     const notifications: Array<{ message: string; severity: string }> = [];

--- a/tests/store/skill-store.test.ts
+++ b/tests/store/skill-store.test.ts
@@ -483,6 +483,24 @@ describe("SkillStore", { concurrency: 1 }, () => {
       assert.ok(!raw.includes("Legacy version"));
     });
 
+    it("migrates flat markdown files under global skills root into SKILL.md folders", async () => {
+      await fs.writeFile(path.join(GLOBAL_SKILLS_DIR, "flat-legacy.md"), [
+        "---",
+        "name: flat-legacy",
+        "description: Flat legacy skill",
+        "---",
+        "# Flat Body",
+      ].join("\n"), "utf-8");
+
+      const store = await makeStore();
+      const result = await store.migrateLegacySkills();
+
+      assert.strictEqual(result.migrated, 1);
+      await assert.rejects(fs.access(path.join(GLOBAL_SKILLS_DIR, "flat-legacy.md")));
+      const migrated = await readFile(path.join(GLOBAL_SKILLS_DIR, "flat-legacy", "SKILL.md"));
+      assert.ok(migrated.includes("description: Flat legacy skill"));
+    });
+
     it("does not write the sentinel when warnings occur, so migration can retry", async () => {
       await fs.mkdir(path.join(LEGACY_SKILLS_DIR, "broken.md"), { recursive: true });
       const legacyFile = path.join(LEGACY_SKILLS_DIR, "legacy-skill.md");

--- a/tests/store/skill-store.test.ts
+++ b/tests/store/skill-store.test.ts
@@ -13,6 +13,7 @@ let ROOT_DIR = "";
 let GLOBAL_SKILLS_DIR = "";
 let PROJECT_SKILLS_DIR = "";
 let LEGACY_SKILLS_DIR = "";
+let LEGACY_PI_GLOBAL_SKILLS_DIR = "";
 let MIGRATION_SENTINEL = "";
 
 async function makeStore(withProject = true): Promise<SkillStore> {
@@ -21,6 +22,7 @@ async function makeStore(withProject = true): Promise<SkillStore> {
     projectSkillsDir: withProject ? PROJECT_SKILLS_DIR : null,
     projectName: withProject ? "demo-project" : null,
     legacySkillsDir: LEGACY_SKILLS_DIR,
+    legacyPiGlobalSkillsDir: LEGACY_PI_GLOBAL_SKILLS_DIR,
     migrationSentinelPath: MIGRATION_SENTINEL,
   });
 }
@@ -34,6 +36,7 @@ async function cleanSlate(): Promise<void> {
   await fs.mkdir(GLOBAL_SKILLS_DIR, { recursive: true });
   await fs.mkdir(PROJECT_SKILLS_DIR, { recursive: true });
   await fs.mkdir(LEGACY_SKILLS_DIR, { recursive: true });
+  await fs.mkdir(LEGACY_PI_GLOBAL_SKILLS_DIR, { recursive: true });
 }
 
 async function readFile(filePath: string): Promise<string> {
@@ -46,6 +49,7 @@ describe("SkillStore", { concurrency: 1 }, () => {
     GLOBAL_SKILLS_DIR = path.join(ROOT_DIR, "global-skills");
     PROJECT_SKILLS_DIR = path.join(ROOT_DIR, "project-skills");
     LEGACY_SKILLS_DIR = path.join(ROOT_DIR, "legacy-skills");
+    LEGACY_PI_GLOBAL_SKILLS_DIR = path.join(ROOT_DIR, "legacy-pi-global-skills");
     MIGRATION_SENTINEL = path.join(ROOT_DIR, ".skill-migration");
   });
 


### PR DESCRIPTION
## Summary
- include skills currently loaded by Pi in this session (not only extension-managed roots)
- merge runtime-loaded skills with managed skills in `/memory-skills`
- mark external skills as read-only and show path info in modal
- add in-modal category filters (`f` panel) and runtime-discovery tests
- move extension-owned storage root to `~/.pi/agent/pi-hermes-memory`
- move extension-managed global skills to `~/.pi/agent/pi-hermes-memory/skills`
- add startup migration from legacy `~/.pi/agent/memory` into `~/.pi/agent/pi-hermes-memory`
- normalize legacy flat `skills/*.md` into `skills/<slug>/SKILL.md` to avoid Pi skill-name conflicts

## Why
This aligns `/memory-skills` with what Pi actually has loaded in the current session, keeps external skills safe (read-only), and avoids polluting the shared `~/.pi/agent/skills` directory by using an extension-owned storage root.

## Migration behavior
- Default writes now target `~/.pi/agent/pi-hermes-memory`
- Existing legacy assets in `~/.pi/agent/memory` are migrated on startup
- Existing flat markdown skill files under `~/.pi/agent/pi-hermes-memory/skills/*.md` are auto-converted into Pi-compatible folder skills (`<slug>/SKILL.md`)

## Validation
- `npm run check`
- `npm test` (full suite)
