### PR TITLE
feat: add child LLM overrides for maintenance calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,8 @@ Create `~/.pi/agent/hermes-memory-config.json`:
   "memoryDir": "~/.pi/agent/pi-hermes-memory",
   "projectsMemoryDir": "projects-memory",
   "sessionSearch": { "variant": "legacy" },
+  "llmModelOverride": "openrouter/deepseek/deepseek-v4-flash",
+  "llmThinkingOverride": "off",
   "nudgeInterval": 10,
   "nudgeToolCalls": 15,
   "reviewRecentMessages": 0,
@@ -453,6 +455,8 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 | `memoryDir` | `~/.pi/agent/pi-hermes-memory` | Custom directory for extension storage files |
 | `projectsMemoryDir` | `projects-memory` | Subdirectory under `~/.pi/agent/` for project-scoped memory |
 | `sessionSearch` | `{ "variant": "legacy" }` | Session search implementation: `legacy` keeps the existing SQLite/FTS snippet search; `anchors` uses the opt-in Markdown request surface and returns compact JSONL line-range anchors from `~/.pi/agent/sessions/` |
+| `llmModelOverride` | unset | Optional model override for child `pi -p` subprocess calls used by background review, correction save, session flush, and consolidation |
+| `llmThinkingOverride` | unset | Optional thinking override for those child subprocess calls; valid values are `off`, `minimal`, `low`, `medium`, `high`, and `xhigh`. If `llmModelOverride` is set and this is omitted, child calls default to `off` |
 | `nudgeInterval` | `10` | Turns between auto-reviews |
 | `nudgeToolCalls` | `15` | Tool calls between auto-reviews (OR with turns) |
 | `reviewRecentMessages` | `0` | Recent messages included in background review (`0` = all) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hermes-memory",
-      "version": "0.7.13",
+      "version": "0.7.14",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-tui": "^0.74.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "description": "🧠 Persistent memory + 🔍 session search + 🛡️ secret scanning for Pi. Token-aware policy-only memory by default, SQLite FTS5 search, auto-consolidation, procedural skills. 368 tests. Ported from Hermes agent.",
   "type": "module",
   "main": "src/index.ts",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import type { MemoryConfig, MemoryOverflowStrategy, SessionSearchVariant } from "./types.js";
+import type { MemoryConfig, MemoryOverflowStrategy, SessionSearchVariant, ThinkingLevel } from "./types.js";
 import {
   DEFAULT_MEMORY_CHAR_LIMIT,
   DEFAULT_USER_CHAR_LIMIT,
@@ -20,6 +20,7 @@ import { normalizeConfiguredMemoryDir, normalizeProjectsMemoryDir } from "./path
 
 const MEMORY_OVERFLOW_STRATEGIES: readonly MemoryOverflowStrategy[] = ["auto-consolidate", "reject", "fifo-evict"];
 const SESSION_SEARCH_VARIANTS: readonly SessionSearchVariant[] = ["legacy", "anchors"];
+const THINKING_LEVELS: readonly ThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh"];
 
 function isMemoryOverflowStrategy(value: unknown): value is MemoryOverflowStrategy {
   return typeof value === "string" && MEMORY_OVERFLOW_STRATEGIES.includes(value as MemoryOverflowStrategy);
@@ -27,6 +28,10 @@ function isMemoryOverflowStrategy(value: unknown): value is MemoryOverflowStrate
 
 function isSessionSearchVariant(value: unknown): value is SessionSearchVariant {
   return typeof value === "string" && SESSION_SEARCH_VARIANTS.includes(value as SessionSearchVariant);
+}
+
+function isThinkingLevel(value: unknown): value is ThinkingLevel {
+  return typeof value === "string" && THINKING_LEVELS.includes(value as ThinkingLevel);
 }
 
 const DEFAULT_CONFIG: MemoryConfig = {
@@ -127,6 +132,11 @@ export function loadConfig(configPath = DEFAULT_CONFIG_PATH): MemoryConfig {
       ) {
         config.sessionSearch = { variant: parsed.sessionSearch.variant };
       }
+      if (typeof parsed.llmModelOverride === "string") {
+        const trimmed = parsed.llmModelOverride.trim();
+        if (trimmed.length > 0) config.llmModelOverride = trimmed;
+      }
+      if (isThinkingLevel(parsed.llmThinkingOverride)) config.llmThinkingOverride = parsed.llmThinkingOverride;
       if (hasMemoryOverflowStrategy) {
         config.autoConsolidate = config.memoryOverflowStrategy === "auto-consolidate";
       } else if (hasLegacyAutoConsolidate) {

--- a/src/handlers/auto-consolidate.ts
+++ b/src/handlers/auto-consolidate.ts
@@ -10,7 +10,8 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { MemoryStore } from "../store/memory-store.js";
 import { CONSOLIDATION_PROMPT, ENTRY_DELIMITER } from "../constants.js";
-import type { ConsolidationResult } from "../types.js";
+import type { ConsolidationResult, MemoryConfig } from "../types.js";
+import { execChildPrompt } from "./pi-child-process.js";
 
 type MemoryTarget = "memory" | "user" | "failure";
 type ToolMemoryTarget = MemoryTarget | "project";
@@ -33,6 +34,7 @@ export async function triggerConsolidation(
   signal?: AbortSignal,
   timeoutMs: number = 60000,
   toolTarget: ToolMemoryTarget = target,
+  llmConfig: Pick<MemoryConfig, "llmModelOverride" | "llmThinkingOverride"> = {},
 ): Promise<ConsolidationResult> {
   const entries = entriesForTarget(store, target);
   const currentContent = entries.join(ENTRY_DELIMITER);
@@ -47,9 +49,10 @@ export async function triggerConsolidation(
   ].join("\n");
 
   try {
-    const result = await pi.exec("pi", ["-p", "--no-session", prompt], {
+    const result = await execChildPrompt(pi, prompt, llmConfig, {
       signal,
-      timeout: timeoutMs,
+      timeoutMs,
+      retryWithoutOverrides: true,
     });
 
     if (result.code === 0) {
@@ -76,6 +79,7 @@ export function registerConsolidateCommand(
   timeoutMs: number = 60000,
   projectStore: MemoryStore | null = null,
   projectName?: string | null,
+  llmConfig: Pick<MemoryConfig, "llmModelOverride" | "llmThinkingOverride"> = {},
 ): void {
   pi.registerCommand("memory-consolidate", {
     description: "Manually trigger memory consolidation to free up space",
@@ -108,7 +112,7 @@ export function registerConsolidateCommand(
           continue;
         }
 
-        const result = await triggerConsolidation(pi, item.store, item.target, ctx.signal, timeoutMs, item.toolTarget);
+        const result = await triggerConsolidation(pi, item.store, item.target, ctx.signal, timeoutMs, item.toolTarget, llmConfig);
 
         if (result.consolidated) {
           await item.store.loadFromDisk();

--- a/src/handlers/auto-consolidate.ts
+++ b/src/handlers/auto-consolidate.ts
@@ -122,10 +122,16 @@ export function registerConsolidateCommand(
         }
       }
 
-      ctx.ui.notify(
-        `\n  🔄 Memory Consolidation\n  ${"─".repeat(30)}\n${results.map((r) => `  ${r}`).join("\n")}`,
-        "info",
-      );
+      const summary = `\n  🔄 Memory Consolidation\n  ${"─".repeat(30)}\n${results.map((r) => `  ${r}`).join("\n")}`;
+
+      try {
+        ctx.ui.notify(summary, "info");
+      } catch {
+        // Child consolidation can indirectly trigger a runtime reload/session
+        // replacement. If that happens, the original command ctx is stale by
+        // the time we reach the final summary, so the command should exit
+        // quietly instead of surfacing a stale-ctx error.
+      }
     },
   });
 }

--- a/src/handlers/auto-consolidate.ts
+++ b/src/handlers/auto-consolidate.ts
@@ -119,12 +119,31 @@ export function registerConsolidateCommand(
         });
       }
 
+      try {
+        ctx.ui.notify(
+          `🔄 Starting memory consolidation for ${targets.length} target${targets.length === 1 ? "" : "s"}...`,
+          "info",
+        );
+      } catch {
+        // Best-effort only. If the command context is already stale, continue
+        // with the consolidation work rather than failing before it starts.
+      }
+
       for (const item of targets) {
         const entries = entriesForTarget(item.store, item.target);
 
         if (entries.length === 0) {
           results.push(`${item.label}: (empty, nothing to consolidate)`);
           continue;
+        }
+
+        try {
+          ctx.ui.notify(
+            `⏳ Consolidating ${item.label}...`,
+            "info",
+          );
+        } catch {
+          // Best-effort progress feedback only.
         }
 
         const result = await triggerConsolidation(

--- a/src/handlers/auto-consolidate.ts
+++ b/src/handlers/auto-consolidate.ts
@@ -27,6 +27,20 @@ function labelForTarget(target: MemoryTarget, toolTarget: ToolMemoryTarget): str
   return "Memory";
 }
 
+function describeConsolidationFailure(
+  result: { code: number; stderr?: string; killed?: boolean },
+  timeoutMs: number,
+): string {
+  const stderr = result.stderr?.trim();
+  const terminated = result.killed || result.code === 143;
+
+  if (terminated) {
+    return `Consolidation subprocess was terminated (likely timeout or cancellation). Timeout: ${timeoutMs}ms. Consider increasing consolidationTimeoutMs if this is a manual run.`;
+  }
+
+  return `Consolidation process exited with code ${result.code}: ${stderr?.slice(0, 200) || "unknown error"}`;
+}
+
 export async function triggerConsolidation(
   pi: ExtensionAPI,
   store: MemoryStore,
@@ -53,14 +67,14 @@ export async function triggerConsolidation(
       signal,
       timeoutMs,
       retryWithoutOverrides: true,
-    });
+    }) as { code: number; stdout?: string; stderr?: string; killed?: boolean };
 
     if (result.code === 0) {
       return { consolidated: true };
     }
     return {
       consolidated: false,
-      error: `Consolidation process exited with code ${result.code}: ${result.stderr?.slice(0, 200) || "unknown error"}`,
+      error: describeConsolidationFailure(result, timeoutMs),
     };
   } catch (err) {
     return {
@@ -84,6 +98,7 @@ export function registerConsolidateCommand(
   pi.registerCommand("memory-consolidate", {
     description: "Manually trigger memory consolidation to free up space",
     handler: async (_args, ctx) => {
+      const manualTimeoutMs = Math.max(timeoutMs, 180000);
       const results: string[] = [];
       const targets: Array<{
         label: string;
@@ -112,7 +127,15 @@ export function registerConsolidateCommand(
           continue;
         }
 
-        const result = await triggerConsolidation(pi, item.store, item.target, ctx.signal, timeoutMs, item.toolTarget, llmConfig);
+        const result = await triggerConsolidation(
+          pi,
+          item.store,
+          item.target,
+          ctx.signal,
+          manualTimeoutMs,
+          item.toolTarget,
+          llmConfig,
+        );
 
         if (result.consolidated) {
           await item.store.loadFromDisk();

--- a/src/handlers/background-review.ts
+++ b/src/handlers/background-review.ts
@@ -12,6 +12,7 @@ import { MemoryStore } from "../store/memory-store.js";
 import { COMBINED_REVIEW_PROMPT } from "../constants.js";
 import type { MemoryConfig } from "../types.js";
 import { applyRecentMessageLimit, collectMessageParts } from "./message-parts.js";
+import { execChildPrompt } from "./pi-child-process.js";
 
 export function setupBackgroundReview(
   pi: ExtensionAPI,
@@ -116,9 +117,9 @@ export function setupBackgroundReview(
     // We intentionally omit ctx.signal — the signal is tied to the turn
     // lifetime and would abort the subprocess before it finishes now that
     // we're not awaiting. The timeout (120s) provides its own safety net.
-    const reviewPromise = pi.exec("pi", ["-p", "--no-session", reviewPrompt.join("\n")], {
+    const reviewPromise = execChildPrompt(pi, reviewPrompt.join("\n"), config, {
       signal: undefined,
-      timeout: 120000,
+      timeoutMs: 120000,
     });
 
     reviewPromise

--- a/src/handlers/correction-detector.ts
+++ b/src/handlers/correction-detector.ts
@@ -25,6 +25,7 @@ import {
 } from "../constants.js";
 import type { MemoryConfig } from "../types.js";
 import { getMessageText } from "../types.js";
+import { execChildPrompt } from "./pi-child-process.js";
 
 /**
  * Extract the directive part from a correction message.
@@ -205,9 +206,9 @@ export function setupCorrectionDetector(
         recentParts.join("\n\n"),
       );
 
-      const result = await pi.exec("pi", ["-p", "--no-session", prompt.join("\n")], {
+      const result = await execChildPrompt(pi, prompt.join("\n"), config, {
         signal: ctx.signal,
-        timeout: 30000,
+        timeoutMs: 30000,
       });
 
       if (result.code === 0 && result.stdout) {

--- a/src/handlers/pi-child-process.ts
+++ b/src/handlers/pi-child-process.ts
@@ -1,0 +1,95 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { MemoryConfig, ThinkingLevel } from "../types.js";
+
+type ChildLlmConfig = Pick<MemoryConfig, "llmModelOverride" | "llmThinkingOverride">;
+
+interface PiExecResult {
+  code: number;
+  stdout?: string;
+  stderr?: string;
+}
+
+interface ExecChildPromptOptions {
+  signal?: AbortSignal;
+  timeoutMs: number;
+  retryWithoutOverrides?: boolean;
+}
+
+const OVERRIDE_FAILURE_SUBJECT = /\b(model|provider|thinking)\b/i;
+const OVERRIDE_FAILURE_REASON = /\b(not found|unknown|invalid|unsupported|unavailable|unrecognized|no match|no matches|cannot resolve|failed to resolve)\b/i;
+
+function normalizedModelOverride(config: ChildLlmConfig): string | undefined {
+  const trimmed = config.llmModelOverride?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function effectiveThinkingOverride(config: ChildLlmConfig): ThinkingLevel | undefined {
+  return config.llmThinkingOverride ?? (normalizedModelOverride(config) ? "off" : undefined);
+}
+
+export function hasChildLlmOverrides(config: ChildLlmConfig): boolean {
+  return normalizedModelOverride(config) !== undefined || effectiveThinkingOverride(config) !== undefined;
+}
+
+export function buildChildPiPromptArgs(prompt: string, config: ChildLlmConfig): string[] {
+  const args = ["-p", "--no-session"];
+  const model = normalizedModelOverride(config);
+  const thinking = effectiveThinkingOverride(config);
+
+  if (model) args.push("--model", model);
+  if (thinking) args.push("--thinking", thinking);
+  args.push(prompt);
+
+  return args;
+}
+
+function basePromptArgs(prompt: string): string[] {
+  return ["-p", "--no-session", prompt];
+}
+
+function shouldRetryWithoutOverridesFromText(text: string | undefined): boolean {
+  if (!text) return false;
+  return OVERRIDE_FAILURE_SUBJECT.test(text) && OVERRIDE_FAILURE_REASON.test(text);
+}
+
+function shouldRetryWithoutOverrides(result: PiExecResult): boolean {
+  return shouldRetryWithoutOverridesFromText(result.stderr) || shouldRetryWithoutOverridesFromText(result.stdout);
+}
+
+function shouldRetryWithoutOverridesForError(error: unknown): boolean {
+  return shouldRetryWithoutOverridesFromText(String(error));
+}
+
+export async function execChildPrompt(
+  pi: Pick<ExtensionAPI, "exec">,
+  prompt: string,
+  config: ChildLlmConfig,
+  options: ExecChildPromptOptions,
+): Promise<PiExecResult> {
+  const execOptions = {
+    signal: options.signal,
+    timeout: options.timeoutMs,
+  };
+
+  try {
+    const result = await pi.exec("pi", buildChildPiPromptArgs(prompt, config), execOptions) as PiExecResult;
+    if (
+      result.code === 0 ||
+      !options.retryWithoutOverrides ||
+      !hasChildLlmOverrides(config) ||
+      !shouldRetryWithoutOverrides(result)
+    ) {
+      return result;
+    }
+  } catch (error) {
+    if (
+      !options.retryWithoutOverrides ||
+      !hasChildLlmOverrides(config) ||
+      !shouldRetryWithoutOverridesForError(error)
+    ) {
+      throw error;
+    }
+  }
+
+  return pi.exec("pi", basePromptArgs(prompt), execOptions) as Promise<PiExecResult>;
+}

--- a/src/handlers/pi-child-process.ts
+++ b/src/handlers/pi-child-process.ts
@@ -31,13 +31,37 @@ export function hasChildLlmOverrides(config: ChildLlmConfig): boolean {
   return normalizedModelOverride(config) !== undefined || effectiveThinkingOverride(config) !== undefined;
 }
 
-export function buildChildPiPromptArgs(prompt: string, config: ChildLlmConfig): string[] {
+export function inheritedExtensionArgs(argv: string[] = process.argv.slice(2)): string[] {
+  const args: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const current = argv[i];
+    if (current === "-e" || current === "--extension") {
+      const next = argv[i + 1];
+      if (typeof next === "string" && next.length > 0) {
+        args.push(current, next);
+        i++;
+      }
+      continue;
+    }
+
+    if (current.startsWith("--extension=")) {
+      args.push(current);
+    }
+  }
+
+  return args;
+}
+
+export function buildChildPiPromptArgs(prompt: string, config: ChildLlmConfig, argv: string[] = process.argv.slice(2)): string[] {
   const args = ["-p", "--no-session"];
   const model = normalizedModelOverride(config);
   const thinking = effectiveThinkingOverride(config);
+  const inheritedExtensions = inheritedExtensionArgs(argv);
 
   if (model) args.push("--model", model);
   if (thinking) args.push("--thinking", thinking);
+  args.push(...inheritedExtensions);
   args.push(prompt);
 
   return args;

--- a/src/handlers/session-flush.ts
+++ b/src/handlers/session-flush.ts
@@ -9,6 +9,7 @@ import { MemoryStore } from "../store/memory-store.js";
 import { FLUSH_PROMPT } from "../constants.js";
 import type { MemoryConfig } from "../types.js";
 import { collectMessageParts } from "./message-parts.js";
+import { execChildPrompt } from "./pi-child-process.js";
 
 export function setupSessionFlush(
   pi: ExtensionAPI,
@@ -42,9 +43,9 @@ export function setupSessionFlush(
     ].join("\n");
 
     try {
-      await pi.exec("pi", ["-p", "--no-session", flushMessage], {
+      await execChildPrompt(pi, flushMessage, config, {
         signal,
-        timeout: timeoutMs,
+        timeoutMs,
       });
     } catch {
       // Best-effort flush — never block shutdown

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,15 +179,15 @@ export default function (pi: ExtensionAPI) {
 
   // ── 7. Setup auto-consolidation (inject consolidator into stores) ──
   store.setConsolidator(async (target, signal) => {
-    return triggerConsolidation(pi, store, target, signal, config.consolidationTimeoutMs);
+    return triggerConsolidation(pi, store, target, signal, config.consolidationTimeoutMs, target, config);
   });
   if (projectStore) {
     projectStore.setConsolidator(async (target, signal) => {
       const toolTarget = target === "memory" ? "project" : target;
-      return triggerConsolidation(pi, projectStore, target, signal, config.consolidationTimeoutMs, toolTarget);
+      return triggerConsolidation(pi, projectStore, target, signal, config.consolidationTimeoutMs, toolTarget, config);
     });
   }
-  registerConsolidateCommand(pi, store, config.consolidationTimeoutMs, projectStore, projectName);
+  registerConsolidateCommand(pi, store, config.consolidationTimeoutMs, projectStore, projectName, config);
 
   // ── 8. Setup correction detection ──
   setupCorrectionDetector(pi, store, projectStore, config, dbManager, projectName);

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -25,50 +25,50 @@ type BunDatabaseInstance = {
   transaction?: (fn: any) => any;
 };
 
+function createBunCompatDatabaseCtor(require: NodeRequire): DatabaseCtor {
+  const bunSqlite = require('bun:sqlite') as { Database: new (dbPath: string) => BunDatabaseInstance };
+
+  return class BunCompatDatabase implements DatabaseLike {
+    private readonly db: BunDatabaseInstance;
+
+    constructor(dbPath: string) {
+      this.db = new bunSqlite.Database(dbPath);
+    }
+
+    prepare(sql: string): StatementLike {
+      return this.db.prepare(sql);
+    }
+
+    exec(sql: string): void {
+      this.db.exec(sql);
+    }
+
+    close(): void {
+      this.db.close();
+    }
+
+    transaction(fn: any): any {
+      if (!this.db.transaction) {
+        return undefined;
+      }
+      return this.db.transaction(fn);
+    }
+  };
+}
+
 function loadDatabaseCtor(): DatabaseCtor {
   const require = createRequire(import.meta.url);
+  const isBunRuntime = typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined';
+
+  if (isBunRuntime) {
+    return createBunCompatDatabaseCtor(require);
+  }
+
   try {
     const mod = require('better-sqlite3') as { default?: DatabaseCtor } | DatabaseCtor;
     return (mod as { default?: DatabaseCtor }).default ?? (mod as DatabaseCtor);
   } catch (err) {
-    const msg = err instanceof Error ? err.message.toLowerCase() : '';
-    const isBunRuntime = typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined';
-    const isBunIncompat = msg.includes('better-sqlite3 is not yet supported in bun') || msg.includes('not yet supported in bun');
-    if (!isBunIncompat) {
-      throw err;
-    }
-    if (!isBunRuntime) {
-      throw err;
-    }
-
-    const bunSqlite = require('bun:sqlite') as { Database: new (dbPath: string) => BunDatabaseInstance };
-
-    return class BunCompatDatabase implements DatabaseLike {
-      private readonly db: BunDatabaseInstance;
-
-      constructor(dbPath: string) {
-        this.db = new bunSqlite.Database(dbPath);
-      }
-
-      prepare(sql: string): StatementLike {
-        return this.db.prepare(sql);
-      }
-
-      exec(sql: string): void {
-        this.db.exec(sql);
-      }
-
-      close(): void {
-        this.db.close();
-      }
-
-      transaction(fn: any): any {
-        if (!this.db.transaction) {
-          return undefined;
-        }
-        return this.db.transaction(fn);
-      }
-    };
+    throw err;
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,8 @@ export type MemoryOverflowStrategy = "auto-consolidate" | "reject" | "fifo-evict
 
 export type SessionSearchVariant = "legacy" | "anchors";
 
+export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+
 export interface SessionSearchConfig {
   /** Session search implementation variant. Default: legacy */
   variant: SessionSearchVariant;
@@ -46,6 +48,10 @@ export interface MemoryConfig {
   projectsMemoryDir?: string;
   /** Session search configuration. Default: { variant: "legacy" } */
   sessionSearch?: SessionSearchConfig;
+  /** Override model used for child pi -p subprocess LLM calls. Default: unset */
+  llmModelOverride?: string;
+  /** Override thinking level used for child pi -p subprocess LLM calls. Default: unset */
+  llmThinkingOverride?: ThinkingLevel;
   /** Strategy when memory is full. Default: auto-consolidate */
   memoryOverflowStrategy?: MemoryOverflowStrategy;
   /** Legacy alias for memoryOverflowStrategy. Default: true */

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -33,6 +33,8 @@ describe("loadConfig", () => {
     assert.strictEqual(config.failureInjectionMaxEntries, 5);
     assert.strictEqual(config.projectsMemoryDir, "projects-memory");
     assert.deepStrictEqual(config.sessionSearch, { variant: "legacy" });
+    assert.strictEqual(config.llmModelOverride, undefined);
+    assert.strictEqual(config.llmThinkingOverride, undefined);
   });
 
   it("overrides defaults when config file exists", () => {
@@ -50,6 +52,8 @@ describe("loadConfig", () => {
       failureInjectionMaxAgeDays: 30,
       failureInjectionMaxEntries: 2,
       projectsMemoryDir: "my-memory",
+      llmModelOverride: " openrouter/deepseek/deepseek-v4-flash ",
+      llmThinkingOverride: "minimal",
     }));
     const config = loadConfig(TEST_CONFIG_PATH);
     assert.strictEqual(config.memoryMode, "legacy-inject");
@@ -63,6 +67,8 @@ describe("loadConfig", () => {
     assert.strictEqual(config.failureInjectionMaxAgeDays, 30);
     assert.strictEqual(config.failureInjectionMaxEntries, 2);
     assert.strictEqual(config.projectsMemoryDir, "my-memory");
+    assert.strictEqual(config.llmModelOverride, "openrouter/deepseek/deepseek-v4-flash");
+    assert.strictEqual(config.llmThinkingOverride, "minimal");
     // Unset values use defaults
     assert.strictEqual(config.userCharLimit, 5000);
     assert.strictEqual(config.reviewEnabled, true);
@@ -82,6 +88,8 @@ describe("loadConfig", () => {
     assert.strictEqual(config.failureInjectionMaxAgeDays, 7);
     assert.strictEqual(config.failureInjectionMaxEntries, 5);
     assert.strictEqual(config.projectsMemoryDir, "projects-memory");
+    assert.strictEqual(config.llmModelOverride, undefined);
+    assert.strictEqual(config.llmThinkingOverride, undefined);
   });
 
   it("expands ~/ memoryDir into an absolute home path", () => {
@@ -256,6 +264,27 @@ describe("loadConfig", () => {
       const config = loadConfig(TEST_CONFIG_PATH);
       assert.deepStrictEqual(config.sessionSearch, { variant });
     }
+  });
+
+  it("accepts valid llmThinkingOverride values and ignores invalid ones", () => {
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+
+    for (const level of ["off", "minimal", "low", "medium", "high", "xhigh"] as const) {
+      fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({ llmThinkingOverride: level }));
+      const config = loadConfig(TEST_CONFIG_PATH);
+      assert.strictEqual(config.llmThinkingOverride, level);
+    }
+
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({ llmThinkingOverride: "ultra" }));
+    const invalid = loadConfig(TEST_CONFIG_PATH);
+    assert.strictEqual(invalid.llmThinkingOverride, undefined);
+  });
+
+  it("ignores blank llmModelOverride values", () => {
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({ llmModelOverride: "   " }));
+    const config = loadConfig(TEST_CONFIG_PATH);
+    assert.strictEqual(config.llmModelOverride, undefined);
   });
 
   it("ignores invalid sessionSearch variants", () => {

--- a/tests/handlers/auto-consolidate.test.ts
+++ b/tests/handlers/auto-consolidate.test.ts
@@ -110,6 +110,69 @@ describe("triggerConsolidation", () => {
     assert.ok(prompt.includes("Target: 'project'"), "prompt should tell the child agent to use target='project'");
   });
 
+  it("retries once without overrides when the override subprocess fails for model resolution reasons", async () => {
+    const pi = {
+      on: () => {},
+      exec: async (...args: any[]) => {
+        execCalls.push(args);
+        if (execCalls.length === 1) {
+          return { code: 1, stdout: "", stderr: "model not found" };
+        }
+        return { code: 0, stdout: "Consolidated", stderr: "" };
+      },
+      registerTool: () => {},
+      registerCommand: () => {},
+    } as any;
+
+    const result = await triggerConsolidation(
+      pi,
+      mockStore,
+      "memory",
+      undefined,
+      60000,
+      "memory",
+      { llmModelOverride: "openrouter/deepseek/deepseek-v4-flash" },
+    );
+
+    assert.strictEqual(result.consolidated, true);
+    assert.strictEqual(execCalls.length, 2, "should retry once without overrides");
+    assert.deepStrictEqual(execCalls[0][1].slice(0, 6), [
+      "-p",
+      "--no-session",
+      "--model",
+      "openrouter/deepseek/deepseek-v4-flash",
+      "--thinking",
+      "off",
+    ]);
+    assert.deepStrictEqual(execCalls[1][1].slice(0, 2), ["-p", "--no-session"]);
+    assert.strictEqual(execCalls[1][1].length, 3, "fallback retry should drop model/thinking overrides");
+  });
+
+  it("does not retry generic consolidation failures that are unrelated to override resolution", async () => {
+    const pi = {
+      on: () => {},
+      exec: async (...args: any[]) => {
+        execCalls.push(args);
+        return { code: 1, stdout: "", stderr: "memory tool returned no changes" };
+      },
+      registerTool: () => {},
+      registerCommand: () => {},
+    } as any;
+
+    const result = await triggerConsolidation(
+      pi,
+      mockStore,
+      "memory",
+      undefined,
+      60000,
+      "memory",
+      { llmModelOverride: "openrouter/deepseek/deepseek-v4-flash" },
+    );
+
+    assert.strictEqual(result.consolidated, false);
+    assert.strictEqual(execCalls.length, 1, "should not retry generic consolidation failures");
+  });
+
   it("handles empty entries gracefully", async () => {
     const emptyStore = {
       getMemoryEntries: () => [],

--- a/tests/handlers/auto-consolidate.test.ts
+++ b/tests/handlers/auto-consolidate.test.ts
@@ -230,6 +230,35 @@ describe("registerConsolidateCommand", () => {
     assert.ok(projectReloaded, "project store should reload after consolidation");
     assert.ok(notification.includes("project:demo-project: ✅ consolidated"), "notification should include project result");
   });
+
+  it("does not throw if the command ctx becomes stale before the final summary notify", async () => {
+    let handler: any;
+
+    const pi = {
+      on: () => {},
+      exec: async (...args: any[]) => {
+        execCalls.push(args);
+        return { code: 0, stdout: "Done", stderr: "" };
+      },
+      registerTool: () => {},
+      registerCommand: (_name: string, command: any) => {
+        handler = command.handler;
+      },
+    } as any;
+
+    registerConsolidateCommand(pi, mockStore, 60000);
+
+    await assert.doesNotReject(async () => {
+      await handler({}, {
+        signal: undefined,
+        ui: {
+          notify: () => {
+            throw new Error("This extension ctx is stale after session replacement or reload.");
+          },
+        },
+      });
+    });
+  });
 });
 
 describe("MemoryStore auto-consolidation integration", () => {

--- a/tests/handlers/auto-consolidate.test.ts
+++ b/tests/handlers/auto-consolidate.test.ts
@@ -76,6 +76,15 @@ describe("triggerConsolidation", () => {
     assert.ok(result.error!.includes("exit"), "error should mention exit code");
   });
 
+  it("surfaces timeout-style child termination clearly", async () => {
+    const pi = createMockPi({ code: 143, stdout: "", stderr: "", killed: true } as any);
+    const result = await triggerConsolidation(pi, mockStore, "memory", undefined, 60000);
+
+    assert.strictEqual(result.consolidated, false);
+    assert.match(result.error!, /terminated/i);
+    assert.match(result.error!, /60000ms/);
+  });
+
   it("returns { consolidated: false } when pi.exec throws", async () => {
     const crashPi = {
       on: () => {},
@@ -229,6 +238,32 @@ describe("registerConsolidateCommand", () => {
     assert.ok(projectPrompt.includes("Target: 'project'"), "project prompt should use target='project'");
     assert.ok(projectReloaded, "project store should reload after consolidation");
     assert.ok(notification.includes("project:demo-project: ✅ consolidated"), "notification should include project result");
+  });
+
+  it("uses a longer timeout floor for the manual consolidate command", async () => {
+    let handler: any;
+
+    const pi = {
+      on: () => {},
+      exec: async (...args: any[]) => {
+        execCalls.push(args);
+        return { code: 0, stdout: "Done", stderr: "" };
+      },
+      registerTool: () => {},
+      registerCommand: (_name: string, command: any) => {
+        handler = command.handler;
+      },
+    } as any;
+
+    registerConsolidateCommand(pi, mockStore, 60000);
+    await handler({}, {
+      signal: undefined,
+      ui: { notify: () => {} },
+    });
+
+    for (const call of execCalls) {
+      assert.strictEqual(call[2]?.timeout, 180000);
+    }
   });
 
   it("does not throw if the command ctx becomes stale before the final summary notify", async () => {

--- a/tests/handlers/auto-consolidate.test.ts
+++ b/tests/handlers/auto-consolidate.test.ts
@@ -204,7 +204,7 @@ describe("registerConsolidateCommand", () => {
 
   it("includes project memory when a project store is available", async () => {
     let handler: any;
-    let notification = "";
+    const notifications: string[] = [];
     let projectReloaded = false;
 
     const pi = {
@@ -228,7 +228,7 @@ describe("registerConsolidateCommand", () => {
     registerConsolidateCommand(pi, mockStore, 60000, projectStore, "demo-project");
     await handler({}, {
       signal: undefined,
-      ui: { notify: (message: string) => { notification = message; } },
+      ui: { notify: (message: string) => { notifications.push(message); } },
     });
 
     assert.strictEqual(execCalls.length, 3, "should consolidate memory, user, and project stores");
@@ -237,7 +237,10 @@ describe("registerConsolidateCommand", () => {
     assert.ok(projectPrompt.includes("project fact"), "project prompt should include project entries");
     assert.ok(projectPrompt.includes("Target: 'project'"), "project prompt should use target='project'");
     assert.ok(projectReloaded, "project store should reload after consolidation");
-    assert.ok(notification.includes("project:demo-project: ✅ consolidated"), "notification should include project result");
+    assert.ok(notifications.some((message) => message.includes("Starting memory consolidation")), "should show an initial progress notification");
+    assert.ok(notifications.some((message) => message.includes("⏳ Consolidating memory")), "should show per-target progress");
+    const finalNotification = notifications[notifications.length - 1] ?? "";
+    assert.ok(finalNotification.includes("project:demo-project: ✅ consolidated"), "final notification should include project result");
   });
 
   it("uses a longer timeout floor for the manual consolidate command", async () => {

--- a/tests/handlers/background-review.test.ts
+++ b/tests/handlers/background-review.test.ts
@@ -175,6 +175,30 @@ describe("setupBackgroundReview", () => {
     assert.doesNotMatch(prompt, /save a reusable procedure using the skill tool/i);
   });
 
+  it("passes child LLM override args to the review subprocess", async () => {
+    const pi = createMockPi();
+    setupBackgroundReview(pi, mockStore, null, {
+      ...defaultConfig,
+      llmModelOverride: "openrouter/deepseek/deepseek-v4-flash",
+      llmThinkingOverride: "minimal",
+    });
+
+    fireMessageEnd("user");
+    fireMessageEnd("user");
+    fireMessageEnd("user");
+
+    for (let i = 0; i < 10; i++) {
+      fireTurnEnd();
+    }
+    await settle();
+
+    const cmdArgs: string[] = execCalls[0][1];
+    assert.deepStrictEqual(
+      cmdArgs.slice(0, 6),
+      ["-p", "--no-session", "--model", "openrouter/deepseek/deepseek-v4-flash", "--thinking", "minimal"],
+    );
+  });
+
   it("does NOT trigger review when reviewEnabled is false", async () => {
     const config = { ...defaultConfig, reviewEnabled: false };
     const pi = createMockPi();

--- a/tests/handlers/correction-detector.test.ts
+++ b/tests/handlers/correction-detector.test.ts
@@ -323,6 +323,29 @@ describe("setupCorrectionDetector handler", () => {
     assert.ok(execCalls.length >= 1, "pi.exec should be called on correction");
   });
 
+  it("passes child LLM override args and defaults thinking to off when only a model override is set", async () => {
+    const pi = createMockPi();
+    setupCorrectionDetector(pi, mockStore, null, {
+      ...config,
+      llmModelOverride: "openrouter/deepseek/deepseek-v4-flash",
+    });
+
+    const branch = [
+      { type: "message", message: { role: "user", content: [{ type: "text", text: "don't do that" }] } },
+      { type: "message", message: { role: "assistant", content: [{ type: "text", text: "ok" }] } },
+    ];
+
+    fireMessageEnd("user", "don't do that");
+    fireTurnEnd(branch);
+    await settle();
+
+    const cmdArgs: string[] = execCalls[0][1];
+    assert.deepStrictEqual(
+      cmdArgs.slice(0, 6),
+      ["-p", "--no-session", "--model", "openrouter/deepseek/deepseek-v4-flash", "--thinking", "off"],
+    );
+  });
+
   it("does NOT trigger on normal messages", async () => {
     const pi = createMockPi();
     setupCorrectionDetector(pi, mockStore, null, config);

--- a/tests/handlers/pi-child-process.test.ts
+++ b/tests/handlers/pi-child-process.test.ts
@@ -1,0 +1,116 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildChildPiPromptArgs, execChildPrompt } from "../../src/handlers/pi-child-process.js";
+
+describe("buildChildPiPromptArgs", () => {
+  it("keeps the current child pi behavior when no overrides are configured", () => {
+    assert.deepStrictEqual(
+      buildChildPiPromptArgs("hello", {}),
+      ["-p", "--no-session", "hello"],
+    );
+  });
+
+  it("adds a model override and defaults thinking to off", () => {
+    assert.deepStrictEqual(
+      buildChildPiPromptArgs("hello", { llmModelOverride: "openrouter/deepseek/deepseek-v4-flash" }),
+      ["-p", "--no-session", "--model", "openrouter/deepseek/deepseek-v4-flash", "--thinking", "off", "hello"],
+    );
+  });
+
+  it("allows thinking overrides without a model override", () => {
+    assert.deepStrictEqual(
+      buildChildPiPromptArgs("hello", { llmThinkingOverride: "low" }),
+      ["-p", "--no-session", "--thinking", "low", "hello"],
+    );
+  });
+});
+
+describe("execChildPrompt", () => {
+  it("retries once without overrides when requested and the override subprocess fails for model resolution reasons", async () => {
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const pi = {
+      exec: async (cmd: string, args: string[]) => {
+        calls.push({ cmd, args });
+        if (calls.length === 1) {
+          return { code: 1, stdout: "", stderr: "model not found" };
+        }
+        return { code: 0, stdout: "ok", stderr: "" };
+      },
+    };
+
+    const result = await execChildPrompt(pi as any, "hello", {
+      llmModelOverride: "openrouter/deepseek/deepseek-v4-flash",
+    }, {
+      timeoutMs: 30000,
+      retryWithoutOverrides: true,
+    });
+
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(calls.map((call) => call.args), [
+      ["-p", "--no-session", "--model", "openrouter/deepseek/deepseek-v4-flash", "--thinking", "off", "hello"],
+      ["-p", "--no-session", "hello"],
+    ]);
+  });
+
+  it("does not retry generic non-zero child failures that are unrelated to override resolution", async () => {
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const pi = {
+      exec: async (cmd: string, args: string[]) => {
+        calls.push({ cmd, args });
+        return { code: 1, stdout: "", stderr: "memory tool returned no changes" };
+      },
+    };
+
+    const result = await execChildPrompt(pi as any, "hello", {
+      llmModelOverride: "openrouter/deepseek/deepseek-v4-flash",
+    }, {
+      timeoutMs: 30000,
+      retryWithoutOverrides: true,
+    });
+
+    assert.strictEqual(result.code, 1);
+    assert.strictEqual(calls.length, 1);
+  });
+
+  it("does not retry generic thrown errors that are unrelated to override resolution", async () => {
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const pi = {
+      exec: async (cmd: string, args: string[]) => {
+        calls.push({ cmd, args });
+        throw new Error("timed out waiting for child process");
+      },
+    };
+
+    await assert.rejects(
+      () => execChildPrompt(pi as any, "hello", {
+        llmModelOverride: "openrouter/deepseek/deepseek-v4-flash",
+      }, {
+        timeoutMs: 30000,
+        retryWithoutOverrides: true,
+      }),
+      /timed out waiting for child process/,
+    );
+
+    assert.strictEqual(calls.length, 1);
+  });
+
+  it("does not retry when retryWithoutOverrides is false", async () => {
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const pi = {
+      exec: async (cmd: string, args: string[]) => {
+        calls.push({ cmd, args });
+        return { code: 1, stdout: "", stderr: "model not found" };
+      },
+    };
+
+    const result = await execChildPrompt(pi as any, "hello", {
+      llmModelOverride: "openrouter/deepseek/deepseek-v4-flash",
+    }, {
+      timeoutMs: 30000,
+      retryWithoutOverrides: false,
+    });
+
+    assert.strictEqual(result.code, 1);
+    assert.strictEqual(calls.length, 1);
+  });
+});

--- a/tests/handlers/pi-child-process.test.ts
+++ b/tests/handlers/pi-child-process.test.ts
@@ -1,26 +1,49 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { buildChildPiPromptArgs, execChildPrompt } from "../../src/handlers/pi-child-process.js";
+import { buildChildPiPromptArgs, execChildPrompt, inheritedExtensionArgs } from "../../src/handlers/pi-child-process.js";
+
+describe("inheritedExtensionArgs", () => {
+  it("captures explicit -e and --extension parent args", () => {
+    assert.deepStrictEqual(
+      inheritedExtensionArgs(["-e", "src/index.ts", "--extension", "/tmp/other.ts"]),
+      ["-e", "src/index.ts", "--extension", "/tmp/other.ts"],
+    );
+  });
+
+  it("captures --extension=... parent args", () => {
+    assert.deepStrictEqual(
+      inheritedExtensionArgs(["--extension=src/index.ts"]),
+      ["--extension=src/index.ts"],
+    );
+  });
+});
 
 describe("buildChildPiPromptArgs", () => {
   it("keeps the current child pi behavior when no overrides are configured", () => {
     assert.deepStrictEqual(
-      buildChildPiPromptArgs("hello", {}),
+      buildChildPiPromptArgs("hello", {}, []),
       ["-p", "--no-session", "hello"],
     );
   });
 
   it("adds a model override and defaults thinking to off", () => {
     assert.deepStrictEqual(
-      buildChildPiPromptArgs("hello", { llmModelOverride: "openrouter/deepseek/deepseek-v4-flash" }),
+      buildChildPiPromptArgs("hello", { llmModelOverride: "openrouter/deepseek/deepseek-v4-flash" }, []),
       ["-p", "--no-session", "--model", "openrouter/deepseek/deepseek-v4-flash", "--thinking", "off", "hello"],
     );
   });
 
   it("allows thinking overrides without a model override", () => {
     assert.deepStrictEqual(
-      buildChildPiPromptArgs("hello", { llmThinkingOverride: "low" }),
+      buildChildPiPromptArgs("hello", { llmThinkingOverride: "low" }, []),
       ["-p", "--no-session", "--thinking", "low", "hello"],
+    );
+  });
+
+  it("inherits explicit extension args from the parent pi process", () => {
+    assert.deepStrictEqual(
+      buildChildPiPromptArgs("hello", {}, ["-e", "src/index.ts"]),
+      ["-p", "--no-session", "-e", "src/index.ts", "hello"],
     );
   });
 });

--- a/tests/handlers/session-flush.test.ts
+++ b/tests/handlers/session-flush.test.ts
@@ -224,6 +224,25 @@ describe("setupSessionFlush", () => {
     assert.equal(opts.timeout, 30000);
   });
 
+  it("passes child LLM override args to flush subprocesses", async () => {
+    const config = defaultConfig({
+      llmModelOverride: "openrouter/deepseek/deepseek-v4-flash",
+      llmThinkingOverride: "low",
+    });
+    setupSessionFlush(mockPi.pi, mockStore, null, config);
+
+    await emitUserTurns(mockPi.handlers, 8);
+
+    const ctx = { sessionManager: { getBranch: () => mockBranch(4) } };
+    await emit(mockPi.handlers, "session_before_compact", { signal: undefined }, ctx);
+
+    const [, args] = mockPi.execCalls[0].args;
+    assert.deepStrictEqual(
+      args.slice(0, 6),
+      ["-p", "--no-session", "--model", "openrouter/deepseek/deepseek-v4-flash", "--thinking", "low"],
+    );
+  });
+
   it("Flush includes the full conversation by default", async () => {
     const config = defaultConfig();
     setupSessionFlush(mockPi.pi, mockStore, null, config);


### PR DESCRIPTION
## Summary
- add optional child `pi -p` LLM overrides via `llmModelOverride` and `llmThinkingOverride`
- route background review, correction save, session flush, and consolidation through a shared child-process helper
- retry consolidation without overrides only for model/provider/thinking resolution failures, while leaving other child-process failures single-shot

## Details
This addresses #55 by letting users pin a cheaper model and thinking level for the extension's maintenance-style subprocess calls instead of inheriting the active session model.

Behavior:
- no override configured: existing child-process behavior is unchanged
- model override without thinking override: child calls default to `--thinking off`
- thinking override only: keep the current model and override only the thinking level
- consolidation retry fallback is intentionally narrow and only triggers when the override itself appears invalid or unavailable

## Validation
- `npm run check`
- `npm test`