### PR TITLE
Fix memory store maintenance flows for issue #52

### DIFF
--- a/src/store/memory-lookup.ts
+++ b/src/store/memory-lookup.ts
@@ -1,0 +1,15 @@
+export function normalizeMemoryLookupText(text: string): string {
+  let normalized = text.trim();
+  if (!normalized) return "";
+
+  const firstNonEmptyLine = normalized
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  if (firstNonEmptyLine) normalized = firstNonEmptyLine;
+
+  normalized = normalized.replace(/^\S+\s+\[[^\]]+\]\s+/u, "");
+  normalized = normalized.replace(/^(\[[^\]]+\])\s+\1(\s+|$)/, "$1 ");
+
+  return normalized.trim();
+}

--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -15,6 +15,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";
 import { scanContent } from "./content-scanner.js";
+import { normalizeMemoryLookupText } from "./memory-lookup.js";
 import {
   ENTRY_DELIMITER,
   DEFAULT_MEMORY_CHAR_LIMIT,
@@ -117,32 +118,17 @@ export class MemoryStore {
     correctedTo?: string;
     project?: string;
   }): Promise<MemoryResult> {
-    content = content.trim();
-    if (!content) return { success: false, error: "Content cannot be empty." };
+    const failureText = this.buildFailureMemoryText(content, options);
+    const result = await this._add("failure", failureText);
 
-    const scanError = scanContent(content);
-    if (scanError) return { success: false, error: scanError };
-
-    const categoryTag = "[" + options.category + "]";
-    const parts = [categoryTag + " " + content];
-    if (options.failureReason) parts.push("Failed: " + options.failureReason);
-    if (options.toolState) parts.push("Tool state: " + options.toolState);
-    if (options.correctedTo) parts.push("Corrected to: " + options.correctedTo);
-    if (options.project) parts.push("Project: " + options.project);
-
-    const failureText = parts.join(" — ");
-    const today = new Date().toISOString().split("T")[0];
-    const encoded = this.encodeEntry(failureText, today, today);
-
-    this.failureEntries.push(encoded);
-    await this.saveToDisk("failure");
-
-    return {
-      success: true,
-      target: "failure",
-      message: "Failure memory saved: " + options.category,
-      entry_count: this.failureEntries.length,
-    };
+    if (!result.success) return result;
+    if (result.message === "Entry added.") {
+      return {
+        ...result,
+        message: "Failure memory saved: " + options.category,
+      };
+    }
+    return result;
   }
 
   getFailureEntries(maxAgeDays = 7): string[] {
@@ -253,7 +239,7 @@ export class MemoryStore {
   }
 
   async replace(target: "memory" | "user" | "failure", oldText: string, newContent: string): Promise<MemoryResult> {
-    oldText = oldText.trim();
+    oldText = normalizeMemoryLookupText(oldText);
     newContent = newContent.trim();
     if (!oldText) return { success: false, error: "old_text cannot be empty." };
     if (!newContent) return { success: false, error: "new_content cannot be empty. Use 'remove' to delete entries." };
@@ -299,18 +285,18 @@ export class MemoryStore {
   }
 
   async remove(target: "memory" | "user" | "failure", oldText: string): Promise<MemoryResult> {
-    oldText = oldText.trim();
+    oldText = normalizeMemoryLookupText(oldText);
     if (!oldText) return { success: false, error: "old_text cannot be empty." };
 
     const entries = this.entriesFor(target);
-    const matches = entries.filter((e) => e.includes(oldText));
+    const matches = entries.filter((e) => this.stripMetadata(e).includes(oldText));
 
     if (matches.length === 0) return { success: false, error: `No entry matched '${oldText}'.` };
     if (matches.length > 1 && new Set(matches).size > 1) {
       return {
         success: false,
         error: `Multiple entries matched '${oldText}'. Be more specific.`,
-        matches: matches.map((e) => e.slice(0, 80) + (e.length > 80 ? "..." : "")),
+        matches: matches.map((e) => this.stripMetadata(e).slice(0, 80) + (this.stripMetadata(e).length > 80 ? "..." : "")),
       };
     }
 
@@ -392,6 +378,23 @@ export class MemoryStore {
     return this.decodeEntry(text).text;
   }
 
+  private buildFailureMemoryText(content: string, options: {
+    category: MemoryCategory;
+    failureReason?: string;
+    toolState?: string;
+    correctedTo?: string;
+    project?: string;
+  }): string {
+    const trimmedContent = content.trim();
+    const categoryTag = "[" + options.category + "]";
+    const parts = [categoryTag + " " + trimmedContent];
+    if (options.failureReason) parts.push("Failed: " + options.failureReason);
+    if (options.toolState) parts.push("Tool state: " + options.toolState);
+    if (options.correctedTo) parts.push("Corrected to: " + options.correctedTo);
+    if (options.project) parts.push("Project: " + options.project);
+    return parts.join(" — ");
+  }
+
   private successResponse(target: "memory" | "user" | "failure", message?: string): MemoryResult {
     const entries = this.entriesFor(target);
     const current = this.charCount(target);
@@ -401,7 +404,6 @@ export class MemoryStore {
     const resp: MemoryResult = {
       success: true,
       target,
-      entries,
       usage: `${pct}% — ${current}/${limit} chars`,
       entry_count: entries.length,
     };

--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -119,16 +119,7 @@ export class MemoryStore {
     project?: string;
   }): Promise<MemoryResult> {
     const failureText = this.buildFailureMemoryText(content, options);
-    const result = await this._add("failure", failureText);
-
-    if (!result.success) return result;
-    if (result.message === "Entry added.") {
-      return {
-        ...result,
-        message: "Failure memory saved: " + options.category,
-      };
-    }
-    return result;
+    return this._add("failure", failureText, undefined, 1, "Failure memory saved: " + options.category);
   }
 
   getFailureEntries(maxAgeDays = 7): string[] {
@@ -144,7 +135,13 @@ export class MemoryStore {
       .map((entry) => this.stripMetadata(entry));
   }
 
-  private async _add(target: "memory" | "user" | "failure", content: string, signal?: AbortSignal, _retriesLeft = 1): Promise<MemoryResult> {
+  private async _add(
+    target: "memory" | "user" | "failure",
+    content: string,
+    signal?: AbortSignal,
+    _retriesLeft = 1,
+    addedMessage = "Entry added.",
+  ): Promise<MemoryResult> {
     content = content.trim();
     if (!content) return { success: false, error: "Content cannot be empty." };
 
@@ -180,7 +177,7 @@ export class MemoryStore {
             // CRITICAL: reload from disk — child process modified files, our arrays are stale
             await this.loadFromDisk();
             // Retry the add exactly once (retriesLeft = 0 means no more consolidation)
-            return this._add(target, content, signal, _retriesLeft - 1);
+            return this._add(target, content, signal, _retriesLeft - 1, addedMessage);
           }
         } catch {
           // Consolidation failed — fall through to error
@@ -193,7 +190,7 @@ export class MemoryStore {
     this.setEntries(target, entries);
     await this.saveToDisk(target);
 
-    return this.successResponse(target, "Entry added.");
+    return this.successResponse(target, addedMessage);
   }
 
   private async fifoEvictAndAdd(

--- a/src/store/sqlite-memory-store.ts
+++ b/src/store/sqlite-memory-store.ts
@@ -1,5 +1,6 @@
 import { DatabaseManager } from './db.js';
 import { isFts5QueryError, normalizeFts5Query } from './fts-query.js';
+import { normalizeMemoryLookupText } from './memory-lookup.js';
 import type { MemoryCategory } from '../types.js';
 
 const MEMORY_SELECT_COLUMNS = `
@@ -421,10 +422,12 @@ export function replaceSyncedMemories(
   },
 ): SqliteMemoryUpdateResult {
   const db = dbManager.getDb();
+  const normalizedOldText = normalizeMemoryLookupText(oldText);
+  if (!normalizedOldText) return { matched: 0, updated: 0, entries: [] };
   const params: unknown[] = [];
   const conditions = buildScopeConditions(params, updates.target, updates.project ?? undefined);
   conditions.push(`content LIKE ? ESCAPE '\\'`);
-  params.push(`%${escapeLikePattern(oldText)}%`);
+  params.push(`%${escapeLikePattern(normalizedOldText)}%`);
 
   const rows = db.prepare(`
     SELECT ${MEMORY_SELECT_COLUMNS}
@@ -490,10 +493,12 @@ export function removeSyncedMemories(
   options: SqliteMemoryRemoveOptions,
 ): SqliteMemoryRemoveResult {
   const db = dbManager.getDb();
+  const normalizedOldText = normalizeMemoryLookupText(oldText);
+  if (!normalizedOldText) return { matched: 0, removed: 0 };
   const params: unknown[] = [];
   const conditions = buildScopeConditions(params, options.target, options.project ?? undefined);
   conditions.push(`content LIKE ? ESCAPE '\\'`);
-  params.push(`%${escapeLikePattern(oldText)}%`);
+  params.push(`%${escapeLikePattern(normalizedOldText)}%`);
 
   const matchingIds = db.prepare(`
     SELECT id

--- a/tests/store/memory-store.test.ts
+++ b/tests/store/memory-store.test.ts
@@ -143,6 +143,7 @@ describe("MemoryStore", { concurrency: 1 }, () => {
       assert.ok(result.usage!.includes("chars"));
       assert.equal(result.entry_count, 1);
       assert.equal(result.message, "Entry added.");
+      assert.equal(result.entries, undefined);
 
       const raw = await readRaw(memoryPath);
       assert.ok(raw.includes(`${TEST_MARKER} project uses pnpm`));
@@ -355,6 +356,47 @@ describe("MemoryStore", { concurrency: 1 }, () => {
     });
   });
 
+  describe("addFailure()", () => {
+    it("applies failure-target char limits", async () => {
+      const store = new MemoryStore(makeConfig({ memoryCharLimit: 40 }));
+      await store.loadFromDisk();
+
+      const result = await store.addFailure(`${TEST_MARKER} ${"x".repeat(120)}`, {
+        category: "failure",
+      });
+      await settle();
+
+      assert.ok(!result.success);
+      assert.ok(result.error);
+      assert.ok(result.error!.includes("exceed the limit"));
+    });
+
+    it("deduplicates exact failure memories", async () => {
+      const store = new MemoryStore(makeConfig());
+      await store.loadFromDisk();
+
+      const first = await store.addFailure(`${TEST_MARKER} use pnpm`, {
+        category: "correction",
+        failureReason: "npm rewrote the lockfile",
+      });
+      const second = await store.addFailure(`${TEST_MARKER} use pnpm`, {
+        category: "correction",
+        failureReason: "npm rewrote the lockfile",
+      });
+      await settle();
+
+      assert.ok(first.success);
+      assert.equal(first.message, "Failure memory saved: correction");
+      assert.ok(second.success);
+      assert.equal(second.message, "Entry already exists (no duplicate added).");
+      assert.equal(second.entry_count, 1);
+
+      const raw = await readRaw(failurePath);
+      const count = raw.split(ENTRY_DELIMITER).filter(Boolean).length;
+      assert.equal(count, 1);
+    });
+  });
+
   // ─── replace() tests ───
 
   describe("replace()", () => {
@@ -370,6 +412,7 @@ describe("MemoryStore", { concurrency: 1 }, () => {
 
       assert.ok(result.success);
       assert.equal(result.message, "Entry replaced.");
+      assert.equal(result.entries, undefined);
 
       const raw = await readRaw(memoryPath);
       assert.ok(!raw.includes(`${TEST_MARKER} uses vim`));
@@ -445,10 +488,47 @@ describe("MemoryStore", { concurrency: 1 }, () => {
       assert.ok(result.success);
       assert.equal(result.message, "Entry removed.");
       assert.equal(result.entry_count, 1);
+      assert.equal(result.entries, undefined);
 
       const raw = await readRaw(memoryPath);
       assert.ok(!raw.includes(`${TEST_MARKER} to be removed`));
       assert.ok(raw.includes(`${TEST_MARKER} to keep`));
+    });
+
+    it("accepts a pasted memory_search line for normal memories", async () => {
+      const store = new MemoryStore(makeConfig());
+      await store.loadFromDisk();
+
+      await store.add("memory", `${TEST_MARKER} prefers pnpm over npm`);
+      await settle();
+
+      const result = await store.remove("memory", `🧠 [global] ${TEST_MARKER} prefers pnpm over npm\n   Created: 2026-05-27 | Last used: 2026-05-27`);
+      await settle();
+
+      assert.ok(result.success);
+      const raw = await readRaw(memoryPath);
+      assert.equal(raw.trim(), "");
+    });
+
+    it("accepts a pasted memory_search line for failure memories", async () => {
+      const store = new MemoryStore(makeConfig());
+      await store.loadFromDisk();
+
+      await store.addFailure(`${TEST_MARKER} use pnpm`, {
+        category: "correction",
+        failureReason: "npm rewrote the lockfile",
+      });
+      await settle();
+
+      const result = await store.remove(
+        "failure",
+        `⚠️ [global] [correction] [correction] ${TEST_MARKER} use pnpm\n   Created: 2026-05-27 | Last used: 2026-05-27`,
+      );
+      await settle();
+
+      assert.ok(result.success);
+      const raw = await readRaw(failurePath);
+      assert.equal(raw.trim(), "");
     });
 
     it("returns error when no match found", async () => {

--- a/tests/store/sqlite-memory-store.test.ts
+++ b/tests/store/sqlite-memory-store.test.ts
@@ -148,6 +148,41 @@ describe('sqlite-memory-store', () => {
       assert.strictEqual(all.length, 1);
       assert.strictEqual(all[0].content, 'remove 50AAmatch literal');
     });
+
+    it('normalizes pasted memory_search lines during replace matching', () => {
+      addMemory(dbManager, 'prefers pnpm over npm');
+
+      const result = replaceSyncedMemories(
+        dbManager,
+        '🧠 [global] prefers pnpm over npm\n   Created: 2026-05-27 | Last used: 2026-05-27',
+        {
+          content: 'prefers pnpm over npm and bun when needed',
+          target: 'memory',
+          project: null,
+        },
+      );
+
+      assert.strictEqual(result.matched, 1);
+      const all = getMemories(dbManager);
+      assert.ok(all.some((entry) => entry.content === 'prefers pnpm over npm and bun when needed'));
+    });
+
+    it('normalizes pasted memory_search lines during remove matching', () => {
+      addMemory(dbManager, '[correction] use pnpm — Failed: npm rewrote the lockfile', 'failure');
+
+      const result = removeSyncedMemories(
+        dbManager,
+        '⚠️ [global] [correction] [correction] use pnpm\n   Created: 2026-05-27 | Last used: 2026-05-27',
+        {
+          target: 'failure',
+          project: null,
+        },
+      );
+
+      assert.strictEqual(result.matched, 1);
+      const all = getMemories(dbManager);
+      assert.strictEqual(all.length, 0);
+    });
   });
 
   describe('searchMemories', () => {


### PR DESCRIPTION
## Summary

Fixes #52 by hardening the Markdown memory store and its SQLite mirror so failure memories respect limits, pasted `memory_search` output can be removed directly, and successful mutation responses stay bounded.

## What changed

- route `addFailure()` through the normal `_add()` path so failure memories get the same cap enforcement, overflow handling, content scanning, and exact dedupe as other targets
- normalize pasted `memory_search` result lines before `replace`/`remove`, and match against visible entry text instead of raw metadata-appended storage entries
- apply the same lookup normalization in SQLite `replaceSyncedMemories()` and `removeSyncedMemories()` so the search mirror stays consistent with Markdown behavior
- drop the full `entries` payload from successful `MemoryResult` mutation responses so large stores do not dump huge JSON blobs back to the model
- make the `addFailure()` success message explicit instead of keying off the literal `Entry added.` string

## Tests

- `npm run check`
- `npm test`
- `npx tsx --test tests/store/memory-store.test.ts tests/store/sqlite-memory-store.test.ts tests/tools/memory-tool.test.ts`
- `npx tsx --test tests/store/memory-store.test.ts`

## Runtime validation in Pi sessions

Two interactive `pi -e src/index.ts` sessions were used to validate the user-facing behavior after the code changes:

- Failure-memory cap enforcement now blocks over-limit writes cleanly. In the first session, adding a new failure memory failed with `Memory at 20718/10000 chars... would exceed the limit`, which confirms the old direct-write bypass is gone.
- After removing low-value failure entries to make room, the same failure memory add succeeded with a concise response: `Failure memory saved: correction` and bounded usage metadata.
- Re-adding the exact same failure memory returned `Entry already exists (no duplicate added).`, confirming exact dedupe now applies to `target="failure"` too.
- `memory_search` returned the expected formatted search output for the new failure memory and the normal memory entry.
- In the second session, removing a failure memory using the full pasted search-result block (`⚠️ [global] ...` plus the `Created`/`Last used` line) succeeded.
- In the same session, removing a normal memory using the full pasted search-result block (`🧠 [global] ...` plus the `Created`/`Last used` line) also succeeded.
- Successful remove responses stayed concise throughout the sessions; they returned status, target, usage, entry count, and message instead of dumping the whole store.

## Notes

- This PR intentionally does not add stable memory IDs or near-duplicate detection. Those are reasonable follow-ups, but they are not required to fix the concrete issue-52 bugs.
