### PR TITLE
feat: add 5 skills to npm package with pi.skills manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "src",
     "README.md",
     "LICENSE",
-    "docs"
+    "docs",
+    "skills"
   ],
   "pi": {
     "extensions": [
@@ -58,5 +59,12 @@
   "dependencies": {
     "@earendil-works/pi-tui": "^0.74.0",
     "better-sqlite3": "^12.9.0"
-  }
+  },
+  "pi.skills": [
+    "skills/adr-recorder/SKILL.md",
+    "skills/prd-writer/SKILL.md",
+    "skills/project-architect/SKILL.md",
+    "skills/release-prepper/SKILL.md",
+    "skills/roadmap-planner/SKILL.md"
+  ]
 }

--- a/skills/adr-recorder/SKILL.md
+++ b/skills/adr-recorder/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: adr-recorder
+description: Write Architecture Decision Records (ADRs) using the MADR template. Use when the user makes a significant technical decision (framework choice, database, deployment platform, architecture pattern, library selection) and wants it documented for future reference. ADRs answer "why did we do this?" months later.
+metadata:
+  version: 2
+  created: "2026-05-19"
+  updated: "2026-05-19"
+  changelog: "v2 — Frontmatter cleanup: non-standard fields (version/created/updated) moved under metadata per pi spec."
+---
+# ADR Recorder — Architecture Decision Record Skill
+
+Use this skill when a meaningful technical decision is made and should be documented for future reference.
+
+## When to Use
+
+- "Bu kararı dokümante et"
+- "ADR yaz"
+- "Niye X seçtik?" sorusunun cevabını kaydet
+- Framework / library / platform / pattern seçimi yapıldığında
+- "Geri dönmek zor olan" kararlar (DB schema, public API, etc.)
+- Onaydan sonra mimari kararı çıkışı sonrası
+
+**NOT for:**
+- Küçük kod kararları (variable naming, etc.)
+- Geçici kararlar / experiment'ler
+- Bireysel tercihler (renk seçimi, vs.)
+
+## Procedure
+
+### Phase 1 — Sanity Check
+
+Karar gerçekten ADR'lik mi? Kriterler:
+- Geri dönmek pahalı (zaman/para/kod)
+- Birden fazla seçenek vardı
+- Birinden vazgeçildi
+- 6 ay sonra "neden böyle yaptık?" sorusu sorulabilir
+
+Eğer hayır: kullanıcıya söyle, ADR yerine `PLANNING-LOG.md`'ye satır eklemeyi öner.
+
+### Phase 2 — ADR Numarası
+
+`docs/adr/` klasöründe en yüksek numarayı bul, +1 al.
+- Format: `0001-kebab-case-title.md`
+- Örnek: `0001-flutter-over-react-native.md`
+
+### Phase 3 — MADR Template (Markdown ADR)
+
+```markdown
+# <Numara>. <Karar Başlığı>
+
+**Status:** Proposed / Accepted / Deprecated / Superseded by [<link>](...)
+**Date:** YYYY-MM-DD
+**Deciders:** <isimler>
+**Tags:** <stack / data / infra / process>
+
+## Context and Problem Statement
+
+Neden bu kararı vermek zorundaydık? Sorunu 2-4 cümle açıkla.
+"Şunu yapmak istedik ama X, Y, Z arasında seçim yapmak gerekti."
+
+## Decision Drivers
+
+Karar verirken neye baktık?
+- Driver 1: ...
+- Driver 2: ...
+- Driver 3: ...
+
+## Considered Options
+
+1. **Option A** — kısa açıklama
+2. **Option B** — kısa açıklama
+3. **Option C** — kısa açıklama
+
+## Decision Outcome
+
+**Chosen option:** "Option B"
+
+**Reasoning:** Neden bu seçildi (2-4 paragraf).
+
+## Pros and Cons of the Options
+
+### Option A
+- ✅ Pro 1
+- ✅ Pro 2
+- ❌ Con 1
+- ❌ Con 2
+
+### Option B ← Chosen
+- ✅ Pro 1
+- ✅ Pro 2
+- ✅ Pro 3
+- ❌ Con 1 (kabul ediyoruz)
+
+### Option C
+- ✅ Pro 1
+- ❌ Con 1
+- ❌ Con 2
+
+## Consequences
+
+**Positive:**
+- ...
+
+**Negative (kabul edilen tradeoffs):**
+- ...
+
+**Neutral:**
+- ...
+
+## Implementation Notes
+
+Bu kararı uygulamak için gereken adımlar (eğer ADR + immediate action):
+- Step 1
+- Step 2
+
+## References
+
+- [Link to related ADR]
+- [Link to relevant article / docs]
+- [Link to discussion]
+
+## Validation / Revisit Trigger
+
+Bu kararı ne zaman tekrar gözden geçirmeli?
+- "Eğer X olursa ADR'i revize et"
+- "6 ay sonra retrospect"
+- "Çapraz-platform iOS perf metriği < hedef olursa"
+```
+
+### Phase 4 — Common ADR Topics
+
+Proje boyunca tipik olarak yazılan ADR'ler:
+
+**Tech stack:**
+- 0001: Frontend framework seçimi (Flutter vs RN vs native)
+- 0002: State management (Riverpod vs BLoC vs Provider)
+- 0003: Database (SQLite vs Hive vs ObjectBox)
+- 0004: Backend platform (Supabase vs Firebase vs custom)
+
+**Architecture:**
+- 00XX: Monorepo vs polyrepo
+- 00XX: Clean Architecture vs MVVM
+- 00XX: Content as JSON vs CMS
+
+**Process:**
+- 00XX: Conventional Commits adoption
+- 00XX: Semver scheme (especially in monorepo)
+- 00XX: CI/CD platform choice
+
+**Infrastructure:**
+- 00XX: Hosting (Cloudflare vs Vercel vs Fly)
+- 00XX: Deep link service (Firebase Dynamic Links sunset → alternative)
+- 00XX: Analytics (PostHog vs Mixpanel vs Firebase)
+
+### Phase 5 — Output
+
+- Dosya yolu: `docs/adr/<NNNN>-<kebab-title>.md`
+- Tek dosya per karar
+- Status başlangıçta "Accepted" (eğer onaylanmış karar) veya "Proposed" (tartışılıyor)
+- `docs/adr/README.md` varsa onu da güncelle (index)
+
+### Phase 6 — Optional: ADR Index
+
+Eğer `docs/adr/README.md` yoksa, ilk ADR'le birlikte oluştur:
+
+```markdown
+# Architecture Decision Records
+
+This directory contains ADRs (Architecture Decision Records) documenting significant technical decisions made in this project.
+
+## What is an ADR?
+
+An ADR captures a decision, its context, and consequences. The goal: 6 months from now, anyone can answer "why did we do this?" by reading the ADR.
+
+## Status Lifecycle
+
+- **Proposed** — Under discussion
+- **Accepted** — Decided, in effect
+- **Deprecated** — No longer recommended, but not yet replaced
+- **Superseded** — Replaced by another ADR (link to new one)
+
+## Index
+
+| # | Title | Status | Date |
+|---|---|---|---|
+| [0001](./0001-flutter-over-react-native.md) | Flutter over React Native | Accepted | 2026-05-19 |
+| ... | ... | ... | ... |
+```
+
+## Pitfalls
+
+- ❌ Her küçük kararı ADR yapmak → ADR enflasyonu, kimse okumaz
+- ❌ "Sonra yazarım" → asla yazılmaz, karar bağlamı kaybolur
+- ❌ Sadece "chosen option" yazıp diğer opsiyonları atlamak → "neden A değil?" sorusu yanıtsız kalır
+- ❌ Pros'u yazıp con'ları atlamak → dürüstlük kaybı, tradeoff gizlenir
+- ❌ Eski ADR'i silmek → "Superseded by" link'ler kopar, history kaybolur
+- ❌ Status alanını boş bırakmak → ADR live mı dead mi belirsiz
+- ❌ ADR'leri 100+ satır yapmak → kimse okumaz, 30-80 satır ideal
+
+## Verification
+
+- [ ] ADR numarası doğru sıralı mı?
+- [ ] Status alanı var mı?
+- [ ] En az 2 alternatif değerlendirildi mi?
+- [ ] Her option'ın pros + cons'ı var mı?
+- [ ] Consequences negative'leri açıkça yazıldı mı?
+- [ ] References bölümü var mı (en az 1)?
+- [ ] Revisit trigger tanımlı mı?
+- [ ] `docs/adr/README.md` index'i güncellendi mi?
+
+## Example Triggers
+
+User: "Flutter'ı seçtik, kaydet" → 0001 ADR yaz, MADR template ile.
+
+User: "Supabase vs Firebase'i karşılaştırıp karar verelim" → Hemen ADR'in Proposed versiyonunu yaz, kullanıcı kararından sonra Accepted yap.
+
+User: "Eski deep link kararı artık geçersiz" → İlgili ADR'i bul, Status'unu "Deprecated" yap. Yeni karar için yeni ADR aç, "Supersedes 00XX" referansını koy.

--- a/skills/prd-writer/SKILL.md
+++ b/skills/prd-writer/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: prd-writer
+description: Write professional Product Requirements Documents (PRDs). Use when the user asks for a PRD, product spec, feature spec, requirements document, user stories, or wants to define what an app/feature should do (vs how it's built). Complements project-architect skill — PRD is "what & why", architecture is "how".
+metadata:
+  version: 2
+  created: "2026-05-19"
+  updated: "2026-05-19"
+  changelog: "v2 — Frontmatter cleanup: non-standard fields (version/created/updated) moved under metadata per pi spec."
+---
+# PRD Writer — Product Requirements Document Skill
+
+Use this skill whenever the user asks for product requirements, feature specifications, or wants to define what a product DOES (not how it's built).
+
+## When to Use
+
+- "PRD yaz" / "write a PRD"
+- "Feature spec / requirements"
+- "User stories"
+- "Product definition"
+- "MVP scope"
+- "Bu app neyi yapacak?"
+
+**NOT for:**
+- Architecture / tech stack (use `project-architect` skill)
+- Sprint planning / timeline (use `roadmap-planner` skill)
+
+## Procedure
+
+### Phase 1 — Discovery
+
+Önce mevcut dokümantasyonu oku (varsa `PLANNING-LOG.md`, `ARCHITECTURE.md`). Sonra eksik kalan yerleri sor:
+
+**Vision & Goals**
+- Tek cümle: bu ürün ne yapıyor?
+- Hedef kitle kim? (persona)
+- 6 ayda başarı nedir? (1 metric)
+
+**Problem & Solution**
+- Hangi problemi çözüyor?
+- Şu an insanlar nasıl çözüyor? (alternatives)
+- Bizimki neden daha iyi? (differentiation)
+
+**Scope & Constraints**
+- MVP'de NE VAR? (must-have)
+- MVP'de NE YOK? (out-of-scope) — bu kritik
+- Hard constraints (offline, multi-lang, etc.)
+
+### Phase 2 — PRD Sections (Standart Şablon)
+
+```markdown
+# <Product Name> — PRD
+
+**Owner:** <kim>
+**Status:** Draft / In Review / Approved
+**Version:** 1.0
+**Last updated:** <tarih>
+
+## 1. TL;DR (One Paragraph Summary)
+2-3 cümle. Ne, kim için, neden.
+
+## 2. Problem Statement
+- Pain point #1
+- Pain point #2
+- Mevcut çözümler ve eksikleri
+
+## 3. Goals & Non-Goals
+**Goals:** (3-5 madde)
+- ...
+
+**Non-Goals (MVP'de yok):** (3-5 madde)
+- ...
+
+## 4. Target Audience
+**Primary persona:**
+- Yaş, meslek, ilgi alanı, dil
+- Günlük hayatı / "day in the life"
+- App'i ne zaman, nerede, nasıl kullanır?
+
+**Secondary persona (varsa):** ...
+
+## 5. User Stories
+Format: "As a <user>, I want <action>, so that <benefit>."
+
+### Epic 1: <Theme>
+- Story 1.1: ...
+- Story 1.2: ...
+
+### Epic 2: <Theme>
+- ...
+
+Her story için Acceptance Criteria yaz (Given/When/Then formatı).
+
+## 6. Feature List (MVP)
+
+| # | Feature | Priority | Effort | Notes |
+|---|---|---|---|---|
+| F1 | <ad> | Must / Should / Could | S/M/L | ... |
+
+Priority sistem: MoSCoW (Must / Should / Could / Won't).
+Effort: T-shirt sizing (XS/S/M/L/XL).
+
+## 7. User Flow Diagrams
+ASCII art ile critical path flow'ları:
+- Onboarding
+- Core action (e.g. "tarot okuma")
+- Sharing / monetization
+
+## 8. Functional Requirements
+Her feature için:
+- Inputs (kullanıcıdan ne alır)
+- Behaviors (ne yapar)
+- Outputs (ne döner)
+- Edge cases (boş veri, network kapalı, vb.)
+
+## 9. Non-Functional Requirements
+- Performance: First paint < 2s, action latency < 200ms
+- Offline: Hangi feature internet'siz çalışır?
+- Accessibility: WCAG AA seviyesi mi?
+- Localization: Hangi diller, RTL var mı?
+- Privacy: Hangi veri toplanır, opt-out var mı?
+- Security: Auth gerekli mi, data encryption?
+
+## 10. Content & Data Requirements
+- İçerik miktarı (örn. 78 kart × 4 dil = 312 metin)
+- İçerik formatı (JSON, MD, DB)
+- İçerik kaynağı (manuel, AI-generated, scraped)
+- Update sıklığı
+
+## 11. Success Metrics
+**North star:** (tek metric)
+
+**Supporting metrics:**
+- DAU / MAU
+- Day-7 retention
+- Average session length
+- Share rate
+- Ad revenue per DAU
+
+## 12. Monetization
+- Free tier ne içerir?
+- Paid tier(s) ne ekler?
+- Pricing strategy (price anchor, geo-pricing)
+- Conversion funnel
+
+## 13. Risks & Open Questions
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| ... | H/M/L | H/M/L | ... |
+
+## 14. Out of Scope (Açıkça)
+MVP'de NE OLMAYACAK — listele. Bu beklenti yönetimi için kritik.
+
+## 15. Future Considerations
+- Faz 2'de eklenebilecek özellikler
+- Faz 3+ vizyonu
+- "Sonra düşünürüz" listesi
+
+## 16. Appendix
+- Glossary
+- Referanslar
+- Competitive analysis (rakipler tablosu)
+```
+
+### Phase 3 — Writing Guidelines
+
+- **User story formatı**: "As a / I want / So that" — sapma yok
+- **Acceptance criteria**: Given/When/Then — her story için
+- **MoSCoW priority**: Must > Should > Could > Won't (asla "high/medium/low" deme — belirsiz)
+- **Out-of-scope açıkça yaz**: "Yapmayacağımız" şeyler kazaen yapılmamak için
+- **Metrics önce, feature sonra**: Her feature'ı bir metrice bağla
+- **Tabloyla zenginleştir**: Düz paragraf yorucu
+- **Uzunluk hedefi**: 400-800 satır markdown (15-30 KB)
+
+### Phase 4 — Output
+
+- Dosya yolu: `docs/PRD.md`
+- Status başlangıçta "Draft", kullanıcı onayından sonra "Approved"
+- Sonunda kullanıcıya 3-5 onaylama sorusu sor (en kritik kararlar için)
+
+## Pitfalls
+
+- ❌ "How" sorularına girmek → bu PRD değil architecture, başka skill'e bırak
+- ❌ Tüm feature'lara "Must" demek → MoSCoW priority anlamsızlaşır, max %60 Must olabilir
+- ❌ User story yerine technical task yazmak → "Implement login button" ❌ vs "As a user I want to log in" ✅
+- ❌ Out-of-scope'u atlamak → kapsama kaymadan ölür
+- ❌ Success metrics olmadan PRD → "ne zaman kazandık" belirsiz
+- ❌ Multiple persona'yı birleştirmek → her persona ayrı yazılır
+- ❌ Localization, offline, accessibility'i unutmak → Non-functional req'de zorunlu
+
+## Verification
+
+- [ ] TL;DR 3 cümleden kısa mı?
+- [ ] En az 1 primary persona detaylı mı?
+- [ ] Her epic'in en az 3 user story'si var mı?
+- [ ] Her story'nin acceptance criteria'sı var mı?
+- [ ] MoSCoW priority dağılımı dengeli mi?
+- [ ] Out-of-scope bölümü en az 5 madde mi?
+- [ ] Success metrics ölçülebilir mi?
+- [ ] Risks tablosunda mitigation var mı?
+- [ ] Open questions kullanıcıya açıkça sorulmuş mu?
+
+## Example Triggers
+
+User: "PRD yaz" → Önce `ARCHITECTURE.md` ve `PLANNING-LOG.md` oku, sonra eksiklikleri sor.
+
+User: "Bu app'in feature listesini çıkar" → PRD'nin Section 6'sından başla, ama tüm PRD bağlamını koru.
+
+User: "User stories yaz" → Tam PRD'ye gerek yok, sadece Section 5'i detaylı doldur, geri kalanı atla.

--- a/skills/project-architect/SKILL.md
+++ b/skills/project-architect/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: project-architect
+description: Produce professional-grade ARCHITECTURE.md documents for software projects. Use when the user requests a system architecture, technical design document, infrastructure plan, or wants to scaffold a new project's foundation. Covers mobile, web, backend, data pipelines, and multi-app/monorepo projects. Adapts depth (Lite vs Full) to team size and project ambition.
+metadata:
+  version: 2
+  created: "2026-05-19"
+  updated: "2026-05-19"
+  changelog: "v2 — Added Lite (8-section) vs Full (17-section) modes. Added Phase 5 PLANNING-LOG handoff so downstream skills (prd-writer, roadmap-planner) don't re-ask the same questions."
+---
+
+# Project Architect — Professional Architecture Document Skill
+
+Use this skill whenever the user asks for an architecture document, system design, technical foundation, or wants to plan how a new project will be built.
+
+## When to Use
+
+- "Bana mimari çıkar" / "draw the architecture"
+- "Project foundation plan" / "system design"
+- "Hangi tech stack'ı kullanmalıyım?" + birden fazla bağlamlı soru
+- "Multi-app / monorepo design"
+- "ARCHITECTURE.md yaz"
+- New greenfield project planning
+- Refactoring an existing project into a cleaner structure
+
+## Procedure
+
+### Phase 1 — Discovery (clarifying questions)
+
+NEVER skip this. Ask 5-10 targeted questions BEFORE writing anything. Group by concern:
+
+**Product context**
+- Who is the user / niche?
+- Single product or family of products?
+- Target platforms (web/mobile/desktop)?
+- Online/offline requirements?
+- Monetization model?
+
+**Technical context**
+- Existing code/assets to migrate?
+- Team size (solo / small / large)?
+- Skill background (which langs/frameworks)?
+- Budget (free tier / paid services OK)?
+- Timeline (weeks / months / years)?
+
+**Scale & constraints**
+- Expected user base (10 / 10K / 1M)?
+- Multi-language / multi-region?
+- Compliance (GDPR / HIPAA / app store policies)?
+- Real-time requirements?
+
+If user already provided context (previous docs like PLANNING-LOG.md), READ those first and only ask gaps.
+
+### Phase 2 — Pick Mode (Lite vs Full)
+
+Discovery cevaplarına bakarak mode seç:
+
+| Sinyal | Mode |
+|---|---|
+| Solo dev, hobby/side project, MVP < 12 hafta, tek platform | **Lite** (8 bölüm) |
+| Solo dev, ciddi ürün hedefi, multi-platform veya multi-product | **Full** (17 bölüm) |
+| Takım (2+), production hedef, ARR/revenue planı | **Full** (17 bölüm) |
+| Refactor / migration on existing codebase | **Full** (17 bölüm) |
+| Library / SDK / single-purpose tool | **Lite** (8 bölüm) |
+
+Mode'u kullanıcıya **söyle**: "Sinyallere bakınca Lite mode öneriyorum — solo + MVP. Full ister misin?" Karar onun.
+
+### Phase 3a — Architecture Document Sections (Lite mode)
+
+Lite mode 8 bölümden oluşur — solo / hobby / first-time projeler için:
+
+1. **Architectural Principles** — 5-7 ilke, kısa
+2. **High-level System Diagram** — Tek bir ASCII diagram, katmanlar
+3. **Repo / Folder Structure** — Klasör tree, her satır yorumlu
+4. **Tech Stack & Why** — Dil, framework, kütüphane seçimi + gerekçe
+5. **Critical Path Flow** — Projenin ana feature'ı için end-to-end akış
+6. **Test Strategy** — Minimum: hangi katmanda test, coverage hedefi
+7. **Cost Structure** — Aylık maliyet tablosu (MVP / launch)
+8. **Open Questions / Next Steps** — Architect onayından sonra ne gelir
+
+### Phase 3b — Architecture Document Sections (Full mode)
+
+Full mode 17 bölüm:
+
+1. **Architectural Principles** — 8-12 ilke, "ne yaptığını" değil "neden böyle" açıklar
+2. **High-level System Diagram** — ASCII art ile katmanlar (user → app → core → data → cloud)
+3. **Repo / Folder Structure** — Tüm dosya/klasör tree, her satır yorumlu
+4. **Internal App Architecture** — Clean Architecture / Hexagonal / MVC etc. layers
+5. **State Management** — Hangi pattern, neden seçildi
+6. **Data Model** — Entity diyagramları
+7. **Critical Path Flow** — Projenin "kalp" feature'ı için end-to-end pipeline
+8. **Build & Release Pipeline** — Local → CI → Release
+9. **Environment & Secret Management** — `.env`, secrets bucket
+10. **Test Strategy** — Test pyramid, coverage hedefleri
+11. **Cost Structure** — Aylık maliyet tablosu (MVP / launch / scale)
+12. **Phased Activation** — Hangi katman ne zaman devreye girer
+13. **Professional Discipline Checklist** — ADR, CHANGELOG, semver, branch protection
+14. **Replication / Templating** — Yeni instance/niş eklemek nasıl?
+15. **Domain Boundaries** — App-specific vs shared vs content
+16. **Risks & Tradeoffs** — Her ana kararın downside'ı
+17. **Open Questions / Next Steps** — Architect onayından sonra ne gelir
+
+### Phase 4 — Writing Guidelines
+
+- **Markdown formatı**: GitHub-flavored Markdown, tablolar bol
+- **Diyagramlar**: ASCII art kullan (Mermaid'e fallback yapma — her platformda render olmayabilir)
+- **Maliyet tabloları**: Mutlaka rakam ver, "az / orta / çok" değil
+- **Karar gerekçelendirmesi**: "X seçildi" yetmez, "Y yerine X seçildi çünkü..." de
+- **Tradeoff açıkça yazılır**: Her kararın bir bedeli var, sakla
+- **"Senior tech lead" tonu**: Profesyonel ama erişilebilir, jargon kullan ama anlamı açıkla
+- **Tekrar etmek YOK**: Aynı bilgi 2 yerde varsa biri silinir veya cross-reference verilir
+- **Uzunluk hedefi**:
+  - Lite: 300-600 satır (10-25 KB)
+  - Full: 800-1500 satır (35-60 KB)
+
+### Phase 5 — Output + Handoff
+
+**Output:**
+- Dosya yolu: `docs/ARCHITECTURE.md` (proje kökünde)
+- Tek dosya, başka split yok
+- Sonunda "open questions" bölümü ile bitir → kullanıcı karar versin
+
+**Discovery handoff (KRİTİK):**
+Discovery aşamasında topladığın bağlamı `docs/PLANNING-LOG.md`'ye işle. Dosya yoksa oluştur. Bu sayede downstream skill'ler (`prd-writer`, `roadmap-planner`) aynı soruları tekrar sormaz.
+
+Minimum PLANNING-LOG.md formatı:
+
+```markdown
+# <Project Name> — Planning Log
+
+## Discovery Q&A — <YYYY-MM-DD>
+
+### Product context
+- Niche: ...
+- Platforms: ...
+- Monetization: ...
+
+### Technical context
+- Team size: ...
+- Stack: ...
+- Timeline: ...
+
+### Confirmed decisions
+| # | Decision | Date |
+|---|---|---|
+| D1 | <karar> | <tarih> |
+
+### Open actions
+- A1: <ne kalmış>
+```
+
+Eğer PLANNING-LOG zaten varsa, "## Discovery — <bugün>" başlığı altında **append** et, mevcut içeriği silme.
+
+**Caller'a dönüş:**
+Kısa özet (3-5 madde) + iki dosyanın yolu:
+- `docs/ARCHITECTURE.md`
+- `docs/PLANNING-LOG.md`
+
+### Phase 6 — Follow-up Suggestions
+
+Architecture bittikten sonra şunları öner:
+1. `PRD.md` (product requirements) — prd-writer skill'i ile
+2. `ROADMAP.md` (sprint plan) — roadmap-planner skill'i ile
+3. İlk ADR (Architecture Decision Record) — adr-recorder skill'i ile
+4. Repo iskelet scaffold
+
+## Pitfalls
+
+- ❌ Discovery phase'i atlamak → genel/jenerik mimari çıkar
+- ❌ Mode seçmemek / Full'u solo dev'e dayatmak → 17 bölümün yarısı boş kalır
+- ❌ Diyagram yerine sadece bullet list → görsel kayıp
+- ❌ "Bunu sonra düşünürüz" yazmak → ya bölüm tam yazılır ya da çıkarılır
+- ❌ Maliyet kısmında muğlak ifade → her zaman rakam
+- ❌ Tradeoff'ları gizlemek → güven kaybı
+- ❌ "İdeal" mimari sun → bağlam'a uygun mimari sun (solo dev'e enterprise pattern uygunsuz)
+- ❌ Birden fazla output dosyası → ARCHITECTURE.md tek dosyadır, scope creep yapma
+- ❌ Tech stack'ı kullanıcıya sormadan seçmek → her zaman discovery'de sor
+- ❌ Discovery cevaplarını PLANNING-LOG'a yazmamak → sonraki skill'ler aynı soruları tekrar sorar
+
+## Verification
+
+Mimari iyi mi diye kontrol için:
+
+- [ ] Mode (Lite/Full) bilinçli seçildi mi ve kullanıcıya söylendi mi?
+- [ ] Lite'te 8 / Full'da 17 bölümün hepsi var mı (veya gerekçeli olarak atlandı mı)?
+- [ ] Her diyagram ASCII art ile var mı?
+- [ ] Repo yapısında her klasör için yorum var mı?
+- [ ] Maliyet tablosu rakamlı mı?
+- [ ] En az 3 tradeoff açıkça yazıldı mı (Full mode)?
+- [ ] Cross-references çalışıyor mu (örn. "bkz. Section 4")?
+- [ ] "Open questions" bölümü gerçekten kullanıcıdan cevap bekliyor mu?
+- [ ] Lite: 300-600 satır / Full: 800-1500 satır mı?
+- [ ] `docs/PLANNING-LOG.md` discovery cevaplarıyla güncellendi mi?
+
+## Example Triggers
+
+User says: "Yeni bir projeye başlıyorum, mimarisini çıkarır mısın?"
+→ Skill devreye gir, Phase 1 discovery sorularıyla başla.
+
+User says: "Bu Python projesi için Flutter mobil mimarisi nasıl olur?"
+→ Mevcut Python kodunu OKU, sonra Phase 1 discovery yap. Multi-platform + migration → Full mode.
+
+User says: "Küçük bir CLI tool yapacağım, mimari lazım mı?"
+→ Lite mode öner. 8 bölüm yeterli.
+
+User says: "ARCHITECTURE.md yaz"
+→ Hiç soru sormadan başlama. Önce mevcut docs/PLANNING-LOG.md vb. dosyaları oku, sonra eksikleri sor.

--- a/skills/release-prepper/SKILL.md
+++ b/skills/release-prepper/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: release-prepper
+description: Prepare a clean, professional release — bump version, update CHANGELOG, write release notes, tag the commit, and produce a pre-flight checklist. Use when the user says "release", "ship it", "deploy", "yeni versiyon çıkart", "v1.0 hazırla", or wants to follow Keep a Changelog + SemVer discipline. Stack-agnostic; works for web, mobile, backend, libraries, monorepos.
+metadata:
+  version: 2
+  created: "2026-05-19"
+  updated: "2026-05-19"
+  changelog: "v2 — Genericized: tarot/Flutter examples moved to a dedicated 'Concrete Example' section. Procedure body uses <placeholder>s for manifest files and version fields."
+---
+
+# Release Prepper — Clean Release Discipline Skill
+
+Use this skill when preparing any release (alpha, beta, production, hotfix).
+
+## When to Use
+
+- "Yeni sürüm çıkart" / "release et"
+- "v1.0 hazırla"
+- "Store'a / production'a yükleyelim"
+- "CHANGELOG güncelle"
+- "Tag at"
+- Hotfix prep
+
+## Procedure
+
+### Phase 1 — Pre-flight Audit
+
+Önce repo durumunu kontrol et:
+
+```
+1. git status              → working tree clean mi?
+2. git log <last-tag>..HEAD → ne değişmiş?
+3. CI status               → main branch green mi?
+4. CHANGELOG.md            → unreleased changes var mı?
+5. Open issues/PRs         → release-blocker var mı?
+```
+
+Eğer herhangi biri kırmızıysa: kullanıcıya söyle, release'i ertele.
+
+### Phase 2 — Version Bump (SemVer)
+
+```
+MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]
+
+Major (X.0.0)  → Breaking change (kullanıcı için bozucu)
+Minor (1.X.0)  → Yeni feature, geriye uyumlu
+Patch (1.0.X)  → Bug fix only
+
+Prerelease örnekleri: 1.0.0-alpha.1, 1.0.0-beta.3, 1.0.0-rc.1
+```
+
+**Monorepo'da:** Her app + package'in ayrı semver'i. Tag format:
+- `<package>@v1.2.3`
+- `<app>@v0.5.0`
+
+Tek-paket repo'da: `v1.2.3`
+
+**Version dosyaları (stack'e göre değişir, hepsini güncelle):**
+- Node.js / npm: `package.json` → `"version"`
+- Python: `pyproject.toml` veya `__version__`
+- Rust: `Cargo.toml` → `[package].version`
+- Flutter/Dart: `pubspec.yaml` → `version`
+- Mobile (native): Android `versionCode/versionName`, iOS `CFBundleVersion`/`CFBundleShortVersionString`
+- Go: git tag yeterli, ama internal `version.go` varsa güncelle
+- Manifest yoksa: git tag tek kaynak
+
+### Phase 3 — CHANGELOG.md Update
+
+**Keep a Changelog** formatı kullan: https://keepachangelog.com
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Feature in development
+
+## [1.2.0] - 2026-05-19
+### Added
+- <user-visible feature> (#42)
+- <i18n: new locale supported> (#38)
+
+### Changed
+- <behavior change visible to user> (#45)
+
+### Fixed
+- <bug fix> (#41)
+
+### Deprecated
+- <will be removed in v2.0>
+
+### Removed
+- <legacy endpoints>
+
+### Security
+- Updated dependencies to patch CVE-YYYY-XXXX
+```
+
+**Section'lar (sıra önemli):**
+1. **Added** — Yeni feature
+2. **Changed** — Mevcut davranış değişti
+3. **Deprecated** — Kullanımdan kalkacak
+4. **Removed** — Silindi
+5. **Fixed** — Bug fix
+6. **Security** — Güvenlik fix
+
+### Phase 4 — Release Notes (User-Facing)
+
+CHANGELOG technical, release notes user-facing. App store / GitHub release / blog post / email içine girer.
+
+**Generic template:**
+
+```markdown
+# <Product Name> v<X.Y.Z>
+
+**✨ Yeni Bu Sürümde**
+
+- <Feature 1, kullanıcı dilinde>
+- <Feature 2>
+
+**🔧 İyileştirmeler**
+- <Performance / UX iyileştirmesi>
+- <Bug fix, kullanıcının görebileceği şekilde>
+
+**🙏 Teşekkürler**
+- <Beta testers / contributors>
+
+---
+
+Bug bulduysan: <link>
+Görüşler: <social>
+```
+
+**Kurallar:**
+- Emoji kullan (store'da göz yakalar) — eğer marka tonuna uyuyorsa
+- Teknik jargon NO ("refactored shuffle algorithm" → kullanıcı umursamaz)
+- Hangi feature kimin için önemli, sırala
+- Internal change'ler (CI, refactor) release notes'a girmez — CHANGELOG'da kal
+
+### Phase 5 — Pre-Release Checklist
+
+Aşağıdakileri sırayla kontrol et:
+
+```markdown
+## Release Checklist — v<X.Y.Z>
+
+### Code
+- [ ] All PRs merged
+- [ ] main branch CI green
+- [ ] No critical TODOs in code
+- [ ] No `print()` / `console.log()` left in prod paths
+- [ ] No commented-out blocks
+
+### Tests
+- [ ] Unit tests pass
+- [ ] Integration / widget tests pass
+- [ ] Manual smoke test in production-like environment
+
+### Versioning
+- [ ] Manifest version bumped (`<manifest file>`)
+- [ ] Platform-specific build numbers incremented (if applicable)
+- [ ] CHANGELOG.md updated
+- [ ] Migration guide for breaking changes (if any)
+
+### Documentation
+- [ ] README.md current
+- [ ] Release notes written
+- [ ] API docs regenerated (if applicable)
+
+### Assets (if user-facing)
+- [ ] App icon / favicon resolutions all present
+- [ ] Splash screen / loading state present
+- [ ] Store / marketing screenshots updated (if UI changed)
+- [ ] Promo video/GIF (if marketing push)
+
+### Stores / hosting (if applicable)
+- [ ] Build uploaded to relevant store(s) / artifact registry
+- [ ] Listing description in all supported languages
+- [ ] Privacy policy URL valid
+- [ ] Content rating / age verified
+
+### Backend (if applicable)
+- [ ] Database migrations tested
+- [ ] Env vars/secrets in production
+- [ ] Rollback plan documented
+- [ ] Feature flags configured
+
+### Monitoring
+- [ ] Release tag prepared in error tracker (Sentry, etc.)
+- [ ] Analytics version property set
+- [ ] Crash / error threshold alert configured
+
+### Communication
+- [ ] Social media posts scheduled
+- [ ] Beta testers notified
+- [ ] Community announcement drafted
+
+### Tag & Deploy
+- [ ] Commit changelog + version bump
+- [ ] Annotated tag created
+- [ ] Tag pushed
+- [ ] CI builds release artifact
+- [ ] Promoted from staging → production
+```
+
+### Phase 6 — Tag + Push
+
+```bash
+# Final commit (CHANGELOG + version bump)
+git add CHANGELOG.md <manifest file(s)>
+git commit -m "chore(release): v<X.Y.Z>"
+
+# Annotated tag (good practice — has metadata)
+git tag -a "<prefix>@v<X.Y.Z>" -m "<Product Name> v<X.Y.Z> — <short headline>"
+
+# Push
+git push origin main
+git push origin "<prefix>@v<X.Y.Z>"
+```
+
+### Phase 7 — Post-Release
+
+- [ ] GitHub release oluştur (release notes ile)
+- [ ] CHANGELOG'da [Unreleased] bölümünü tekrar boşalt
+- [ ] Sentry / error tracker'da release tagle
+- [ ] Sosyal medya postlarını schedule et / gönder
+- [ ] 24 saat boyunca crash rate / error rate izle
+- [ ] Eğer kritik bug çıkarsa hotfix yolunu hazır tut
+
+## Concrete Example (illustrative — Flutter mobile app)
+
+Aşağıdaki örnek bir Flutter mobil tarot uygulaması için. Farklı stack'lerde direkt kopyalama — sadece pattern'i göster.
+
+```bash
+# Manifest dosyaları
+# pubspec.yaml:    version: 1.2.0+12
+# android/app/build.gradle: versionCode 12 / versionName "1.2.0"
+# ios/Runner.xcodeproj: CFBundleVersion 12 / CFBundleShortVersionString 1.2.0
+
+git add CHANGELOG.md pubspec.yaml android/app/build.gradle ios/
+git commit -m "chore(release): v1.2.0"
+git tag -a "dev-tarot@v1.2.0" -m "Dev Tarot v1.2.0 — Sosyal Paylaşım + TR"
+git push origin main dev-tarot@v1.2.0
+```
+
+Release notes örneği (Türkçe, mobil app store için):
+
+```markdown
+# Dev Tarot v1.2.0
+
+**🎴 Yeni Bu Sürümde**
+
+✨ **Sosyal Paylaşım**: Çekilişlerini artık Instagram Story'e tek tıkla paylaşabilirsin
+🌍 **Türkçe Desteği**: App tamamen Türkçe!
+
+**🔧 İyileştirmeler**
+- Kart döndürme animasyonu daha akıcı
+- Geçmiş ekranı çökme düzeltildi
+```
+
+Farklı stack örnekleri:
+- **Node.js library**: manifest = `package.json`, tag = `v1.2.0`, GitHub release + `npm publish`
+- **Python package**: manifest = `pyproject.toml`, tag = `v1.2.0`, PyPI upload (`twine upload dist/*`)
+- **Web app**: manifest = `package.json`, tag = `v1.2.0`, deploy via Vercel/Cloudflare/Fly preview → prod promotion
+- **Monorepo**: `<package>@v1.2.0` per-package tag, Changesets gibi tool yardımcı olabilir
+
+## Pitfalls
+
+- ❌ CHANGELOG güncellemeden tag → "ne değişti?" sorusu cevapsız
+- ❌ Patch'i Minor diye bumplamak → SemVer kontratını kırarsın
+- ❌ Release notes'a "refactored internal X" yazmak → kullanıcı bunu umursamaz
+- ❌ Tag'i sonradan force-push'lamak → CI/CD pipelines kırılır
+- ❌ Test atlayıp acele release → her zaman geri tepiyor
+- ❌ Store screenshot'larını güncellemiyor olmak → reject edilir
+- ❌ "Hotfix" deyip aslında feature push'lamak → SemVer'a aykırı
+- ❌ Generic skill'i stack-spesifik manifest varsayımıyla yazmak → bu skill stack-agnostik
+
+## Verification
+
+- [ ] CHANGELOG güncel mi (en üstte yeni versiyon var mı)?
+- [ ] Version bump SemVer'a uygun mu?
+- [ ] Tag formatı doğru mu?
+- [ ] Release notes user-friendly mi (jargon yok)?
+- [ ] Pre-flight checklist'in TÜM kutucukları işaretli mi?
+- [ ] Rollback planı var mı?
+- [ ] CI green mi push'tan önce?
+- [ ] Stack'e özel manifest dosyaları (`package.json`, `pubspec.yaml`, etc.) hepsi güncel mi?
+
+## Example Triggers
+
+User: "v1.0 hazırla" → Tam release prep (changelog + notes + checklist + tag).
+
+User: "Sadece changelog güncelle" → Sadece Phase 3.
+
+User: "Hotfix at" → Phase 1 + 2 (patch bump) + 3 + 5 + 6, skip marketing.
+
+User: "Bu commit'leri changelog'a yaz" → `git log <last-tag>..HEAD` ile commit'leri al, conventional commit prefix'lerine göre kategorile (feat:→Added, fix:→Fixed, vb).

--- a/skills/roadmap-planner/SKILL.md
+++ b/skills/roadmap-planner/SKILL.md
@@ -1,0 +1,299 @@
+---
+name: roadmap-planner
+description: Create phase-based development roadmaps with realistic sprint planning, milestones, and timeline estimates. Use when the user asks for a roadmap, sprint plan, milestones, timeline, "when can we ship", or wants to break a project into phases. Complements PRD (what) and Architecture (how) — roadmap is "when & in what order".
+metadata:
+  version: 2
+  created: "2026-05-19"
+  updated: "2026-05-19"
+  changelog: "v2 — Genericized examples; removed Flutter/tarot-specific bias from procedure body. Concrete example moved to dedicated section."
+---
+
+# Roadmap Planner — Phase-Based Development Plan Skill
+
+Use this skill when the user needs a development timeline, phase breakdown, sprint plan, or "when can we ship this" answer.
+
+## When to Use
+
+- "Roadmap yaz" / "roadmap çıkar"
+- "Sprint plan"
+- "Milestones"
+- "Timeline"
+- "Faz planı"
+- "Ne zaman bitirebiliriz?"
+
+**NOT for:**
+- Feature definition (use `prd-writer`)
+- Tech decisions (use `project-architect`)
+
+## Procedure
+
+### Phase 1 — Context Gathering
+
+Önce mevcut dokümanları oku:
+- `docs/PRD.md` (feature listesi)
+- `docs/ARCHITECTURE.md` (teknik bağlam)
+- `docs/PLANNING-LOG.md` (kısıtlar)
+
+Eksik olanları sor:
+- Team size (solo / 2-3 kişi / takım)?
+- Heftada kaç saat çalışabilir? (full-time / part-time / weekend)
+- Hard deadlines var mı? (yatırımcı toplantısı, store launch, kişisel)
+- Geçmiş benzer proje tecrübesi var mı?
+- Stack & platform (web / mobile / backend / data)?
+
+### Phase 2 — Roadmap Structure (Generic Template)
+
+Aşağıdaki **generic** şablonu mevcut projeye göre uyarla. `<placeholder>`'ları gerçek isimlerle doldur.
+
+```markdown
+# <Project Name> — Roadmap
+
+**Owner:** <kim>
+**Status:** Active
+**Last updated:** <tarih>
+**Total estimated duration:** <N hafta / N ay>
+
+## 0. Assumptions
+- Team: <solo / N kişi> + AI partner
+- Capacity: <X> hours/week
+- Skill level: <X>
+- Stack: <Y>
+- Platform target: <web / mobile / backend / data / cross>
+
+## Phase Overview
+
+```
+Faz 0 — Foundation       (1-2 hafta)  ← Tooling, scaffold, CI
+Faz 1 — MVP Core         (4-6 hafta)  ← İlk çalışan ürün
+Faz 2 — Polish & Launch  (2-3 hafta)  ← Beta, store/marketplace
+Faz 3 — Soft Launch      (2 hafta)    ← Limited release
+Faz 4 — Scale            (kalıcı)     ← Genişleme
+```
+
+## Faz 0 — Foundation
+
+**Goal:** Profesyonel altyapı + ilk "hello world" çıktısı
+
+**Duration:** 1-2 hafta (~20-40 saat)
+
+**Deliverables:**
+- [ ] Repo scaffold (klasör yapısı + README'ler + .gitignore)
+- [ ] CI pipeline (lint, test, build)
+- [ ] Dev environment çalışıyor (local run)
+- [ ] İlk ADR'ler yazıldı
+- [ ] Domain registered, secrets bucket kuruldu
+
+**Sprints:**
+
+### Sprint 0.1 (Hafta 1) — Setup
+- [ ] Day 1-2: Repo scaffold script çalıştır, klasörleri kur
+- [ ] Day 3-4: Toolchain (SDK / runtime) kur, "hello world" çıktısı al
+- [ ] Day 5: CI workflow'ları yaz
+- [ ] Day 6-7: Initial commit, branch protection ayarla
+
+### Sprint 0.2 (Hafta 2) — Foundation Detail
+- [ ] CI'da test + build pass eden boş app
+- [ ] İlk content / config / seed data versiyon
+- [ ] Build/export scripts çalışır halde
+
+**Exit criteria:** `git push` → CI green → build artefakt → hedef ortamda çalışır.
+
+## Faz 1 — MVP Core
+
+**Goal:** Tek niş / tek hedef kitle, çekirdek feature çalışan ürün
+
+**Duration:** 4-6 hafta
+
+**Deliverables:**
+- [ ] Core domain layer + tests
+- [ ] <N> primary features çalışır (PRD'den)
+- [ ] Persistence katmanı (yerel / cloud)
+- [ ] Temel UI/UX akışı
+- [ ] Tema + iconography
+- [ ] Primary dil tam, secondary dil placeholder
+
+**Sprints (örnek bölümleme):**
+
+### Sprint 1.1 — Domain Layer
+- [ ] Entity'leri tanımla
+- [ ] Core services + tests
+- [ ] Edge case coverage
+
+### Sprint 1.2 — Data Layer
+- [ ] Persistence (local DB / API)
+- [ ] Config / preferences
+
+### Sprint 1.3 — UI Skeleton
+- [ ] Main screen layout
+- [ ] Primary widget'lar
+- [ ] Tema tokens applied
+
+### Sprint 1.4 — Primary Flow
+- [ ] User happy path çalışır end-to-end
+- [ ] Persist + retrieve
+
+### Sprint 1.5 — Secondary Feature
+- [ ] PRD'de "Must Have" diye işaretli kalan feature
+- [ ] Integration tests
+
+### Sprint 1.6 — Polish & Internal Beta
+- [ ] Bug bash
+- [ ] Performance pass
+- [ ] Internal release / staging deploy
+- [ ] 5 beta tester feedback
+
+**Exit criteria:** Beta tester'lar ürünü kullanır + "useable" diyor.
+
+## Faz 2 — Polish & Launch Prep
+
+**Goal:** Production-ready ürün
+
+**Duration:** 2-3 hafta
+
+**Deliverables:**
+- [ ] All NFRs met (performance, accessibility, offline/online)
+- [ ] Localization complete
+- [ ] Store / marketplace assets (icon, screenshots, description)
+- [ ] Privacy policy, terms of service
+- [ ] Sentry / equivalent observability live
+- [ ] Analytics + crash reporting
+- [ ] Monetization integrated (kapalı veya açık mod)
+- [ ] Promo video / GIF
+- [ ] Launch checklist tamamlandı
+
+## Faz 3 — Soft Launch
+
+**Goal:** Limited geographic / audience release, feedback loop
+
+**Duration:** 2 hafta (+ data collection)
+
+**Activities:**
+- [ ] Production release (sınırlı pazar / dil)
+- [ ] Beta community feedback (ilgili community'ler)
+- [ ] Social media launch posts
+- [ ] İlk 3 user complaint üzerine iterate
+
+**Metrics gate:**
+- 50+ aktif kullanıcı in 2 weeks
+- Crash-free rate > 99%
+- Day-1 retention > 30%
+
+## Faz 4 — Scale (Ongoing)
+
+**Themes (her quarter):**
+- Q1: Yeni platform / channel
+- Q2: 2nd niş / segment
+- Q3: Otomasyon (content pipeline, dağıtım)
+- Q4: Monetization optimize
+
+## Velocity Calibration
+
+Bu plan **TEORIK**. Gerçek velocity sprint sonrasında ayarlanır:
+
+| Sprint | Planned | Actual | Notes |
+|---|---|---|---|
+| 0.1 | 20h | TBD | TBD |
+
+Her sprint sonunda bu tabloyu güncelle. Variance > %30 ise plan revize.
+
+## Risk-Adjusted Timeline
+
+| Senaryo | Toplam süre |
+|---|---|
+| Best case (skill öğrenme hızlı, blocker yok) | 12 hafta |
+| Realistic (ortalama hızda) | 16 hafta |
+| Pessimistic (öğrenme yavaş, 2 blocker) | 22 hafta |
+
+## Dependencies & Blockers
+
+| Dependency | Status | Owner | ETA |
+|---|---|---|---|
+| Toolchain install | Done | Sen | - |
+| Domain choice | Pending | Sen | Bu hafta |
+| Store / hosting account | Pending | Sen | Faz 2 başı |
+
+## Milestone Calendar (Approximate)
+
+| Milestone | Target | Status |
+|---|---|---|
+| M0 — Repo scaffold ready | Hafta 2 sonu | ⏳ |
+| M1 — First build runs locally | Hafta 4 sonu | ⏳ |
+| M2 — Core flow works end-to-end | Hafta 9 sonu | ⏳ |
+| M3 — Internal beta | Hafta 10 sonu | ⏳ |
+| M4 — Soft launch | Hafta 13 sonu | ⏳ |
+| M5 — Second platform | Hafta 22 sonu | ⏳ |
+| M6 — 2nd niche / segment | Hafta 30 sonu | ⏳ |
+
+## Definition of Done (Project-wide)
+
+Her sprint task'ı "done" kabul edilmeden önce:
+- [ ] Code written
+- [ ] Tests pass
+- [ ] PR reviewed (self or AI)
+- [ ] Merged to main
+- [ ] CI green
+- [ ] Doc updated (if behavior change)
+- [ ] CHANGELOG entry (if user-visible)
+```
+
+### Phase 3 — Estimation Rules
+
+- **Solo dev part-time (10h/wk)**: küçük feature 1-2 hafta, orta 2-4 hafta, büyük 4-8 hafta
+- **Learning tax**: ilk kez kullanılan framework için süreyi 1.5x yap
+- **Integration tax**: 3+ servisin entegrasyonu var ise +%30 zaman ekle
+- **"Polish & test" zamanı**: dev süresinin %30-50'si kadar
+- **Buffer**: her faz sonunda 1 hafta buffer bırak
+
+### Phase 4 — Output
+
+- Dosya yolu: `docs/ROADMAP.md`
+- Markdown formatı + ASCII Gantt-like chart
+- Hafta numaraları, tarih değil (esneklik için)
+- Velocity tablo'su boş başlat, sprint sonlarında doldurulur
+
+## Concrete Example (illustrative only)
+
+Aşağıdaki **örnek** bir Flutter mobile tarot uygulamasına ait. Skill'i farklı stack'lerde kullanırken bu örneği taklit etme — kendi domain'inin entity'leri ve manifest'leriyle doldur.
+
+```
+Faz 1 — MVP Core (örnek bölümleme, Flutter projesi)
+  1.1 Domain Layer        Card / Deck / Reading entity, ShuffleService, SlotRenderer, ComboDetector + tests
+  1.2 Data Layer          JsonDeckLoader, SqliteReadingRepository, SharedPreferences wrapper
+  1.3 UI Skeleton         Main screen, Card widget + flip animation, Reading mode selector, Theme tokens
+  1.4 Reading Flow        Draw cards interaction, Reading view with positions, Save to history
+  1.5 Share Feature       ShareCardRenderer, Watermark + deep link, share_plus integration
+  1.6 Polish & Beta       Bug bash, perf pass, Internal Play track upload, 5 tester feedback
+```
+
+Eğer projen web ise: `1.3` Next.js page'ler + Tailwind tokens olur.
+Eğer projen backend ise: `1.3` controller/route layer + OpenAPI spec olur.
+Eğer projen data pipeline ise: `1.3` orchestration (Airflow/Dagster) + first DAG olur.
+
+## Pitfalls
+
+- ❌ "2 günde yaparız" optimizmi → her zaman 2-3x süre koy
+- ❌ Buffer atlamak → bir slip her şeyi çökertir
+- ❌ "Faz 2'de düşünürüz" sonsuz erteleme → her fazın exit criteria'sı net
+- ❌ Soft launch'sız direkt production → feedback loop kaybı
+- ❌ Platform 2'yi platform 1 ile paralel planlamak → ekstra 30% zaman, ayrı sprint
+- ❌ Localization'ı sonsuz erteleme → MVP'de en az 1 secondary dil
+- ❌ Generic skill'i belirli bir stack varsayımıyla yazmak → bu skill stack-agnostik, prosedür gövdesinde framework adı geçmez
+
+## Verification
+
+- [ ] Her fazın exit criteria'sı var mı?
+- [ ] Her sprint'in deliverable listesi var mı?
+- [ ] Best/realistic/pessimistic 3'lü tahmin var mı?
+- [ ] Dependencies tablosu güncel mi?
+- [ ] Velocity tablo'su sprint sonrası doldurulmak üzere hazır mı?
+- [ ] Milestone calendar tarih içeriyor mu (hafta numarası OK)?
+- [ ] Definition of Done tanımlı mı?
+- [ ] Stack'e özel terim varsa "Concrete Example" bölümüne taşındı mı (prosedüre değil)?
+
+## Example Triggers
+
+User: "Ne zaman bitirebiliriz?" → Tam roadmap çıkar, ayrıca best/realistic/pessimistic ver.
+
+User: "Sprint planı" → Faz 1 detayını derinleştir, diğer fazları üst seviyede tut.
+
+User: "Faz 2 ne içerecek?" → Sadece Faz 2'yi derinleştir, geri kalanı varolanı koru.


### PR DESCRIPTION
## Problem

The `pi-hermes-memory` npm package does not include its 5 document-generator skills in the distribution. The `pi.skills` manifest is missing from `package.json`, and the `skills/` directory is not listed in the `files` array.

As a result, Pi cannot auto-discover these skills from the npm installation. Users must manually install or copy skill files.

## Skills Included

- `skills/adr-recorder/SKILL.md` — Architecture Decision Records (MADR template)
- `skills/prd-writer/SKILL.md` — Product Requirements Documents
- `skills/project-architect/SKILL.md` — ARCHITECTURE.md documents
- `skills/release-prepper/SKILL.md` — Release preparation (Keep a Changelog + SemVer)
- `skills/roadmap-planner/SKILL.md` — Development roadmaps with milestones

## Changes

1. Added `pi.skills` array to `package.json` with 5 skill paths
2. Added `skills` to `package.json` `files` array
3. Added all 5 `skills/*/SKILL.md` files to the repository

## Note

These skill files already exist in the Pi local installation at `~/.pi/agent/pi-hermes-memory/skills/`. They are currently distributed via a separate install path, not through npm. This PR makes them available directly from the npm package.