### PR TITLE
Fix configured memory path normalization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hermes-memory",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-tui": "^0.74.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_FAILURE_INJECTION_MAX_AGE_DAYS,
   DEFAULT_FAILURE_INJECTION_MAX_ENTRIES,
 } from "./constants.js";
+import { normalizeConfiguredMemoryDir, normalizeProjectsMemoryDir } from "./paths.js";
 
 const MEMORY_OVERFLOW_STRATEGIES: readonly MemoryOverflowStrategy[] = ["auto-consolidate", "reject", "fifo-evict"];
 const SESSION_SEARCH_VARIANTS: readonly SessionSearchVariant[] = ["legacy", "anchors"];
@@ -111,8 +112,14 @@ export function loadConfig(configPath = DEFAULT_CONFIG_PATH): MemoryConfig {
       if (typeof parsed.failureInjectionMaxEntries === "number") config.failureInjectionMaxEntries = parsed.failureInjectionMaxEntries;
       if (typeof parsed.nudgeToolCalls === "number") config.nudgeToolCalls = parsed.nudgeToolCalls;
       if (typeof parsed.projectCharLimit === "number") config.projectCharLimit = parsed.projectCharLimit;
-      if (typeof parsed.memoryDir === "string") config.memoryDir = parsed.memoryDir;
-      if (typeof parsed.projectsMemoryDir === "string") config.projectsMemoryDir = parsed.projectsMemoryDir;
+      if (typeof parsed.memoryDir === "string") {
+        const normalizedMemoryDir = normalizeConfiguredMemoryDir(parsed.memoryDir);
+        if (normalizedMemoryDir) config.memoryDir = normalizedMemoryDir;
+      }
+      if (typeof parsed.projectsMemoryDir === "string") {
+        const normalizedProjectsMemoryDir = normalizeProjectsMemoryDir(parsed.projectsMemoryDir);
+        if (normalizedProjectsMemoryDir) config.projectsMemoryDir = normalizedProjectsMemoryDir;
+      }
       if (
         typeof parsed.sessionSearch === "object" &&
         parsed.sessionSearch !== null &&

--- a/src/handlers/sync-markdown-memories.ts
+++ b/src/handlers/sync-markdown-memories.ts
@@ -12,6 +12,7 @@ import {
   syncMemoryEntry,
 } from '../store/sqlite-memory-store.js';
 import { ENTRY_DELIMITER, MEMORY_FILE, USER_FILE } from '../constants.js';
+import { AGENT_ROOT } from '../paths.js';
 
 export interface BackfillCounters {
   filesScanned: number;
@@ -64,10 +65,14 @@ function scanProjectDirs(agentRoot: string, globalDir: string, projectsMemoryDir
     }
   }
 
-  const globalDirName = path.basename(globalDir);
+  const resolvedAgentRoot = path.resolve(agentRoot);
+  const resolvedGlobalDir = path.resolve(globalDir);
+  const globalDirName = path.dirname(resolvedGlobalDir) === resolvedAgentRoot
+    ? path.basename(resolvedGlobalDir)
+    : null;
   if (fs.existsSync(agentRoot)) {
     for (const name of fs.readdirSync(agentRoot)) {
-      if (name === globalDirName || name === projectsMemoryDir || name === 'skills' || name.startsWith('.')) continue;
+      if ((globalDirName && name === globalDirName) || name === projectsMemoryDir || name === 'skills' || name.startsWith('.')) continue;
       if (projects.has(name)) continue;
       const dir = path.join(agentRoot, name);
       const memoryFile = path.join(dir, MEMORY_FILE);
@@ -86,6 +91,7 @@ export function syncMarkdownMemoriesToSqlite(
   dbManager: DatabaseManager,
   globalDir: string,
   projectsMemoryDir?: string,
+  agentRoot = AGENT_ROOT,
 ): BackfillCounters & { projectCount: number } {
   const counters: BackfillCounters = {
     filesScanned: 0,
@@ -114,7 +120,6 @@ export function syncMarkdownMemoriesToSqlite(
   importFile(globalUserFile, 'user');
   importFile(globalFailureFile, 'failure');
 
-  const agentRoot = path.dirname(globalDir);
   const projects = scanProjectDirs(agentRoot, globalDir, projectsMemoryDir);
   for (const project of projects) {
     importFile(project.memoryFile, 'memory', project.name);
@@ -128,6 +133,7 @@ export function registerSyncMarkdownMemoriesCommand(
   dbManager: DatabaseManager,
   globalDir: string,
   projectsMemoryDir?: string,
+  agentRoot = AGENT_ROOT,
 ): void {
   pi.registerCommand('memory-sync-markdown', {
     description: 'Backfill Markdown memories into the SQLite search store',
@@ -135,7 +141,7 @@ export function registerSyncMarkdownMemoriesCommand(
       ctx.ui.notify('🔄 Scanning Markdown memory files for SQLite backfill...', 'info');
 
       try {
-        const counters = syncMarkdownMemoriesToSqlite(dbManager, globalDir, projectsMemoryDir);
+        const counters = syncMarkdownMemoriesToSqlite(dbManager, globalDir, projectsMemoryDir, agentRoot);
 
         let output = `\n✅ Markdown → SQLite sync complete!\n\n`;
         output += `📊 Results:\n`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,6 @@
  */
 
 import * as path from "node:path";
-import * as os from "node:os";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { MemoryStore } from "./store/memory-store.js";
 import { SkillStore } from "./store/skill-store.js";
@@ -52,6 +51,7 @@ import { detectProject, detectProjectSkills } from "./project.js";
 import { buildPromptContext } from "./prompt-context.js";
 import { migrateLegacyProjectMemoryDirs } from "./project-memory-migration.js";
 import { migrateExtensionRoot } from "./extension-root-migration.js";
+import { AGENT_ROOT } from "./paths.js";
 
 export function resolveProjectSkillDiscovery(
   skillStore: SkillStore,
@@ -80,7 +80,7 @@ export function registerProjectSkillDiscoveryHandler(
 export default function (pi: ExtensionAPI) {
   const config = loadConfig();
 
-  const agentRoot = path.join(os.homedir(), ".pi", "agent");
+  const agentRoot = AGENT_ROOT;
   const legacyGlobalDir = path.join(agentRoot, "memory");
   const defaultGlobalDir = path.join(agentRoot, "pi-hermes-memory");
 
@@ -121,9 +121,9 @@ export default function (pi: ExtensionAPI) {
   // Keep project memory available for users upgrading from the old
   // ~/.pi/agent/<project>/ layout. This is non-destructive: legacy folders
   // remain in place while entries are copied/merged into projects-memory/.
-  migrateLegacyProjectMemoryDirs(globalDir, config.projectsMemoryDir);
+  migrateLegacyProjectMemoryDirs(agentRoot, config.projectsMemoryDir);
   try {
-    syncMarkdownMemoriesToSqlite(dbManager, globalDir, config.projectsMemoryDir);
+    syncMarkdownMemoriesToSqlite(dbManager, globalDir, config.projectsMemoryDir, agentRoot);
   } catch {
     // Best-effort only: failed SQLite backfill should not block extension startup.
   }
@@ -196,7 +196,7 @@ export default function (pi: ExtensionAPI) {
   registerInterviewCommand(pi, store);
   registerSwitchProjectCommand(pi, config);
   registerLearnMemoryCommand(pi);
-  registerSyncMarkdownMemoriesCommand(pi, dbManager, globalDir, config.projectsMemoryDir);
+  registerSyncMarkdownMemoriesCommand(pi, dbManager, globalDir, config.projectsMemoryDir, agentRoot);
   registerPreviewContextCommand(pi, store, projectStore, projectName, config);
 
   // ── 11. SQLite session search + extended memory ──

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,7 +136,7 @@ export default function (pi: ExtensionAPI) {
   const projectStore = project.memoryDir ? new MemoryStore(projectConfig) : null;
 
   // ── 1. Load memory from disk on session start ──
-  pi.on("session_start", async (event, _ctx) => {
+  pi.on("session_start", async (_event, ctx) => {
     if (shouldMigrateExtensionRoot && !extensionRootMigrated) {
       try {
         await migrateExtensionRoot(legacyGlobalDir, globalDir);
@@ -146,7 +146,7 @@ export default function (pi: ExtensionAPI) {
       extensionRootMigrated = true;
     }
 
-    refreshSkillProjectContext((event as { cwd?: string }).cwd);
+    refreshSkillProjectContext(ctx.cwd);
     await skillStore.migrateLegacySkills();
     await skillStore.ensureDiscoveredRoots();
     await store.loadFromDisk();

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,0 +1,57 @@
+import * as os from "node:os";
+import * as path from "node:path";
+import { DEFAULT_PROJECTS_MEMORY_DIR } from "./constants.js";
+
+export const AGENT_ROOT = path.join(os.homedir(), ".pi", "agent");
+
+export function expandHome(input: string): string {
+  if (input === "~") return os.homedir();
+  if (input.startsWith("~/") || input.startsWith("~\\")) {
+    return path.join(os.homedir(), input.slice(2));
+  }
+  return input;
+}
+
+export function normalizeConfiguredMemoryDir(input: string): string | undefined {
+  const trimmed = input.trim();
+  if (!trimmed) return undefined;
+
+  const expanded = expandHome(trimmed);
+  if (path.isAbsolute(expanded)) return path.normalize(expanded);
+  return path.resolve(AGENT_ROOT, expanded);
+}
+
+function isSafeRelativeDirectory(input: string): boolean {
+  const segments = input.split(/[\\/]+/).filter(Boolean);
+  return segments.length === 1 && segments[0] !== "." && segments[0] !== "..";
+}
+
+export function normalizeProjectsMemoryDir(input: string): string | undefined {
+  const trimmed = input.trim();
+  if (!trimmed) return undefined;
+
+  const expanded = expandHome(trimmed);
+  let relative = expanded;
+
+  if (path.isAbsolute(expanded)) {
+    const resolved = path.resolve(expanded);
+    const relativeToAgentRoot = path.relative(AGENT_ROOT, resolved);
+    if (
+      relativeToAgentRoot === ""
+      || relativeToAgentRoot.startsWith("..")
+      || path.isAbsolute(relativeToAgentRoot)
+    ) {
+      return undefined;
+    }
+    relative = relativeToAgentRoot;
+  }
+
+  const normalized = path.normalize(relative).replace(/^[\\/]+|[\\/]+$/g, "");
+  if (!isSafeRelativeDirectory(normalized)) return undefined;
+  return normalized;
+}
+
+export function resolveProjectsRoot(projectsMemoryDir = DEFAULT_PROJECTS_MEMORY_DIR): string {
+  const normalized = normalizeProjectsMemoryDir(projectsMemoryDir) ?? DEFAULT_PROJECTS_MEMORY_DIR;
+  return path.join(AGENT_ROOT, normalized);
+}

--- a/src/project-memory-migration.ts
+++ b/src/project-memory-migration.ts
@@ -31,7 +31,7 @@ function isLegacyProjectDir(agentRoot: string, projectsMemoryDir: string, name: 
 }
 
 export function migrateLegacyProjectMemoryDirs(
-  globalDir: string,
+  agentRoot: string,
   projectsMemoryDir = "projects-memory",
 ): ProjectMemoryMigrationResult {
   const result: ProjectMemoryMigrationResult = {
@@ -42,7 +42,6 @@ export function migrateLegacyProjectMemoryDirs(
     warnings: [],
   };
 
-  const agentRoot = path.dirname(globalDir);
   if (!fs.existsSync(agentRoot)) return result;
 
   const projectsRoot = path.join(agentRoot, projectsMemoryDir);

--- a/src/project.ts
+++ b/src/project.ts
@@ -5,6 +5,7 @@
 
 import * as path from "node:path";
 import * as os from "node:os";
+import { resolveProjectsRoot } from "./paths.js";
 
 export interface ProjectInfo {
   /** Project name (directory basename), or null if not in a project. */
@@ -44,7 +45,7 @@ export function detectProject(projectsMemoryDir = "projects-memory", cwd?: strin
 
   return {
     name,
-    memoryDir: path.join(homeDir, ".pi", "agent", projectsMemoryDir, name),
+    memoryDir: path.join(resolveProjectsRoot(projectsMemoryDir), name),
   };
 }
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -84,6 +84,48 @@ describe("loadConfig", () => {
     assert.strictEqual(config.projectsMemoryDir, "projects-memory");
   });
 
+  it("expands ~/ memoryDir into an absolute home path", () => {
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({
+      memoryDir: "~/.pi/agent/pi-hermes-memory",
+    }));
+
+    const config = loadConfig(TEST_CONFIG_PATH);
+    assert.strictEqual(config.memoryDir, path.join(os.homedir(), ".pi", "agent", "pi-hermes-memory"));
+  });
+
+  it("resolves relative memoryDir values against ~/.pi/agent instead of cwd", () => {
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({
+      memoryDir: "custom-memory-root",
+    }));
+
+    const config = loadConfig(TEST_CONFIG_PATH);
+    assert.strictEqual(config.memoryDir, path.join(os.homedir(), ".pi", "agent", "custom-memory-root"));
+  });
+
+  it("normalizes projectsMemoryDir inside ~/.pi/agent and ignores unsafe values", () => {
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({
+      projectsMemoryDir: " ~/.pi/agent/team-projects/ ",
+    }));
+    let config = loadConfig(TEST_CONFIG_PATH);
+    assert.strictEqual(config.projectsMemoryDir, "team-projects");
+
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({
+      projectsMemoryDir: "../escape",
+    }));
+    config = loadConfig(TEST_CONFIG_PATH);
+    assert.strictEqual(config.projectsMemoryDir, "projects-memory");
+
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({
+      projectsMemoryDir: "team/projects-memory",
+    }));
+    config = loadConfig(TEST_CONFIG_PATH);
+    assert.strictEqual(config.projectsMemoryDir, "projects-memory");
+  });
+
   it("handles partial config with all boolean overrides", () => {
     fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
     fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({

--- a/tests/handlers/sync-markdown-memories.test.ts
+++ b/tests/handlers/sync-markdown-memories.test.ts
@@ -106,7 +106,7 @@ describe('memory sqlite sync + markdown backfill', () => {
       },
     } as any;
 
-    registerSyncMarkdownMemoriesCommand(mockPi, dbManager, globalDir);
+    registerSyncMarkdownMemoriesCommand(mockPi, dbManager, globalDir, undefined, agentRoot);
 
     await handler({}, ctx);
     const afterFirst = getMemories(dbManager);
@@ -151,7 +151,7 @@ describe('memory sqlite sync + markdown backfill', () => {
       },
     } as any;
 
-    registerSyncMarkdownMemoriesCommand(mockPi, dbManager, globalDir);
+    registerSyncMarkdownMemoriesCommand(mockPi, dbManager, globalDir, undefined, agentRoot);
     await handler({}, ctx);
 
     const projectRows = getMemories(dbManager, { project: 'legacy-project', target: 'memory' });
@@ -168,7 +168,7 @@ describe('memory sqlite sync + markdown backfill', () => {
       'utf-8',
     );
 
-    const counters = syncMarkdownMemoriesToSqlite(dbManager, globalDir);
+    const counters = syncMarkdownMemoriesToSqlite(dbManager, globalDir, undefined, agentRoot);
 
     assert.strictEqual(counters.projectCount, 1);
     assert.strictEqual(counters.imported, 1);
@@ -179,5 +179,33 @@ describe('memory sqlite sync + markdown backfill', () => {
     });
     assert.strictEqual(results.length, 1);
     assert.strictEqual(results[0].content, 'latest path searchable entry');
+  });
+
+  it('still scans project markdown under ~/.pi/agent when memoryDir is customized elsewhere', () => {
+    const customGlobalDir = path.join(tmpDir, 'external-memory-root');
+    fs.mkdirSync(customGlobalDir, { recursive: true });
+
+    const customDbManager = new DatabaseManager(customGlobalDir);
+    try {
+      const projectDir = path.join(agentRoot, 'projects-memory', 'custom-root-project');
+      fs.mkdirSync(projectDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(projectDir, 'MEMORY.md'),
+        'custom root project entry <!-- created=2026-05-11, last=2026-05-11 -->',
+        'utf-8',
+      );
+
+      const counters = syncMarkdownMemoriesToSqlite(customDbManager, customGlobalDir, undefined, agentRoot);
+
+      assert.strictEqual(counters.projectCount, 1);
+      const results = searchMemories(customDbManager, 'custom root project entry', {
+        project: 'custom-root-project',
+        target: 'memory',
+      });
+      assert.strictEqual(results.length, 1);
+      assert.strictEqual(results[0].content, 'custom root project entry');
+    } finally {
+      customDbManager.close();
+    }
   });
 });

--- a/tests/project-memory-migration.test.ts
+++ b/tests/project-memory-migration.test.ts
@@ -9,13 +9,10 @@ import { migrateLegacyProjectMemoryDirs } from "../src/project-memory-migration.
 describe("migrateLegacyProjectMemoryDirs", () => {
   let tmpDir: string;
   let agentRoot: string;
-  let globalDir: string;
-
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "project-memory-migration-test-"));
     agentRoot = path.join(tmpDir, "agent");
-    globalDir = path.join(agentRoot, "memory");
-    fs.mkdirSync(globalDir, { recursive: true });
+    fs.mkdirSync(agentRoot, { recursive: true });
   });
 
   afterEach(() => {
@@ -28,7 +25,7 @@ describe("migrateLegacyProjectMemoryDirs", () => {
     fs.mkdirSync(legacyDir, { recursive: true });
     fs.writeFileSync(legacyFile, "legacy project memory", "utf-8");
 
-    const result = migrateLegacyProjectMemoryDirs(globalDir);
+    const result = migrateLegacyProjectMemoryDirs(agentRoot);
 
     const migratedFile = path.join(agentRoot, "projects-memory", "project-a", "MEMORY.md");
     assert.strictEqual(fs.readFileSync(migratedFile, "utf-8"), "legacy project memory");
@@ -56,7 +53,7 @@ describe("migrateLegacyProjectMemoryDirs", () => {
       "utf-8",
     );
 
-    const result = migrateLegacyProjectMemoryDirs(globalDir);
+    const result = migrateLegacyProjectMemoryDirs(agentRoot);
     const merged = fs.readFileSync(path.join(migratedDir, "MEMORY.md"), "utf-8");
 
     assert.deepStrictEqual(merged.split(ENTRY_DELIMITER), ["shared", "new only", "legacy only"]);
@@ -67,11 +64,13 @@ describe("migrateLegacyProjectMemoryDirs", () => {
   });
 
   it("skips global memory and the new projects-memory directory", () => {
+    const globalDir = path.join(agentRoot, "memory");
+    fs.mkdirSync(globalDir, { recursive: true });
     fs.writeFileSync(path.join(globalDir, "MEMORY.md"), "global memory", "utf-8");
     fs.mkdirSync(path.join(agentRoot, "projects-memory", "project-a"), { recursive: true });
     fs.writeFileSync(path.join(agentRoot, "projects-memory", "project-a", "MEMORY.md"), "new memory", "utf-8");
 
-    const result = migrateLegacyProjectMemoryDirs(globalDir);
+    const result = migrateLegacyProjectMemoryDirs(agentRoot);
 
     assert.deepStrictEqual(
       { scanned: result.scanned, copied: result.copied, merged: result.merged, skipped: result.skipped },


### PR DESCRIPTION
## Summary
Fixes the `memoryDir: "~/.pi/agent/pi-hermes-memory"` config bug from #42 by normalizing configured storage paths before startup uses them.

## What changed
- expand and normalize `memoryDir` during config loading so `~` resolves to the user home directory instead of becoming a literal repo-local path
- resolve relative `memoryDir` values against `~/.pi/agent` so config behavior is stable and not dependent on the current working directory
- centralize path normalization in a new helper module for extension storage paths
- keep `projectsMemoryDir` constrained to a single safe directory segment under `~/.pi/agent`, which matches the existing config contract and avoids opening a partially supported nested-path mode
- make startup migration and Markdown-to-SQLite sync use the Pi agent root explicitly instead of inferring it from `memoryDir`, so custom global memory roots do not break legacy project migration or project memory discovery
- add regression tests for `~` expansion, relative path normalization, unsafe `projectsMemoryDir` rejection, and the custom-global-root migration/sync behavior

## Verification
- `npm run check`
- `npx tsx --test tests/config.test.ts`
- `npx tsx --test tests/project-memory-migration.test.ts`
- independent subagent review of the uncommitted diff, followed by a follow-up fix for the only finding around nested `projectsMemoryDir` handling

## Notes
- Full `npm test` is still blocked in this environment by the existing `better-sqlite3` vs Node ABI mismatch in SQLite-backed tests; this branch does not introduce a new path-related test failure there.

Fixes #42
