### PR TITLE
fix: broaden memory_search fallback for natural-language queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ Thumbs.db
 docs/0.4/RELEASE-POST.md
 docs/0.4/linkedin_post.md
 .codex
+.serena

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hermes-memory",
-      "version": "0.7.14",
+      "version": "0.7.15",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-tui": "^0.74.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1653,28 +1653,27 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
@@ -1685,9 +1684,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -1706,9 +1705,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -2567,9 +2566,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2628,9 +2627,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3051,9 +3050,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "dev": true,
       "funding": [
         {
@@ -3063,7 +3062,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -3450,9 +3450,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3941,25 +3941,25 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
+      "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -4567,9 +4567,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4586,6 +4586,22 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "description": "🧠 Persistent memory + 🔍 session search + 🛡️ secret scanning for Pi. Token-aware policy-only memory by default, SQLite FTS5 search, auto-consolidation, procedural skills. 368 tests. Ported from Hermes agent.",
   "type": "module",
   "main": "src/index.ts",

--- a/src/store/fts-query.ts
+++ b/src/store/fts-query.ts
@@ -2,6 +2,23 @@ const FTS5_OPERATOR_PATTERN = /\b(OR|AND|NOT|NEAR)\b/;
 const FTS5_TOKEN_PATTERN = /"([^"]*)"|(\S+)/g;
 const NATURAL_LANGUAGE_CONNECTORS = new Set(['and', 'or', 'not', 'near']);
 
+function collectNaturalLanguageTerms(query: string): string[] {
+  const terms: string[] = [];
+
+  for (const match of query.matchAll(FTS5_TOKEN_PATTERN)) {
+    const phrase = match[1];
+    const term = match[2];
+    if (phrase === undefined && term && NATURAL_LANGUAGE_CONNECTORS.has(term.toLowerCase())) {
+      continue;
+    }
+
+    const rawValue = phrase ?? term ?? '';
+    if (rawValue.length > 0) terms.push(rawValue);
+  }
+
+  return terms;
+}
+
 /**
  * Normalize natural-language search input into an FTS5 query.
  * Plain terms become individually quoted for implicit AND matching.
@@ -16,19 +33,30 @@ export function normalizeFts5Query(query: string): string {
     return trimmed;
   }
 
-  const normalizedTerms: string[] = [];
-  for (const match of trimmed.matchAll(FTS5_TOKEN_PATTERN)) {
-    const phrase = match[1];
-    const term = match[2];
-    if (phrase === undefined && term && NATURAL_LANGUAGE_CONNECTORS.has(term.toLowerCase())) {
-      continue;
-    }
+  return collectNaturalLanguageTerms(trimmed)
+    .map((term) => `"${term.replace(/"/g, '""')}"`)
+    .join(' ');
+}
 
-    const rawValue = phrase ?? term ?? '';
-    normalizedTerms.push(`"${rawValue.replace(/"/g, '""')}"`);
+/**
+ * Build a broader fallback query for natural-language searches.
+ * Returns null for explicit operator queries or when the input is already a
+ * single searchable term.
+ */
+export function buildFallbackFts5Query(query: string): string | null {
+  const trimmed = query.trim();
+  if (trimmed.length === 0 || FTS5_OPERATOR_PATTERN.test(trimmed)) {
+    return null;
   }
 
-  return normalizedTerms.join(' ');
+  const terms = collectNaturalLanguageTerms(trimmed);
+  if (terms.length <= 1) {
+    return null;
+  }
+
+  return terms
+    .map((term) => `"${term.replace(/"/g, '""')}"`)
+    .join(' OR ');
 }
 
 export function isFts5QueryError(err: unknown): boolean {

--- a/src/store/sqlite-memory-store.ts
+++ b/src/store/sqlite-memory-store.ts
@@ -1,5 +1,5 @@
 import { DatabaseManager } from './db.js';
-import { isFts5QueryError, normalizeFts5Query } from './fts-query.js';
+import { buildFallbackFts5Query, isFts5QueryError, normalizeFts5Query } from './fts-query.js';
 import { normalizeMemoryLookupText } from './memory-lookup.js';
 import type { MemoryCategory } from '../types.js';
 
@@ -579,60 +579,77 @@ export function searchMemories(
   if (normalizedQuery.length === 0) {
     return [];
   }
-  conditions.push('m.id IN (SELECT rowid FROM memory_fts WHERE memory_fts MATCH ?)');
-  params.push(normalizedQuery);
 
-  if (project !== undefined) {
-    if (project === null) {
-      conditions.push('m.project IS NULL');
-    } else {
-      conditions.push('m.project = ?');
-      params.push(project);
+  const runSearch = (matchQuery: string): SqliteMemoryEntry[] => {
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+
+    conditions.push('m.id IN (SELECT rowid FROM memory_fts WHERE memory_fts MATCH ?)');
+    params.push(matchQuery);
+
+    if (project !== undefined) {
+      if (project === null) {
+        conditions.push('m.project IS NULL');
+      } else {
+        conditions.push('m.project = ?');
+        params.push(project);
+      }
     }
-  }
 
-  if (target) {
-    conditions.push('m.target = ?');
-    params.push(target);
-  }
-
-  if (category) {
-    conditions.push('m.category = ?');
-    params.push(category);
-  }
-
-  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
-
-  const sql = `
-    SELECT ${MEMORY_SELECT_COLUMNS}
-    FROM memories m
-    ${whereClause}
-    ORDER BY m.last_referenced DESC
-    LIMIT ?
-  `;
-  params.push(limit);
-
-  try {
-    const rows = db.prepare(sql).all(...params) as Array<{
-      id: number;
-      project: string | null;
-      target: string;
-      category: string | null;
-      content: string;
-      failure_reason: string | null;
-      tool_state: string | null;
-      corrected_to: string | null;
-      created: string;
-      last_referenced: string;
-    }>;
-
-    return rows.map(mapRow);
-  } catch (err) {
-    if (isFts5QueryError(err)) {
-      return [];
+    if (target) {
+      conditions.push('m.target = ?');
+      params.push(target);
     }
-    throw err;
+
+    if (category) {
+      conditions.push('m.category = ?');
+      params.push(category);
+    }
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    const sql = `
+      SELECT ${MEMORY_SELECT_COLUMNS}
+      FROM memories m
+      ${whereClause}
+      ORDER BY m.last_referenced DESC
+      LIMIT ?
+    `;
+
+    try {
+      const rows = db.prepare(sql).all(...params, limit) as Array<{
+        id: number;
+        project: string | null;
+        target: string;
+        category: string | null;
+        content: string;
+        failure_reason: string | null;
+        tool_state: string | null;
+        corrected_to: string | null;
+        created: string;
+        last_referenced: string;
+      }>;
+
+      return rows.map(mapRow);
+    } catch (err) {
+      if (isFts5QueryError(err)) {
+        return [];
+      }
+      throw err;
+    }
+  };
+
+  const exactResults = runSearch(normalizedQuery);
+  if (exactResults.length > 0) {
+    return exactResults;
   }
+
+  const fallbackQuery = buildFallbackFts5Query(query);
+  if (!fallbackQuery || fallbackQuery === normalizedQuery) {
+    return exactResults;
+  }
+
+  return runSearch(fallbackQuery);
 }
 
 /**

--- a/tests/store/sqlite-memory-store.test.ts
+++ b/tests/store/sqlite-memory-store.test.ts
@@ -219,6 +219,20 @@ describe('sqlite-memory-store', () => {
       assert.ok(results.length > 0);
       assert.ok(results.some((r) => r.content.includes('gpu timeout issue')));
     });
+    it('should fall back to broader natural-language matching when strict term matching misses', () => {
+      addMemory(dbManager, "user's name is Naruto", 'user');
+
+      const results = searchMemories(dbManager, 'name identity Naruto', { target: 'user' });
+
+      assert.ok(results.length > 0);
+      assert.ok(results.some((r) => r.content.includes("Naruto")));
+    });
+
+    it('should not broaden explicit operator queries', () => {
+      const results = searchMemories(dbManager, 'pnpm AND nonexistent');
+
+      assert.strictEqual(results.length, 0);
+    });
 
     it('should preserve explicit quoted phrase searches', () => {
       const results = searchMemories(dbManager, '"memory search"');

--- a/tests/tools/memory-search-tool.test.ts
+++ b/tests/tools/memory-search-tool.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { DatabaseManager } from '../../src/store/db.js';
+import { addMemory } from '../../src/store/sqlite-memory-store.js';
+import { registerMemorySearchTool } from '../../src/tools/memory-search-tool.js';
+
+let ROOT_DIR = '';
+
+afterEach(() => {
+  if (ROOT_DIR) fs.rmSync(ROOT_DIR, { recursive: true, force: true });
+  ROOT_DIR = '';
+});
+
+function makeDbManager(): DatabaseManager {
+  ROOT_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-memory-search-tool-test-'));
+  return new DatabaseManager(ROOT_DIR);
+}
+
+describe('registerMemorySearchTool', () => {
+  it('returns a broader natural-language match when strict term matching misses', async () => {
+    const dbManager = makeDbManager();
+    addMemory(dbManager, "user's name is Naruto", 'user');
+
+    let captured: any;
+    const mockPi = {
+      registerTool: (def: any) => {
+        captured = def;
+      },
+    } as any;
+
+    registerMemorySearchTool(mockPi, dbManager);
+
+    const result = await captured.execute('tc-1', { query: 'name identity Naruto', target: 'user' });
+
+    assert.strictEqual(result.details.success, true);
+    assert.strictEqual(result.details.count, 1);
+    assert.match(result.content[0].text, /Naruto/);
+
+    dbManager.close();
+  });
+});


### PR DESCRIPTION
## Summary
- add a natural-language fallback query for memory search when strict FTS matching returns no results
- preserve explicit FTS operator queries without broadening them
- add regression coverage for the Naruto/identity-style retrieval miss and bump package version to 0.7.15

## Testing
- npm test
- npm run check

Closes #64