### PR TITLE
fix: normalize FTS query handling for memory and session search

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,11 @@ By default, the extension indexes your Pi session history into a SQLite database
 | `session_search` | Search past conversations — "what did we discuss about auth?" |
 | `memory_search` | Search extended memory store — unlimited capacity, keyword-based |
 
+Search behavior notes:
+- Multi-word natural-language queries are supported for both `memory_search` and `session_search`.
+- Exact phrases can be requested with quotes, for example `"memory search"`.
+- Advanced FTS queries with operators like `OR` still work when you need them.
+
 Session history is indexed automatically on session shutdown. To bulk-import existing sessions:
 
 ```

--- a/src/store/fts-query.ts
+++ b/src/store/fts-query.ts
@@ -1,0 +1,38 @@
+const FTS5_OPERATOR_PATTERN = /\b(OR|AND|NOT|NEAR)\b/;
+const FTS5_TOKEN_PATTERN = /"([^"]*)"|(\S+)/g;
+const NATURAL_LANGUAGE_CONNECTORS = new Set(['and', 'or', 'not', 'near']);
+
+/**
+ * Normalize natural-language search input into an FTS5 query.
+ * Plain terms become individually quoted for implicit AND matching.
+ * Explicit quoted phrases are preserved, connector stopwords are ignored in
+ * natural-language mode, and raw uppercase FTS5 operators pass through.
+ */
+export function normalizeFts5Query(query: string): string {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) return '';
+
+  if (FTS5_OPERATOR_PATTERN.test(trimmed)) {
+    return trimmed;
+  }
+
+  const normalizedTerms: string[] = [];
+  for (const match of trimmed.matchAll(FTS5_TOKEN_PATTERN)) {
+    const phrase = match[1];
+    const term = match[2];
+    if (phrase === undefined && term && NATURAL_LANGUAGE_CONNECTORS.has(term.toLowerCase())) {
+      continue;
+    }
+
+    const rawValue = phrase ?? term ?? '';
+    normalizedTerms.push(`"${rawValue.replace(/"/g, '""')}"`);
+  }
+
+  return normalizedTerms.join(' ');
+}
+
+export function isFts5QueryError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const msg = err.message.toLowerCase();
+  return msg.includes('fts5') || msg.includes('unterminated string');
+}

--- a/src/store/session-search.ts
+++ b/src/store/session-search.ts
@@ -1,17 +1,5 @@
 import { DatabaseManager } from './db.js';
-
-/**
- * Escape a string for FTS5 query syntax.
- * Wraps the query in double quotes to treat it as a literal phrase.
- */
-function escapeFts5Query(query: string): string {
-  // If the query already contains FTS5 operators (OR, AND, NOT, NEAR), leave it as-is
-  if (/\b(OR|AND|NOT|NEAR)\b/.test(query)) {
-    return query;
-  }
-  // Otherwise, wrap in double quotes to treat as literal phrase
-  return `"${query.replace(/"/g, '""')}"`;
-}
+import { isFts5QueryError, normalizeFts5Query } from './fts-query.js';
 
 /**
  * Search result from session history.
@@ -52,6 +40,10 @@ export function searchSessions(
   query: string,
   options: SessionSearchOptions = {}
 ): SessionSearchResult[] {
+  if (query.trim().length === 0) {
+    return [];
+  }
+
   const db = dbManager.getDb();
   const { limit = 10, project, role, since } = options;
 
@@ -60,8 +52,12 @@ export function searchSessions(
   const params: unknown[] = [];
 
   // FTS5 match condition — use subquery for reliable rowid matching
+  const normalizedQuery = normalizeFts5Query(query);
+  if (normalizedQuery.length === 0) {
+    return [];
+  }
   conditions.push('m.rowid IN (SELECT rowid FROM message_fts WHERE message_fts MATCH ?)');
-  params.push(escapeFts5Query(query));
+  params.push(normalizedQuery);
 
   // Project filter
   if (project) {
@@ -119,8 +115,10 @@ export function searchSessions(
       snippet: row.snippet,
     }));
   } catch (err) {
-    // FTS5 can throw on malformed queries — return empty results
-    return [];
+    if (isFts5QueryError(err)) {
+      return [];
+    }
+    throw err;
   }
 }
 

--- a/src/store/sqlite-memory-store.ts
+++ b/src/store/sqlite-memory-store.ts
@@ -1,4 +1,5 @@
 import { DatabaseManager } from './db.js';
+import { isFts5QueryError, normalizeFts5Query } from './fts-query.js';
 import type { MemoryCategory } from '../types.js';
 
 const MEMORY_SELECT_COLUMNS = `
@@ -551,19 +552,6 @@ export function removeExactSyncedMemories(
 }
 
 /**
- * Escape a string for FTS5 query syntax.
- * Wraps the query in double quotes to treat it as a literal phrase.
- */
-function escapeFts5Query(query: string): string {
-  // If the query already contains FTS5 operators (OR, AND, NOT, NEAR), leave it as-is
-  if (/\b(OR|AND|NOT|NEAR)\b/.test(query)) {
-    return query;
-  }
-  // Otherwise, wrap in double quotes to treat as literal phrase
-  return `"${query.replace(/"/g, '""')}"`;
-}
-
-/**
  * Search memories using FTS5.
  */
 export function searchMemories(
@@ -571,6 +559,10 @@ export function searchMemories(
   query: string,
   options: { project?: string; target?: string; category?: MemoryCategory; limit?: number } = {}
 ): SqliteMemoryEntry[] {
+  if (query.trim().length === 0) {
+    return [];
+  }
+
   const db = dbManager.getDb();
   const { project, target, category, limit = 10 } = options;
 
@@ -578,8 +570,12 @@ export function searchMemories(
   const params: unknown[] = [];
 
   // FTS5 match via subquery with escaped query
+  const normalizedQuery = normalizeFts5Query(query);
+  if (normalizedQuery.length === 0) {
+    return [];
+  }
   conditions.push('m.id IN (SELECT rowid FROM memory_fts WHERE memory_fts MATCH ?)');
-  params.push(escapeFts5Query(query));
+  params.push(normalizedQuery);
 
   if (project !== undefined) {
     if (project === null) {
@@ -611,20 +607,27 @@ export function searchMemories(
   `;
   params.push(limit);
 
-  const rows = db.prepare(sql).all(...params) as Array<{
-    id: number;
-    project: string | null;
-    target: string;
-    category: string | null;
-    content: string;
-    failure_reason: string | null;
-    tool_state: string | null;
-    corrected_to: string | null;
-    created: string;
-    last_referenced: string;
-  }>;
+  try {
+    const rows = db.prepare(sql).all(...params) as Array<{
+      id: number;
+      project: string | null;
+      target: string;
+      category: string | null;
+      content: string;
+      failure_reason: string | null;
+      tool_state: string | null;
+      corrected_to: string | null;
+      created: string;
+      last_referenced: string;
+    }>;
 
-  return rows.map(mapRow);
+    return rows.map(mapRow);
+  } catch (err) {
+    if (isFts5QueryError(err)) {
+      return [];
+    }
+    throw err;
+  }
 }
 
 /**

--- a/tests/store/session-search.test.ts
+++ b/tests/store/session-search.test.ts
@@ -35,6 +35,8 @@ describe('session-search', () => {
         { id: `${id}-msg-2`, role: 'assistant', content: 'To set up Prisma, install the package and run prisma init. Then configure your DATABASE_URL in .env', timestamp: '2026-05-03T00:01:30Z' },
         { id: `${id}-msg-3`, role: 'user', content: 'What about database migrations?', timestamp: '2026-05-03T00:02:00Z' },
         { id: `${id}-msg-4`, role: 'assistant', content: 'Use prisma migrate dev to create migrations. This generates SQL files and applies them.', timestamp: '2026-05-03T00:02:30Z' },
+        { id: `${id}-msg-5`, role: 'user', content: 'What about gpu timeout issue debugging?', timestamp: '2026-05-03T00:03:00Z' },
+        { id: `${id}-msg-6`, role: 'assistant', content: 'This exact phrase memory search example helps verify phrase queries.', timestamp: '2026-05-03T00:03:30Z' },
       ],
       ...overrides,
     };
@@ -110,12 +112,56 @@ describe('session-search', () => {
       assert.strictEqual(results.length, 0);
     });
 
+    it('should match multi-word queries without requiring an exact phrase', () => {
+      indexSession(dbManager, createTestSession());
+
+      const results = searchSessions(dbManager, 'gpu issue');
+      assert.ok(results.length > 0);
+      assert.ok(results.some((r) => r.content.includes('gpu timeout issue')));
+    });
+
+    it('should ignore lowercase connector words in natural-language queries', () => {
+      indexSession(dbManager, createTestSession());
+
+      const results = searchSessions(dbManager, 'gpu and issue');
+      assert.ok(results.length > 0);
+      assert.ok(results.some((r) => r.content.includes('gpu timeout issue')));
+    });
+
+    it('should preserve explicit quoted phrase searches', () => {
+      indexSession(dbManager, createTestSession());
+
+      const results = searchSessions(dbManager, '"memory search"');
+      assert.ok(results.length > 0);
+      assert.ok(results.every((r) => r.content.includes('memory search')));
+    });
+
+    it('should preserve valid operator queries', () => {
+      indexSession(dbManager, createTestSession());
+
+      const results = searchSessions(dbManager, 'Prisma OR gpu');
+      assert.ok(results.length >= 2);
+      assert.ok(results.some((r) => r.content.includes('Prisma')));
+      assert.ok(results.some((r) => r.content.includes('gpu timeout issue')));
+    });
+
     it('should handle malformed FTS5 queries gracefully', () => {
       indexSession(dbManager, createTestSession());
 
       // Malformed FTS5 query should not throw
       const results = searchSessions(dbManager, 'AND OR NOT');
       assert.ok(Array.isArray(results));
+    });
+
+    it('should handle unmatched quotes gracefully', () => {
+      indexSession(dbManager, createTestSession());
+
+      const results = searchSessions(dbManager, 'issue "timeout');
+      assert.ok(Array.isArray(results));
+    });
+
+    it('should return empty for blank queries', () => {
+      assert.deepStrictEqual(searchSessions(dbManager, '   '), []);
     });
   });
 
@@ -126,7 +172,7 @@ describe('session-search', () => {
 
     it('should return correct count after indexing', () => {
       indexSession(dbManager, createTestSession());
-      assert.strictEqual(getIndexedMessageCount(dbManager), 4);
+      assert.strictEqual(getIndexedMessageCount(dbManager), 6);
     });
   });
 });

--- a/tests/store/sqlite-memory-store.test.ts
+++ b/tests/store/sqlite-memory-store.test.ts
@@ -154,6 +154,9 @@ describe('sqlite-memory-store', () => {
     beforeEach(() => {
       addMemory(dbManager, 'prefers pnpm over npm');
       addMemory(dbManager, 'uses Prisma with PostgreSQL', 'memory', 'project-a');
+      addMemory(dbManager, 'debugged gpu timeout issue after driver update');
+      addMemory(dbManager, 'memory search indexing notes');
+      addMemory(dbManager, 'exact phrase memory search example');
       addMemory(dbManager, 'name: Chandrateja', 'user');
       addMemory(dbManager, 'timezone: AEST', 'user');
     });
@@ -168,6 +171,31 @@ describe('sqlite-memory-store', () => {
       const results = searchMemories(dbManager, 'Prisma');
       assert.ok(results.length > 0);
       assert.ok(results.some(r => r.content.includes('Prisma')));
+    });
+
+    it('should match multi-word queries without requiring an exact phrase', () => {
+      const results = searchMemories(dbManager, 'gpu issue');
+      assert.ok(results.length > 0);
+      assert.ok(results.some((r) => r.content.includes('gpu timeout issue')));
+    });
+
+    it('should ignore lowercase connector words in natural-language queries', () => {
+      const results = searchMemories(dbManager, 'gpu and issue');
+      assert.ok(results.length > 0);
+      assert.ok(results.some((r) => r.content.includes('gpu timeout issue')));
+    });
+
+    it('should preserve explicit quoted phrase searches', () => {
+      const results = searchMemories(dbManager, '"memory search"');
+      assert.ok(results.length > 0);
+      assert.ok(results.every((r) => r.content.includes('memory search')));
+    });
+
+    it('should preserve valid operator queries', () => {
+      const results = searchMemories(dbManager, 'pnpm OR AEST');
+      assert.ok(results.length >= 2);
+      assert.ok(results.some((r) => r.content.includes('pnpm')));
+      assert.ok(results.some((r) => r.content.includes('AEST')));
     });
 
     it('should limit results', () => {
@@ -189,6 +217,22 @@ describe('sqlite-memory-store', () => {
 
     it('should return empty for no matches', () => {
       const results = searchMemories(dbManager, 'nonexistent-xyz');
+      assert.strictEqual(results.length, 0);
+    });
+
+    it('should return empty for blank queries', () => {
+      assert.deepStrictEqual(searchMemories(dbManager, '   '), []);
+    });
+
+    it('should not throw on unmatched quotes', () => {
+      assert.doesNotThrow(() => {
+        const results = searchMemories(dbManager, 'issue "timeout');
+        assert.ok(Array.isArray(results));
+      });
+    });
+
+    it('should return empty for malformed operator queries', () => {
+      const results = searchMemories(dbManager, 'AND OR NOT');
       assert.strictEqual(results.length, 0);
     });
   });


### PR DESCRIPTION
## Problem

Issue #50 is real: both `memory_search` and `session_search` were wrapping whole natural-language queries in quotes, which turned multi-word input into exact phrase searches and caused common queries to miss.

PR #57 identified the right root cause, but its quote passthrough still left a quote-handling regression in `memory_search`.

## Fix

This PR moves the query normalization into a shared helper and applies the same logic in both search paths.

- Multi-word natural-language input is normalized into quoted-per-term implicit-AND search
- Explicit quoted phrases are preserved
- Uppercase FTS operators still pass through as raw FTS queries
- Lowercase connector words like `and` are ignored in natural-language mode
- Blank queries short-circuit before hitting SQLite
- Only genuine FTS query parse failures are converted into empty results; other DB/runtime errors still surface

## Tests

- Added regression coverage for multi-word search in both memory and session search
- Added quoted-phrase coverage
- Added lowercase connector-word coverage
- Added malformed/unmatched quote coverage
- Added blank-query coverage
- Added valid operator-query coverage

## Verification

- `npm run check` passes
- Direct helper output was sanity-checked with `tsx`
- Representative FTS5 query shapes were validated with `sqlite3`
- A subagent review found edge cases, those were fixed, and the final re-review found no remaining issues

Note: the local Node-backed store tests could not be executed end-to-end in this environment because `better-sqlite3` is currently built for a different Node ABI (`ERR_DLOPEN_FAILED`). CI should cover that path.

Closes #50
Supersedes the current approach in #57.
