### PR TITLE
fix: honor PI_CODING_AGENT_DIR for agent paths

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,5 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import * as os from "node:os";
 import type { MemoryConfig, MemoryOverflowStrategy, SessionSearchVariant, ThinkingLevel } from "./types.js";
 import {
   DEFAULT_MEMORY_CHAR_LIMIT,
@@ -16,7 +15,7 @@ import {
   DEFAULT_FAILURE_INJECTION_MAX_AGE_DAYS,
   DEFAULT_FAILURE_INJECTION_MAX_ENTRIES,
 } from "./constants.js";
-import { normalizeConfiguredMemoryDir, normalizeProjectsMemoryDir } from "./paths.js";
+import { AGENT_ROOT, normalizeConfiguredMemoryDir, normalizeProjectsMemoryDir } from "./paths.js";
 
 const MEMORY_OVERFLOW_STRATEGIES: readonly MemoryOverflowStrategy[] = ["auto-consolidate", "reject", "fifo-evict"];
 const SESSION_SEARCH_VARIANTS: readonly SessionSearchVariant[] = ["legacy", "anchors"];
@@ -60,9 +59,7 @@ const DEFAULT_CONFIG: MemoryConfig = {
 };
 
 export const DEFAULT_CONFIG_PATH = path.join(
-  os.homedir(),
-  ".pi",
-  "agent",
+  AGENT_ROOT,
   "hermes-memory-config.json",
 );
 

--- a/src/handlers/index-sessions.ts
+++ b/src/handlers/index-sessions.ts
@@ -4,12 +4,12 @@
 
 import path from 'node:path';
 import fs from 'node:fs';
-import os from 'node:os';
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { DatabaseManager } from '../store/db.js';
 import { indexAllSessions, getSessionStats } from '../store/session-indexer.js';
+import { AGENT_ROOT } from '../paths.js';
 
-const SESSIONS_DIR = path.join(os.homedir(), '.pi', 'agent', 'sessions');
+const SESSIONS_DIR = path.join(AGENT_ROOT, 'sessions');
 
 export function registerIndexSessionsCommand(pi: ExtensionAPI): void {
   pi.registerCommand("memory-index-sessions", {
@@ -34,7 +34,7 @@ export function registerIndexSessionsCommand(pi: ExtensionAPI): void {
 
         ctx.ui.notify(`📁 Found ${totalFiles} session files across ${projectDirs.length} projects\n⏳ Indexing...`, 'info');
 
-        const memoryDir = path.join(os.homedir(), '.pi', 'agent', 'pi-hermes-memory');
+        const memoryDir = path.join(AGENT_ROOT, 'pi-hermes-memory');
         const dbManager = new DatabaseManager(memoryDir);
 
         try {

--- a/src/handlers/switch-project.ts
+++ b/src/handlers/switch-project.ts
@@ -11,7 +11,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { MemoryConfig } from "../types.js";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import * as os from "node:os";
+import { resolveProjectsRoot } from "../paths.js";
 
 export function registerSwitchProjectCommand(pi: ExtensionAPI, config?: MemoryConfig): void {
   const projectsMemoryDir = config?.projectsMemoryDir ?? "projects-memory";
@@ -19,9 +19,7 @@ export function registerSwitchProjectCommand(pi: ExtensionAPI, config?: MemoryCo
     description: "Switch the active project for project-scoped memory",
 
     async handler(_args, ctx) {
-      const homeDir = os.homedir();
-      const agentDir = path.join(homeDir, ".pi", "agent");
-      const projectsDir = path.join(agentDir, projectsMemoryDir);
+      const projectsDir = resolveProjectsRoot(projectsMemoryDir);
 
       // Discover all project directories (subdirectories of projects-memory/ that have MEMORY.md)
       let projects: string[] = [];

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -2,7 +2,12 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { DEFAULT_PROJECTS_MEMORY_DIR } from "./constants.js";
 
-export const AGENT_ROOT = path.join(os.homedir(), ".pi", "agent");
+export const AGENT_ROOT = resolveAgentRoot();
+
+export function resolveAgentRoot(env: Record<string, string | undefined> = process.env): string {
+  const configured = env.PI_CODING_AGENT_DIR?.trim();
+  return configured ? path.resolve(expandHome(configured)) : path.join(os.homedir(), ".pi", "agent");
+}
 
 export function expandHome(input: string): string {
   if (input === "~") return os.homedir();

--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -13,7 +13,6 @@
 
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import * as os from "node:os";
 import { scanContent } from "./content-scanner.js";
 import { normalizeMemoryLookupText } from "./memory-lookup.js";
 import {
@@ -26,6 +25,7 @@ import {
   USER_FILE,
 } from "../constants.js";
 import type { MemoryConfig, MemoryResult, MemorySnapshot, ConsolidationResult, MemoryCategory, MemoryOverflowStrategy } from "../types.js";
+import { AGENT_ROOT } from "../paths.js";
 
 export class MemoryStore {
   private memoryEntries: string[] = [];
@@ -47,7 +47,7 @@ export class MemoryStore {
   // ─── Path helpers ───
 
   private get memoryDir(): string {
-    return this.config.memoryDir ?? path.join(os.homedir(), ".pi", "agent", "pi-hermes-memory");
+    return this.config.memoryDir ?? path.join(AGENT_ROOT, "pi-hermes-memory");
   }
 
   private pathFor(target: "memory" | "user" | "failure"): string {

--- a/src/store/skill-store.ts
+++ b/src/store/skill-store.ts
@@ -7,7 +7,6 @@
 
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import * as os from "node:os";
 import { scanContent } from "./content-scanner.js";
 import {
   buildSkillId,
@@ -21,6 +20,7 @@ import {
   tokenizeForSimilarity,
 } from "./skill-utils.js";
 import type { SkillDocument, SkillIndex, SkillResult, SkillScope } from "../types.js";
+import { AGENT_ROOT } from "../paths.js";
 
 interface SkillStoreOptions {
   globalSkillsDir?: string;
@@ -55,7 +55,7 @@ export class SkillStore {
   private migrationSentinelPath: string;
 
   constructor(options: SkillStoreOptions = {}) {
-    const agentRoot = path.join(os.homedir(), ".pi", "agent");
+    const agentRoot = AGENT_ROOT;
     this.globalSkillsDir = options.globalSkillsDir ?? path.join(agentRoot, "skills");
     this.projectSkillsDir = options.projectSkillsDir ?? null;
     this.projectName = options.projectName ?? null;

--- a/src/tools/session-search-tool.ts
+++ b/src/tools/session-search-tool.ts
@@ -1,5 +1,4 @@
 import * as path from 'node:path';
-import * as os from 'node:os';
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { StringEnum } from "@earendil-works/pi-ai";
@@ -8,6 +7,7 @@ import { searchSessions, getIndexedMessageCount } from '../store/session-search.
 import { searchSessionAnchors } from '../store/session-anchor-search.js';
 import type { SessionAnchorRange, SessionAnchorSearchResult } from '../store/session-anchor-search.js';
 import type { SessionSearchConfig } from '../types.js';
+import { AGENT_ROOT } from '../paths.js';
 
 interface SearchResult {
   success: boolean;
@@ -21,7 +21,7 @@ interface SessionSearchToolOptions {
   sessionsDir?: string;
 }
 
-const DEFAULT_SESSIONS_DIR = path.join(os.homedir(), '.pi', 'agent', 'sessions');
+const DEFAULT_SESSIONS_DIR = path.join(AGENT_ROOT, 'sessions');
 
 export function registerSessionSearchTool(
   pi: ExtensionAPI,

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import { loadConfig } from "../src/config.js";
+import { AGENT_ROOT } from "../src/paths.js";
 
 const TEST_CONFIG_PATH = path.join(os.tmpdir(), `hermes-memory-config-test-${process.pid}.json`);
 
@@ -102,21 +103,21 @@ describe("loadConfig", () => {
     assert.strictEqual(config.memoryDir, path.join(os.homedir(), ".pi", "agent", "pi-hermes-memory"));
   });
 
-  it("resolves relative memoryDir values against ~/.pi/agent instead of cwd", () => {
+  it("resolves relative memoryDir values against the agent root instead of cwd", () => {
     fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
     fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({
       memoryDir: "custom-memory-root",
     }));
 
     const config = loadConfig(TEST_CONFIG_PATH);
-    assert.strictEqual(config.memoryDir, path.join(os.homedir(), ".pi", "agent", "custom-memory-root"));
+    assert.strictEqual(config.memoryDir, path.join(AGENT_ROOT, "custom-memory-root"));
   });
 
-  it("normalizes projectsMemoryDir inside ~/.pi/agent and ignores unsafe values", () => {
+  it("normalizes projectsMemoryDir inside the agent root and ignores unsafe values", () => {
     fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
 
     fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({
-      projectsMemoryDir: " ~/.pi/agent/team-projects/ ",
+      projectsMemoryDir: ` ${path.join(AGENT_ROOT, "team-projects")}/ `,
     }));
     let config = loadConfig(TEST_CONFIG_PATH);
     assert.strictEqual(config.projectsMemoryDir, "team-projects");

--- a/tests/handlers/resources-discover.test.ts
+++ b/tests/handlers/resources-discover.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import * as os from "node:os";
 import * as path from "node:path";
 import { resolveProjectSkillDiscovery, registerProjectSkillDiscoveryHandler } from "../../src/index.js";
+import { AGENT_ROOT } from "../../src/paths.js";
 import { SkillStore } from "../../src/store/skill-store.js";
 
 describe("resources_discover skill path resolution", () => {
@@ -27,7 +28,7 @@ describe("resources_discover skill path resolution", () => {
 
     const result = await handlers.resources_discover({ cwd: "/tmp/demo-repo" }, {});
     const expectedGlobal = "/tmp/global-skills";
-    const expectedPath = path.join(os.homedir(), ".pi", "agent", "projects-memory", "demo-repo", "skills");
+    const expectedPath = path.join(AGENT_ROOT, "projects-memory", "demo-repo", "skills");
 
     assert.deepStrictEqual(result, { skillPaths: [expectedGlobal, expectedPath] });
   });
@@ -43,7 +44,7 @@ describe("resources_discover skill path resolution", () => {
 
     const cwd = "/tmp/demo-repo";
     const resource = resolveProjectSkillDiscovery(store, "projects-memory", cwd);
-    const expectedPath = path.join(os.homedir(), ".pi", "agent", "projects-memory", "demo-repo", "skills");
+    const expectedPath = path.join(AGENT_ROOT, "projects-memory", "demo-repo", "skills");
 
     assert.deepStrictEqual(resource, { skillPaths: ["/tmp/global-skills", expectedPath] });
     assert.strictEqual(store.getProjectName(), "demo-repo");

--- a/tests/paths.test.ts
+++ b/tests/paths.test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as os from "node:os";
+import * as path from "node:path";
+import { resolveAgentRoot } from "../src/paths.js";
+
+describe("agent root path resolution", () => {
+  it("prefers PI_CODING_AGENT_DIR over the legacy ~/.pi/agent root", () => {
+    const root = resolveAgentRoot({ PI_CODING_AGENT_DIR: "/tmp/pi-agent-dir" });
+
+    assert.strictEqual(root, path.resolve("/tmp/pi-agent-dir"));
+  });
+
+  it("falls back to ~/.pi/agent when PI_CODING_AGENT_DIR is unset or blank", () => {
+    const expected = path.join(os.homedir(), ".pi", "agent");
+
+    assert.strictEqual(resolveAgentRoot({}), expected);
+    assert.strictEqual(resolveAgentRoot({ PI_CODING_AGENT_DIR: "  " }), expected);
+  });
+
+  it("expands home-relative PI_CODING_AGENT_DIR values", () => {
+    const root = resolveAgentRoot({ PI_CODING_AGENT_DIR: "~/custom-pi-agent" });
+
+    assert.strictEqual(root, path.join(os.homedir(), "custom-pi-agent"));
+  });
+});

--- a/tests/project.test.ts
+++ b/tests/project.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import * as os from "node:os";
 import * as path from "node:path";
 import { detectProject, detectProjectSkills } from "../src/project.js";
+import { AGENT_ROOT } from "../src/paths.js";
 
 describe("project detection", () => {
   it("detectProject returns null outside a project", () => {
@@ -17,7 +18,7 @@ describe("project detection", () => {
     assert.strictEqual(result.name, "demo-repo");
     assert.strictEqual(
       result.memoryDir,
-      path.join(os.homedir(), ".pi", "agent", "projects-memory", "demo-repo"),
+      path.join(AGENT_ROOT, "projects-memory", "demo-repo"),
     );
   });
 
@@ -28,7 +29,7 @@ describe("project detection", () => {
     assert.strictEqual(result.name, "demo-repo");
     assert.strictEqual(
       result.skillsDir,
-      path.join(os.homedir(), ".pi", "agent", "projects-memory", "demo-repo", "skills"),
+      path.join(AGENT_ROOT, "projects-memory", "demo-repo", "skills"),
     );
   });
 });


### PR DESCRIPTION
## Summary

- Route Hermes default storage paths through a shared agent-root resolver.
- Prefer `PI_CODING_AGENT_DIR` when present, with `~/...` expansion and legacy `~/.pi/agent` fallback.
- Update config, session indexing/search, memory store, skill store, project switching, and related tests to use the resolved agent root.

## Motivation

Hermes still hard-coded several defaults under `~/.pi/agent`. That breaks isolated Pi agent environments that set `PI_CODING_AGENT_DIR`, causing memory, skills, sessions, and config files to land outside the active agent directory.

This change centralizes agent-root resolution so all default paths follow the configured Pi agent environment while preserving backward compatibility for existing users.

## Changes

- Add `resolveAgentRoot()` in `src/paths.ts`.
- Export `AGENT_ROOT` from that resolver.
- Use `AGENT_ROOT` for default config, session, memory, skill, and project-memory paths.
- Use `resolveProjectsRoot()` in project switching instead of rebuilding paths manually.
- Add path-resolution tests for:
  - `PI_CODING_AGENT_DIR` override
  - blank/unset fallback
  - home-relative path expansion
- Update existing tests to assert against resolved agent-root paths instead of hard-coded `~/.pi/agent` strings.

## Testing

- `npm test` — all 33 test files passed.
- `npm run check` — TypeScript check passed.

