### PR TITLE
Fix project memory auto-consolidation

### DIFF
--- a/src/handlers/auto-consolidate.ts
+++ b/src/handlers/auto-consolidate.ts
@@ -12,24 +12,38 @@ import { MemoryStore } from "../store/memory-store.js";
 import { CONSOLIDATION_PROMPT, ENTRY_DELIMITER } from "../constants.js";
 import type { ConsolidationResult } from "../types.js";
 
+type MemoryTarget = "memory" | "user" | "failure";
+type ToolMemoryTarget = MemoryTarget | "project";
+
+function entriesForTarget(store: MemoryStore, target: MemoryTarget): string[] {
+  return target === "user" ? store.getUserEntries() : store.getMemoryEntries();
+}
+
+function labelForTarget(target: MemoryTarget, toolTarget: ToolMemoryTarget): string {
+  if (toolTarget === "project") return "Project Memory";
+  if (target === "user") return "User Profile";
+  if (target === "failure") return "Failure Memory";
+  return "Memory";
+}
+
 export async function triggerConsolidation(
   pi: ExtensionAPI,
   store: MemoryStore,
-  target: "memory" | "user" | "failure",
+  target: MemoryTarget,
   signal?: AbortSignal,
   timeoutMs: number = 60000,
+  toolTarget: ToolMemoryTarget = target,
 ): Promise<ConsolidationResult> {
-  const entries =
-    target === "memory" ? store.getMemoryEntries() : store.getUserEntries();
+  const entries = entriesForTarget(store, target);
   const currentContent = entries.join(ENTRY_DELIMITER);
 
   const prompt = [
     CONSOLIDATION_PROMPT,
     "",
-    `--- Current ${target === "user" ? "User Profile" : "Memory"} Entries ---`,
+    `--- Current ${labelForTarget(target, toolTarget)} Entries ---`,
     currentContent || "(empty)",
     "",
-    `Use the memory tool to consolidate. Target: '${target}'`,
+    `Use the memory tool to consolidate. Target: '${toolTarget}'`,
   ].join("\n");
 
   try {
@@ -60,30 +74,47 @@ export function registerConsolidateCommand(
   pi: ExtensionAPI,
   store: MemoryStore,
   timeoutMs: number = 60000,
+  projectStore: MemoryStore | null = null,
+  projectName?: string | null,
 ): void {
   pi.registerCommand("memory-consolidate", {
     description: "Manually trigger memory consolidation to free up space",
     handler: async (_args, ctx) => {
       const results: string[] = [];
+      const targets: Array<{
+        label: string;
+        store: MemoryStore;
+        target: MemoryTarget;
+        toolTarget: ToolMemoryTarget;
+      }> = [
+        { label: "memory", store, target: "memory", toolTarget: "memory" },
+        { label: "user", store, target: "user", toolTarget: "user" },
+      ];
 
-      for (const target of ["memory", "user"] as const) {
-        const entries =
-          target === "memory"
-            ? store.getMemoryEntries()
-            : store.getUserEntries();
+      if (projectStore) {
+        targets.push({
+          label: projectName ? `project:${projectName}` : "project",
+          store: projectStore,
+          target: "memory",
+          toolTarget: "project",
+        });
+      }
+
+      for (const item of targets) {
+        const entries = entriesForTarget(item.store, item.target);
 
         if (entries.length === 0) {
-          results.push(`${target}: (empty, nothing to consolidate)`);
+          results.push(`${item.label}: (empty, nothing to consolidate)`);
           continue;
         }
 
-        const result = await triggerConsolidation(pi, store, target, ctx.signal, timeoutMs);
+        const result = await triggerConsolidation(pi, item.store, item.target, ctx.signal, timeoutMs, item.toolTarget);
 
         if (result.consolidated) {
-          await store.loadFromDisk();
-          results.push(`${target}: ✅ consolidated`);
+          await item.store.loadFromDisk();
+          results.push(`${item.label}: ✅ consolidated`);
         } else {
-          results.push(`${target}: ❌ ${result.error}`);
+          results.push(`${item.label}: ❌ ${result.error}`);
         }
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,11 +177,17 @@ export default function (pi: ExtensionAPI) {
   // ── 6. Setup session-end flush ──
   setupSessionFlush(pi, store, projectStore, config);
 
-  // ── 7. Setup auto-consolidation (inject consolidator into store) ──
+  // ── 7. Setup auto-consolidation (inject consolidator into stores) ──
   store.setConsolidator(async (target, signal) => {
     return triggerConsolidation(pi, store, target, signal, config.consolidationTimeoutMs);
   });
-  registerConsolidateCommand(pi, store, config.consolidationTimeoutMs);
+  if (projectStore) {
+    projectStore.setConsolidator(async (target, signal) => {
+      const toolTarget = target === "memory" ? "project" : target;
+      return triggerConsolidation(pi, projectStore, target, signal, config.consolidationTimeoutMs, toolTarget);
+    });
+  }
+  registerConsolidateCommand(pi, store, config.consolidationTimeoutMs, projectStore, projectName);
 
   // ── 8. Setup correction detection ──
   setupCorrectionDetector(pi, store, projectStore, config, dbManager, projectName);

--- a/tests/handlers/auto-consolidate.test.ts
+++ b/tests/handlers/auto-consolidate.test.ts
@@ -7,7 +7,7 @@ import assert from "node:assert/strict";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";
-import { triggerConsolidation } from "../../src/handlers/auto-consolidate.js";
+import { registerConsolidateCommand, triggerConsolidation } from "../../src/handlers/auto-consolidate.js";
 import { ENTRY_DELIMITER } from "../../src/constants.js";
 
 // ─── Mock infrastructure ───
@@ -100,6 +100,16 @@ describe("triggerConsolidation", () => {
     assert.ok(prompt.includes("User Profile"), "prompt should reference user profile");
   });
 
+  it("can consolidate project memory using the project tool target", async () => {
+    const pi = createMockPi();
+    await triggerConsolidation(pi, mockStore, "memory", undefined, 60000, "project");
+
+    const prompt = execCalls[0][1][execCalls[0][1].length - 1];
+    assert.ok(prompt.includes("old entry 1"), "prompt should include project memory entries");
+    assert.ok(prompt.includes("Project Memory"), "prompt should label project memory");
+    assert.ok(prompt.includes("Target: 'project'"), "prompt should tell the child agent to use target='project'");
+  });
+
   it("handles empty entries gracefully", async () => {
     const emptyStore = {
       getMemoryEntries: () => [],
@@ -112,6 +122,50 @@ describe("triggerConsolidation", () => {
 
     const prompt = execCalls[0][1][execCalls[0][1].length - 1];
     assert.ok(prompt.includes("(empty)"), "prompt should show (empty) for empty entries");
+  });
+});
+
+describe("registerConsolidateCommand", () => {
+  beforeEach(() => {
+    execCalls = [];
+  });
+
+  it("includes project memory when a project store is available", async () => {
+    let handler: any;
+    let notification = "";
+    let projectReloaded = false;
+
+    const pi = {
+      on: () => {},
+      exec: async (...args: any[]) => {
+        execCalls.push(args);
+        return { code: 0, stdout: "Done", stderr: "" };
+      },
+      registerTool: () => {},
+      registerCommand: (_name: string, command: any) => {
+        handler = command.handler;
+      },
+    } as any;
+
+    const projectStore = {
+      getMemoryEntries: () => ["project fact"],
+      getUserEntries: () => [],
+      loadFromDisk: async () => { projectReloaded = true; },
+    } as any;
+
+    registerConsolidateCommand(pi, mockStore, 60000, projectStore, "demo-project");
+    await handler({}, {
+      signal: undefined,
+      ui: { notify: (message: string) => { notification = message; } },
+    });
+
+    assert.strictEqual(execCalls.length, 3, "should consolidate memory, user, and project stores");
+    const projectPrompt = execCalls[2][1][execCalls[2][1].length - 1];
+    assert.ok(projectPrompt.includes("Project Memory"), "project prompt should be labeled");
+    assert.ok(projectPrompt.includes("project fact"), "project prompt should include project entries");
+    assert.ok(projectPrompt.includes("Target: 'project'"), "project prompt should use target='project'");
+    assert.ok(projectReloaded, "project store should reload after consolidation");
+    assert.ok(notification.includes("project:demo-project: ✅ consolidated"), "notification should include project result");
   });
 });
 


### PR DESCRIPTION
## Summary
- wire auto-consolidation into the project-scoped MemoryStore
- tell child consolidation runs to use target='project' for project memory
- include project memory in /memory-consolidate when a project store is available
- add coverage for project consolidation prompts and manual command behavior

## Why
Project memory writes route to projectStore, but only the global store had a consolidator. When project memory hit the character limit, auto-consolidate was skipped and the memory tool returned the capacity error.

## Test
- npm run check -- --pretty false
- node --import tsx --test tests/handlers/auto-consolidate.test.ts
- npm test