### PR TITLE
fix: quote individual FTS5 terms instead of entire query (fixes #50)

### DIFF
--- a/src/store/session-search.ts
+++ b/src/store/session-search.ts
@@ -2,15 +2,19 @@ import { DatabaseManager } from './db.js';
 
 /**
  * Escape a string for FTS5 query syntax.
- * Wraps the query in double quotes to treat it as a literal phrase.
+ * Quotes individual terms so FTS5 uses implicit AND (all terms must appear, any order).
+ * Preserves explicit FTS5 operators (OR, AND, NOT, NEAR) and quoted phrases.
  */
 function escapeFts5Query(query: string): string {
-  // If the query already contains FTS5 operators (OR, AND, NOT, NEAR), leave it as-is
-  if (/\b(OR|AND|NOT|NEAR)\b/.test(query)) {
+  // If the query already contains FTS5 operators (OR, AND, NOT, NEAR) or explicit
+  // double-quoted phrases, pass through as-is so callers retain full control.
+  if (/\b(OR|AND|NOT|NEAR)\b/.test(query) || query.includes('"')) {
     return query;
   }
-  // Otherwise, wrap in double quotes to treat as literal phrase
-  return `"${query.replace(/"/g, '""')}"`;
+  // Quote individual terms so FTS5 matches all of them with implicit AND.
+  const terms = query.trim().split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return '""';
+  return terms.map(t => `"${t.replace(/"/g, '""')}"`).join(' ');
 }
 
 /**

--- a/src/store/sqlite-memory-store.ts
+++ b/src/store/sqlite-memory-store.ts
@@ -552,15 +552,19 @@ export function removeExactSyncedMemories(
 
 /**
  * Escape a string for FTS5 query syntax.
- * Wraps the query in double quotes to treat it as a literal phrase.
+ * Quotes individual terms so FTS5 uses implicit AND (all terms must appear, any order).
+ * Preserves explicit FTS5 operators (OR, AND, NOT, NEAR) and quoted phrases.
  */
 function escapeFts5Query(query: string): string {
-  // If the query already contains FTS5 operators (OR, AND, NOT, NEAR), leave it as-is
-  if (/\b(OR|AND|NOT|NEAR)\b/.test(query)) {
+  // If the query already contains FTS5 operators (OR, AND, NOT, NEAR) or explicit
+  // double-quoted phrases, pass through as-is so callers retain full control.
+  if (/\b(OR|AND|NOT|NEAR)\b/.test(query) || query.includes('"')) {
     return query;
   }
-  // Otherwise, wrap in double quotes to treat as literal phrase
-  return `"${query.replace(/"/g, '""')}"`;
+  // Quote individual terms so FTS5 matches all of them with implicit AND.
+  const terms = query.trim().split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return '""';
+  return terms.map(t => `"${t.replace(/"/g, '""')}"`).join(' ');
 }
 
 /**


### PR DESCRIPTION
## Problem

`escapeFts5Query()` in both `sqlite-memory-store.ts` and `session-search.ts` wrapped the entire query in double quotes, making FTS5 require an **exact phrase match**. Multi-word natural language queries like `gpu issues` or `laptop hardware` almost never produce results because the exact phrase doesn't appear in stored text.

## Reproduction

With 400+ indexed messages:
- `memory_search("nvidia")` → 29 results ✓
- `memory_search("gpu issues")` → **0 results** ✗ (phrase match fails)
- `session_search("laptop hardware")` → **0 results** ✗

## Fix

Quote **individual terms** so FTS5 uses implicit AND matching (all terms must appear, in any order):

```ts
// Before:
return `"${query.replace(/"/g, '""')}"`;

// After:
const terms = query.trim().split(/\s+/).filter(Boolean);
if (terms.length === 0) return '""';
return terms.map(t => `"${t.replace(/"/g, '""')}"`).join(' ');
```

Also added `query.includes('"')` check to the operator passthrough condition — callers who wrap their query in explicit double quotes still get exact phrase matching.

## Behavior

| Query | Before | After |
|-------|--------|-------|
| `gpu` | matches | matches (unchanged) |
| `gpu issues` | `"gpu issues"` → 0 hits | `"gpu" "issues"` → AND match |
| `auth OR token` | passthrough | passthrough (unchanged) |
| `"nvidia modeset"` | passthrough | passthrough (new) |

## Files

- `src/store/sqlite-memory-store.ts` — `memory_search` tool
- `src/store/session-search.ts` — `session_search` tool

Closes #50