### PR TITLE
Add recency and cycle sorting to /memory-skills

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hermes-memory",
-      "version": "0.7.10",
+      "version": "0.7.11",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-tui": "^0.74.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "🧠 Persistent memory + 🔍 session search + 🛡️ secret scanning for Pi. Token-aware policy-only memory by default, SQLite FTS5 search, auto-consolidation, procedural skills. 368 tests. Ported from Hermes agent.",
   "type": "module",
   "main": "src/index.ts",

--- a/src/handlers/skills-command.ts
+++ b/src/handlers/skills-command.ts
@@ -24,6 +24,7 @@ export const MEMORY_SKILLS_KEYMAP = {
   moveGlobal: "g",
   moveProject: "p",
   deleteSelected: "d",
+  cycleSort: "s",
   selectAllFiltered: "a",
   clearSelection: "n",
   focusSearch: "/",
@@ -34,6 +35,7 @@ export const MEMORY_SKILLS_KEYMAP = {
 } as const;
 
 export type SkillRowCategory = "G" | "P" | "E";
+export type SkillSortMode = "updated" | "created" | "name";
 
 export interface SkillModalRow {
   skillId: string;
@@ -45,6 +47,8 @@ export interface SkillModalRow {
   description: string;
   path: string;
   displayPath: string;
+  created?: string;
+  updated?: string;
   projectName?: string;
   selected: boolean;
   searchText: string;
@@ -162,6 +166,70 @@ function categoryOrder(category: SkillRowCategory): number {
   }
 }
 
+function recencyValue(row: Pick<SkillModalRow, "updated" | "created">): string {
+  return row.updated || row.created || "";
+}
+
+function sortModeLabel(sortMode: SkillSortMode): string {
+  switch (sortMode) {
+    case "updated":
+      return "Updated";
+    case "created":
+      return "Created";
+    case "name":
+      return "Name";
+  }
+}
+
+function nextSortMode(sortMode: SkillSortMode): SkillSortMode {
+  switch (sortMode) {
+    case "updated":
+      return "created";
+    case "created":
+      return "name";
+    case "name":
+      return "updated";
+  }
+}
+
+function compareSkillRows(a: SkillModalRow, b: SkillModalRow, sortMode: SkillSortMode): number {
+  if (sortMode === "name") {
+    const byName = a.displayName.localeCompare(b.displayName);
+    if (byName !== 0) return byName;
+    return categoryOrder(a.category) - categoryOrder(b.category);
+  }
+
+  const primaryA = sortMode === "updated" ? recencyValue(a) : (a.created || "");
+  const primaryB = sortMode === "updated" ? recencyValue(b) : (b.created || "");
+  if (primaryA || primaryB) {
+    if (!primaryA) return 1;
+    if (!primaryB) return -1;
+    if (primaryA !== primaryB) return primaryB.localeCompare(primaryA);
+  }
+
+  if (sortMode === "updated") {
+    const createdA = a.created || "";
+    const createdB = b.created || "";
+    if (createdA || createdB) {
+      if (!createdA) return 1;
+      if (!createdB) return -1;
+      if (createdA !== createdB) return createdB.localeCompare(createdA);
+    }
+  } else {
+    const updatedA = recencyValue(a);
+    const updatedB = recencyValue(b);
+    if (updatedA || updatedB) {
+      if (!updatedA) return 1;
+      if (!updatedB) return -1;
+      if (updatedA !== updatedB) return updatedB.localeCompare(updatedA);
+    }
+  }
+
+  const byCategory = categoryOrder(a.category) - categoryOrder(b.category);
+  if (byCategory !== 0) return byCategory;
+  return a.displayName.localeCompare(b.displayName);
+}
+
 export function collectLoadedSkillsFromCommands(commands: SkillCommandInfo[]): LoadedSkillRow[] {
   const loaded: LoadedSkillRow[] = [];
 
@@ -269,6 +337,8 @@ export function buildSkillRows(skills: SkillIndex[], selectedSkillIds = new Set<
       description: skill.description,
       path: skill.path,
       displayPath,
+      created: skill.created,
+      updated: skill.updated,
       projectName: skill.projectName,
       selected: selectedSkillIds.has(skill.skillId),
       searchText: `${displayName} ${skill.name} ${skill.description || ""} ${skill.path} ${displayPath}`.trim(),
@@ -280,6 +350,7 @@ export function buildUnifiedSkillRows(
   managedSkills: SkillIndex[],
   loadedSkills: LoadedSkillRow[],
   selectedSkillIds = new Set<string>(),
+  sortMode: SkillSortMode = "updated",
 ): SkillModalRow[] {
   const managedRows = buildSkillRows(managedSkills, selectedSkillIds);
   const managedPathKeys = new Set(managedRows.map((row) => normalizePathForKey(row.path)));
@@ -308,12 +379,7 @@ export function buildUnifiedSkillRows(
     });
   }
 
-  return [...managedRows, ...externalRows]
-    .sort((a, b) => {
-      const byCategory = categoryOrder(a.category) - categoryOrder(b.category);
-      if (byCategory !== 0) return byCategory;
-      return a.displayName.localeCompare(b.displayName);
-    });
+  return [...managedRows, ...externalRows].sort((a, b) => compareSkillRows(a, b, sortMode));
 }
 
 export function filterSkillRows(rows: SkillModalRow[], query: string): SkillModalRow[] {
@@ -534,8 +600,9 @@ export class SkillsManagerModal implements Focusable {
   private activeFilters: SkillCategoryFilters = { ...DEFAULT_SKILL_FILTERS };
   private pendingFilters: SkillCategoryFilters | null = null;
   private filterCursor = 0;
+  private sortMode: SkillSortMode = "updated";
   private summaryLines: string[] = [
-    "Select skills with space, then move with g/p or delete with d. Press f for filters.",
+    "Select skills with space, then move with g/p or delete with d. Press s to change sort and f for filters.",
   ];
 
   constructor(
@@ -573,9 +640,11 @@ export class SkillsManagerModal implements Focusable {
           name: row.name,
           displayName: row.displayName,
           description: row.description,
+          created: row.created ?? "",
+          updated: row.updated ?? "",
         }));
 
-    this.rows = buildUnifiedSkillRows(this.managedSkills, this.loadedSkills, selectedSkillIds);
+    this.rows = buildUnifiedSkillRows(this.managedSkills, this.loadedSkills, selectedSkillIds, this.sortMode);
     this.syncSearchFocus();
   }
 
@@ -632,7 +701,7 @@ export class SkillsManagerModal implements Focusable {
 
   private setRows(managedSkills: SkillIndex[], retainSelectedSkillIds: string[] = [], focusSkillId?: string): void {
     this.managedSkills = managedSkills;
-    this.rows = buildUnifiedSkillRows(this.managedSkills, this.loadedSkills, new Set(retainSelectedSkillIds));
+    this.rows = buildUnifiedSkillRows(this.managedSkills, this.loadedSkills, new Set(retainSelectedSkillIds), this.sortMode);
     this.syncQueryFromInput();
 
     const rows = this.filteredRows;
@@ -684,6 +753,34 @@ export class SkillsManagerModal implements Focusable {
       row.selected = false;
     }
     this.summaryLines = ["Cleared all selections."];
+    this.tui.requestRender();
+  }
+
+  private cycleSortMode(): void {
+    this.sortMode = nextSortMode(this.sortMode);
+    const selectedIds = this.getSelectedIds();
+    const currentRow = this.getCurrentRow();
+    this.rows = buildUnifiedSkillRows(
+      this.managedSkills,
+      this.loadedSkills,
+      new Set(selectedIds),
+      this.sortMode,
+    );
+    this.syncQueryFromInput();
+
+    const rows = this.filteredRows;
+    if (rows.length === 0) {
+      this.selectedIndex = 0;
+    } else if (currentRow) {
+      const focusIndex = rows.findIndex((row) => row.skillId === currentRow.skillId);
+      this.selectedIndex = focusIndex >= 0
+        ? focusIndex
+        : Math.min(this.selectedIndex, rows.length - 1);
+    } else {
+      this.selectedIndex = Math.min(this.selectedIndex, rows.length - 1);
+    }
+
+    this.summaryLines = [`Sort mode: ${sortModeLabel(this.sortMode)}.`];
     this.tui.requestRender();
   }
 
@@ -943,6 +1040,10 @@ export class SkillsManagerModal implements Focusable {
       this.openFilterPanel();
       return;
     }
+    if (data === MEMORY_SKILLS_KEYMAP.cycleSort) {
+      this.cycleSortMode();
+      return;
+    }
 
     if (matchesKey(data, Key.tab) || matchesKey(data, Key.slash)) {
       this.focusSearchWithOptionalInput();
@@ -998,7 +1099,7 @@ export class SkillsManagerModal implements Focusable {
       this.promptDelete();
       return;
     }
-    if (this.isPrintableInput(data) && !["g", "p", "d", "a", "n", "f"].includes(data)) {
+    if (this.isPrintableInput(data) && !["g", "p", "d", "a", "n", "f", "s"].includes(data)) {
       this.focusSearchWithOptionalInput(data);
     }
   }
@@ -1076,7 +1177,7 @@ export class SkillsManagerModal implements Focusable {
     lines.push(this.renderFramedLine(
       this.theme.fg(
         "dim",
-        `${filteredRows.length} visible · ${this.rows.length} total · ${selectedCount} selected${this.busy ? " · working…" : ""}`,
+        `${filteredRows.length} visible · ${this.rows.length} total · ${selectedCount} selected · sort: ${sortModeLabel(this.sortMode)}${this.busy ? " · working…" : ""}`,
       ),
       safeWidth,
     ));
@@ -1141,8 +1242,8 @@ export class SkillsManagerModal implements Focusable {
     const help = this.pendingDeleteConfirm
       ? "Confirm delete: y yes · n no · esc cancel"
       : this.callbacks.projectName
-        ? "↑↓ move · space select · / search · f filters · tab switch · g global · p project · d delete · a all · n none · esc close"
-        : "↑↓ move · space select · / search · f filters · tab switch · g global · p project (disabled) · d delete · a all · n none · esc close";
+        ? "↑↓ move · space select · / search · s sort · f filters · tab switch · g global · p project · d delete · a all · n none · esc close"
+        : "↑↓ move · space select · / search · s sort · f filters · tab switch · g global · p project (disabled) · d delete · a all · n none · esc close";
     lines.push(this.renderFramedLine(this.theme.fg("dim", help), safeWidth));
 
     if (this.focusArea === "filters") {

--- a/src/store/skill-store.ts
+++ b/src/store/skill-store.ts
@@ -253,6 +253,8 @@ export class SkillStore {
     }
 
     return skills.sort((a, b) => {
+      if (a.updated !== b.updated) return b.updated.localeCompare(a.updated);
+      if (a.created !== b.created) return b.created.localeCompare(a.created);
       if (a.scope !== b.scope) return a.scope.localeCompare(b.scope);
       return (a.displayName || a.name).localeCompare(b.displayName || b.name);
     });
@@ -790,6 +792,8 @@ export class SkillStore {
       name: doc.name,
       displayName: doc.displayName,
       description: doc.description,
+      created: doc.created,
+      updated: doc.updated,
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,6 +126,10 @@ export interface SkillIndex {
   displayName?: string;
   /** Short description shown in skill listings */
   description: string;
+  /** ISO date created */
+  created: string;
+  /** ISO date last updated */
+  updated: string;
 }
 
 export interface SkillDocument extends SkillIndex {
@@ -133,10 +137,6 @@ export interface SkillDocument extends SkillIndex {
   body: string;
   /** Version number */
   version: number;
-  /** ISO date created */
-  created: string;
-  /** ISO date last updated */
-  updated: string;
 }
 
 export interface SkillResult {

--- a/tests/handlers/skills-command.test.ts
+++ b/tests/handlers/skills-command.test.ts
@@ -23,6 +23,8 @@ const SAMPLE_SKILLS: SkillIndex[] = [
     name: "debug-typescript-errors",
     displayName: "Debug TypeScript Errors",
     description: "Trace compiler issues step by step",
+    created: "2026-05-19",
+    updated: "2026-05-21",
   },
   {
     skillId: "project:demo-project:deploy-checklist",
@@ -33,6 +35,34 @@ const SAMPLE_SKILLS: SkillIndex[] = [
     name: "deploy-checklist",
     displayName: "Deploy Checklist",
     description: "Project release checklist",
+    created: "2026-05-18",
+    updated: "2026-05-20",
+  },
+];
+
+const SORT_MODE_SKILLS: SkillIndex[] = [
+  {
+    skillId: "global:zebra-runbook",
+    scope: "global",
+    fileName: "SKILL.md",
+    path: "/tmp/global/zebra-runbook/SKILL.md",
+    name: "zebra-runbook",
+    displayName: "Zebra Runbook",
+    description: "Older creation date, newer update date",
+    created: "2026-05-18",
+    updated: "2026-05-21",
+  },
+  {
+    skillId: "project:demo-project:alpha-checklist",
+    scope: "project",
+    fileName: "SKILL.md",
+    path: "/tmp/project/alpha-checklist/SKILL.md",
+    projectName: "demo-project",
+    name: "alpha-checklist",
+    displayName: "Alpha Checklist",
+    description: "Newer creation date, older update date",
+    created: "2026-05-22",
+    updated: "2026-05-20",
   },
 ];
 
@@ -109,6 +139,29 @@ describe("skills command helpers", () => {
     assert.ok(external);
     assert.strictEqual(external?.mutable, false);
     assert.ok(external?.displayPath.includes(".agents"));
+  });
+
+  it("buildUnifiedSkillRows keeps managed skills sorted by updated recency", () => {
+    const loaded = collectLoadedSkillsFromCommands(LOADED_SKILL_COMMANDS as any);
+    const rows = buildUnifiedSkillRows(SAMPLE_SKILLS, loaded);
+
+    assert.strictEqual(rows[0]?.skillId, "global:debug-typescript-errors");
+    assert.strictEqual(rows[1]?.skillId, "project:demo-project:deploy-checklist");
+    assert.strictEqual(rows[2]?.category, "E");
+  });
+
+  it("buildUnifiedSkillRows can sort by created date or name", () => {
+    const loaded = collectLoadedSkillsFromCommands(LOADED_SKILL_COMMANDS as any);
+
+    const createdRows = buildUnifiedSkillRows(SORT_MODE_SKILLS, loaded, new Set<string>(), "created");
+    assert.strictEqual(createdRows[0]?.skillId, "project:demo-project:alpha-checklist");
+    assert.strictEqual(createdRows[1]?.skillId, "global:zebra-runbook");
+
+    const nameRows = buildUnifiedSkillRows(SORT_MODE_SKILLS, loaded, new Set<string>(), "name");
+    assert.strictEqual(nameRows[0]?.skillId, "project:demo-project:alpha-checklist");
+    assert.strictEqual(nameRows[1]?.displayName, "debug-typescript-errors");
+    assert.strictEqual(nameRows[2]?.displayName, "langgraph-fundamentals");
+    assert.strictEqual(nameRows[3]?.skillId, "global:zebra-runbook");
   });
 
   it("moveSelectedSkills blocks project moves without an active project", async () => {
@@ -464,6 +517,39 @@ describe("SkillsManagerModal", () => {
     const output = modal.render(120).join("\n");
     assert.ok(output.includes("langgraph-fundamentals"));
     assert.ok(!output.includes("Deploy Checklist"));
+  });
+
+  it("cycles sort mode with s and shows the active mode in the modal", () => {
+    const harness = createModalHarness();
+    const loaded = collectLoadedSkillsFromCommands(LOADED_SKILL_COMMANDS as any);
+    const rows = buildUnifiedSkillRows(SORT_MODE_SKILLS, loaded);
+
+    const modal = new SkillsManagerModal(
+      harness.tui as any,
+      harness.theme as any,
+      rows,
+      {
+        moveSelected: async () => ({ skills: SORT_MODE_SKILLS, summaryLines: ["done"] }),
+        deleteSelected: async () => ({ skills: SORT_MODE_SKILLS, summaryLines: ["done"] }),
+        close: () => undefined,
+        projectName: "demo-project",
+      },
+      { managedSkills: SORT_MODE_SKILLS, loadedSkills: loaded },
+    );
+
+    let output = modal.render(120).join("\n");
+    assert.ok(output.includes("sort: Updated"));
+    assert.ok(output.includes("Zebra Runbook"));
+
+    modal.handleInput("s");
+    output = modal.render(120).join("\n");
+    assert.ok(output.includes("sort: Created"));
+    assert.ok(output.includes("Sort mode: Created."));
+
+    modal.handleInput("s");
+    output = modal.render(120).join("\n");
+    assert.ok(output.includes("sort: Name"));
+    assert.ok(output.includes("Alpha Checklist"));
   });
 
   it("blocks external skill mutations as read-only", async () => {

--- a/tests/store/skill-store.test.ts
+++ b/tests/store/skill-store.test.ts
@@ -264,6 +264,41 @@ describe("SkillStore", { concurrency: 1 }, () => {
       const index = await store.loadIndex();
       assert.deepStrictEqual(index, []);
     });
+
+    it("sorts skills by updated date descending, then created date descending", async () => {
+      const store = await makeStore();
+      const olderDir = path.join(GLOBAL_SKILLS_DIR, "older-skill");
+      const newerDir = path.join(GLOBAL_SKILLS_DIR, "newer-skill");
+      await fs.mkdir(olderDir, { recursive: true });
+      await fs.mkdir(newerDir, { recursive: true });
+      await fs.writeFile(path.join(olderDir, "SKILL.md"), [
+        "---",
+        'name: "older-skill"',
+        'description: "Older skill"',
+        "version: 2",
+        'created: "2026-05-18"',
+        'updated: "2026-05-20"',
+        "---",
+        "## Procedure",
+        "1. Old",
+      ].join("\n"), "utf-8");
+      await fs.writeFile(path.join(newerDir, "SKILL.md"), [
+        "---",
+        'name: "newer-skill"',
+        'description: "Newer skill"',
+        "version: 1",
+        'created: "2026-05-19"',
+        'updated: "2026-05-21"',
+        "---",
+        "## Procedure",
+        "1. New",
+      ].join("\n"), "utf-8");
+
+      const index = await store.loadIndex("global");
+      assert.strictEqual(index[0]?.skillId, "global:newer-skill");
+      assert.strictEqual(index[1]?.skillId, "global:older-skill");
+      assert.ok(index[0]!.updated >= index[1]!.updated);
+    });
   });
 
   describe("loadSkill()", () => {


### PR DESCRIPTION
## Summary
- sort extension-managed skills in `/memory-skills` by `updated` desc, then `created` desc by default
- add an in-modal `s` key to cycle sort mode between Updated, Created, and Name
- show the active sort mode in the modal status line and help text

## Why
This is a follow-up to the skill review feedback in #32 around making newer or recently touched skills easier to find and review.

## Testing
- npm run check
- npx tsx --test tests/handlers/skills-command.test.ts tests/store/skill-store.test.ts
