### PR TITLE
fix: cap WAL growth with wal_autocheckpoint + journal_size_limit + checkpoint on close

### DIFF
--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -106,6 +106,8 @@ export class DatabaseManager {
 
     // Enable WAL mode + FK enforcement for each connection.
     db.exec('PRAGMA journal_mode = WAL');
+    db.exec('PRAGMA wal_autocheckpoint = 100');
+    db.exec('PRAGMA journal_size_limit = 5242880');
     db.exec('PRAGMA foreign_keys = ON');
 
     // Create tables and triggers
@@ -251,6 +253,7 @@ export class DatabaseManager {
    */
   close(): void {
     if (this.db) {
+      try { this.db.exec('PRAGMA wal_checkpoint(TRUNCATE)'); } catch { /* best effort */ }
       this.db.close();
       this.db = null;
     }


### PR DESCRIPTION
## Problem

SQLite WAL mode is enabled at `src/store/db.ts:108` but no WAL management pragmas are set. This causes the `sessions.db-wal` file to grow without bound.

**Observed impact** (on a real system after ~2 weeks of daily use):
- `sessions.db`: 1.4 MB
- `sessions.db-wal`: **26 MB** (17× bloat)
- Growth rate: ~8 MB/day
- The WAL never shrinks because `journal_size_limit` defaults to `-1` (unlimited) and no checkpoint is ever triggered by the extension.

## Root Cause

The only WAL-related pragma in the entire codebase is `PRAGMA journal_mode = WAL`. Missing:
- `wal_autocheckpoint` — relies on SQLite default (1000 pages / ~4 MB before auto-checkpoint)
- `journal_size_limit` — defaults to `-1` (unlimited growth)
- `wal_checkpoint(TRUNCATE)` — never called, not even on `close()`

Additionally, `DatabaseManager.close()` is never called during the extension lifecycle — the DB connection stays open for the entire Pi process lifetime.

## Fix

Three one-liners in `src/store/db.ts`:

1. `PRAGMA wal_autocheckpoint = 100` — auto-checkpoint every ~400 KB of WAL writes
2. `PRAGMA journal_size_limit = 5242880` — cap the WAL file at 5 MB
3. `PRAGMA wal_checkpoint(TRUNCATE)` in `close()` — reclaim space on connection close (best-effort, wrapped in try/catch)

## Verification

Tested on a live system with 475 memories, 42 sessions, and 3 active Pi processes. The WAL shrank from 26 MB to 86 KB after checkpoint, then remained bounded under the 5 MB limit.