### PR TITLE
feat: project-local memory support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,11 @@ Your Pi agent normally forgets everything when you close a session. **This exten
 ## Quick Start
 
 ```bash
-# Install
+# 全局安装（所有项目共享记忆）
 pi install npm:pi-hermes-memory
+
+# 项目级安装（记忆留在项目 .pi/hermes-memory/ 中，不污染 ~/.pi）
+pi install -l npm:pi-hermes-memory
 
 # Index your past sessions (one-time)
 /memory-index-sessions

--- a/docs/superpowers/plans/2026-06-12-project-local-memory.md
+++ b/docs/superpowers/plans/2026-06-12-project-local-memory.md
@@ -1,0 +1,308 @@
+# Project-Local Memory — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 支持 `pi install -l npm:pi-hermes-memory` 项目级安装，记忆留在 `<proj>/.pi/hermes-memory/` 中，不碰 `~/.pi`。全局安装用户零感知。
+
+**Architecture:** 新增 `detectMemoryRoot()` 函数从入口文件路径推导记忆根目录，替换 `index.ts` 中硬编码的 `AGENT_ROOT`。项目 `.pi` 和全局 `~/.pi` 通过 `agent/` 子目录是否存在来区分。
+
+**Tech Stack:** TypeScript (jiti), Node.js `node:fs`/`node:path`/`node:url`, `node:test` + `node:assert/strict`
+
+**Spec:** `docs/superpowers/specs/2026-06-12-project-local-memory-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/paths.ts` | Modify | 新增 `detectMemoryRoot()` |
+| `src/index.ts` | Modify | 入口用 `detectMemoryRoot` 替换路径逻辑 |
+| `tests/paths.test.ts` | Create | `detectMemoryRoot` 单元测试 |
+| `README.md` | Modify | 添加项目级安装说明 |
+
+---
+
+### Task 1: `detectMemoryRoot()` — 实现 + 测试
+
+**Files:**
+- Create: `tests/paths.test.ts`
+- Modify: `src/paths.ts`
+
+- [ ] **Step 1: 写测试文件**
+
+创建 `tests/paths.test.ts`：
+
+```typescript
+import * as path from "node:path";
+import * as os from "node:os";
+import * as fs from "node:fs";
+import * as assert from "node:assert/strict";
+import { describe, it, before, after } from "node:test";
+import { detectMemoryRoot } from "../src/paths.js";
+
+const TEST_DIR = path.join(os.tmpdir(), `hermes-paths-test-${Date.now()}`);
+
+describe("detectMemoryRoot", () => {
+  before(() => {
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  after(() => {
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("项目级安装: 返回 <proj>/.pi/hermes-memory/", () => {
+    // 模拟项目结构
+    const projectDir = path.join(TEST_DIR, "my-project");
+    const piDir = path.join(projectDir, ".pi");
+    const extensionsDir = path.join(piDir, "extensions");
+    const npmDir = path.join(extensionsDir, "npm", "pi-hermes-memory", "src");
+    fs.mkdirSync(npmDir, { recursive: true });
+
+    const entryFile = path.join(npmDir, "index.ts");
+    // 项目 .pi 目录没有 agent/ 子目录 → 项目级
+    const result = detectMemoryRoot(entryFile);
+    assert.equal(result, path.join(piDir, "hermes-memory"));
+  });
+
+  it("全局安装: 返回 ~/.pi/agent/pi-hermes-memory/", () => {
+    // 模拟全局 Pi 结构（~/.pi/agent/）
+    const homePiDir = path.join(TEST_DIR, ".pi-global");
+    const agentDir = path.join(homePiDir, ".pi", "agent");
+    const extensionsDir = path.join(agentDir, "extensions", "npm", "pi-hermes-memory", "src");
+    fs.mkdirSync(extensionsDir, { recursive: true });
+
+    const entryFile = path.join(extensionsDir, "index.ts");
+    // ~/.pi 有 agent/ 子目录 → 全局
+    const result = detectMemoryRoot(entryFile);
+    assert.equal(result, path.join(agentDir, "pi-hermes-memory"));
+  });
+
+  it("找不到 .pi/ 目录时回退到默认路径", () => {
+    const entryFile = path.join(TEST_DIR, "no-pi-dir", "some-ext", "index.ts");
+    fs.mkdirSync(path.dirname(entryFile), { recursive: true });
+
+    const result = detectMemoryRoot(entryFile);
+    const expected = path.join(os.homedir(), ".pi", "agent", "pi-hermes-memory");
+    assert.equal(result, expected);
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试验证失败**
+
+```bash
+cd /mnt/c/Users/10850/Documents/codelab/pi-hermes-memory && node --import jiti/register --test tests/paths.test.ts
+```
+
+Expected: FAIL — `detectMemoryRoot` not exported from paths.ts
+
+- [ ] **Step 3: 在 `src/paths.ts` 中实现 `detectMemoryRoot`**
+
+在 `src/paths.ts` 末尾添加：
+
+```typescript
+import { existsSync } from "node:fs";
+
+/**
+ * 从 extension 入口文件路径检测记忆根目录。
+ *
+ * 全局安装: ~/.pi/agent/extensions/.../index.ts
+ *   → 向上找到 ~/.pi（含 agent/子目录）→ ~/.pi/agent/pi-hermes-memory/
+ * 项目级安装: <proj>/.pi/extensions/.../index.ts
+ *   → 向上找到 <proj>/.pi（不含 agent/）→ <proj>/.pi/hermes-memory/
+ */
+export function detectMemoryRoot(entryFile: string): string {
+  let dir = path.dirname(entryFile);
+  while (dir !== path.dirname(dir)) {
+    const piDir = path.join(dir, ".pi");
+    if (existsSync(piDir)) {
+      if (existsSync(path.join(piDir, "agent"))) {
+        return path.join(piDir, "agent", "pi-hermes-memory");
+      }
+      return path.join(piDir, "hermes-memory");
+    }
+    dir = path.dirname(dir);
+  }
+  return path.join(os.homedir(), ".pi", "agent", "pi-hermes-memory");
+}
+```
+
+- [ ] **Step 4: 运行测试验证通过**
+
+```bash
+node --import jiti/register --test tests/paths.test.ts
+```
+
+Expected: 3/3 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/paths.ts tests/paths.test.ts
+git commit -m "feat(paths): add detectMemoryRoot() for project-local memory detection"
+```
+
+---
+
+### Task 2: `index.ts` — 用 `detectMemoryRoot` 替换路径逻辑
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: 替换入口路径逻辑**
+
+修改 `src/index.ts`，将：
+
+```typescript
+import { AGENT_ROOT } from "./paths.js";
+```
+
+改为：
+
+```typescript
+import { detectMemoryRoot } from "./paths.js";
+import { fileURLToPath } from "node:url";
+```
+
+然后将：
+
+```typescript
+  const agentRoot = AGENT_ROOT;
+  const legacyGlobalDir = path.join(agentRoot, "memory");
+  const defaultGlobalDir = path.join(agentRoot, "pi-hermes-memory");
+
+  const configuredMemoryDir = config.memoryDir?.trim();
+  const pointsToLegacyMemoryDir = configuredMemoryDir
+    ? path.resolve(configuredMemoryDir) === path.resolve(legacyGlobalDir)
+    : false;
+
+  const globalDir = !configuredMemoryDir || pointsToLegacyMemoryDir
+    ? defaultGlobalDir
+    : configuredMemoryDir;
+
+  const shouldMigrateExtensionRoot = !configuredMemoryDir || pointsToLegacyMemoryDir;
+```
+
+改为：
+
+```typescript
+  const baseDir = detectMemoryRoot(fileURLToPath(import.meta.url));
+  const agentRoot = path.dirname(baseDir);
+  const legacyGlobalDir = path.join(agentRoot, "memory");
+  const shouldMigrateExtensionRoot = true;
+```
+
+- [ ] **Step 2: 全局替换 `globalDir` → `baseDir`**
+
+在 `src/index.ts` 中将所有 `globalDir` 替换为 `baseDir`（共 ~15 处）：
+
+涉及行：
+- `const store = new MemoryStore({ ...config, memoryDir: globalDir });` → `baseDir`
+- `globalSkillsDir: path.join(globalDir, "skills"),` → `baseDir`
+- `migrationSentinelPath: path.join(globalDir, ".skills-migrated-to-extension-storage"),` → `baseDir`
+- `const dbManager = new DatabaseManager(globalDir);` → `baseDir`
+- `syncMarkdownMemoriesToSqlite(dbManager, globalDir, ...)` → `baseDir`
+- `registerSyncMarkdownMemoriesCommand(pi, dbManager, globalDir, ...)` → `baseDir`
+- `migrateExtensionRoot(legacyGlobalDir, globalDir)` → `baseDir`
+
+- [ ] **Step 3: 类型检查**
+
+```bash
+npm run check
+```
+
+Expected: zero errors
+
+- [ ] **Step 4: 运行全部测试**
+
+```bash
+npm test
+```
+
+Expected: 全部通过（如果 npm test 不可用，则用 node test runner）
+
+```bash
+node --import jiti/register --test tests/paths.test.ts tests/store/memory-store.test.ts tests/handlers/system-prompt.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "feat(index): use detectMemoryRoot() for project-local memory dir"
+```
+
+---
+
+### Task 3: README — 添加项目级安装说明
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: 更新 Quick Start**
+
+在 `README.md` 的 "Quick Start" 部分，将：
+
+```markdown
+## Quick Start
+
+```bash
+# Install
+pi install npm:pi-hermes-memory
+```
+
+改为：
+
+```markdown
+## Quick Start
+
+```bash
+# 全局安装（所有项目共享记忆）
+pi install npm:pi-hermes-memory
+
+# 项目级安装（记忆留在项目 .pi/hermes-memory/ 中，不污染 ~/.pi）
+pi install -l npm:pi-hermes-memory
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): add project-local install instructions"
+```
+
+---
+
+### Task 4: 最终验证 + Release
+
+- [ ] **Step 1: 完整测试**
+
+```bash
+npm run check && npm test
+```
+
+Expected: type check zero errors, all tests pass
+
+- [ ] **Step 2: 手动验证项目级安装**
+
+```bash
+# 在测试项目中
+cd /tmp/test-project
+mkdir -p .pi
+pi install -l /path/to/pi-hermes-memory
+pi -p "save a test memory"
+
+# 验证记忆文件在正确位置
+ls .pi/hermes-memory/
+# 应有: MEMORY.md, USER.md
+```
+
+- [ ] **Step 3: 版本号 + 提交**
+
+```bash
+# 不需要单独 bump 版本号，随下次 release 一起
+git add -A
+git commit -m "chore: final verification for project-local memory"
+```

--- a/docs/superpowers/specs/2026-06-12-project-local-memory-design.md
+++ b/docs/superpowers/specs/2026-06-12-project-local-memory-design.md
@@ -1,0 +1,153 @@
+# Project-Local Memory — Design Spec
+
+> Date: 2026-06-12
+> Status: Approved
+> Target: v0.8.0
+
+## Problem
+
+`pi install npm:pi-hermes-memory` 是全局安装，所有记忆放在 `~/.pi/agent/pi-hermes-memory/`，污染用户 home 目录。用户希望：
+
+1. 在特定项目文件夹中安装 hermes（项目级 extension）
+2. 所有记忆留在项目中，不碰 `~/.pi`
+3. 离开项目时 hermes 不激活（由 Pi 自动处理）
+4. 全局安装的用户零感知，体感完全不变
+
+## Solution
+
+新增 `detectMemoryRoot()` 函数：从 extension 入口文件路径反推记忆根目录。项目级安装用 `<project>/.pi/hermes-memory/`，全局安装用 `~/.pi/agent/pi-hermes-memory/`。
+
+用户通过 `pi install -l npm:pi-hermes-memory` 实现项目级安装（Pi 原生支持）。
+
+## Architecture
+
+```
+入口文件路径
+    │
+    ▼
+detectMemoryRoot(import.meta.url)
+    │
+    ├── 全局安装: ~/.pi/agent/extensions/npm/pi-hermes-memory/src/index.ts
+    │       → 搜索到 .pi/agent/
+    │       → 记忆根: ~/.pi/agent/pi-hermes-memory/
+    │
+    └── 项目级安装: <proj>/.pi/extensions/npm/pi-hermes-memory/src/index.ts
+            → 搜索到 .pi/
+            → 记忆根: <proj>/.pi/hermes-memory/
+```
+
+**不改动任何 handler、tool、command、配置、event 处理。**
+
+## Files Changed
+
+### 1. `src/paths.ts` — 新增 `detectMemoryRoot()`
+
+```typescript
+import { existsSync } from "node:fs";
+
+/**
+ * 从 extension 入口文件路径检测记忆根目录。
+ *
+ * 全局安装: ~/.pi/agent/extensions/.../index.ts
+ *   → 记忆根: ~/.pi/agent/pi-hermes-memory/
+ * 项目级安装: <proj>/.pi/extensions/.../index.ts
+ *   → 记忆根: <proj>/.pi/hermes-memory/
+ */
+export function detectMemoryRoot(entryFile: string): string {
+  let dir = path.dirname(entryFile);
+  while (dir !== path.dirname(dir)) {
+    const piDir = path.join(dir, ".pi");
+    if (existsSync(piDir)) {
+      return path.join(piDir, "hermes-memory");
+    }
+    dir = path.dirname(dir);
+  }
+  // 回退到全局默认（不应到达，但保守处理）
+  return path.join(os.homedir(), ".pi", "agent", "pi-hermes-memory");
+}
+```
+
+### 2. `src/index.ts` — 入口处替换路径逻辑
+
+**修改前：**
+```typescript
+const agentRoot = AGENT_ROOT;
+const legacyGlobalDir = path.join(agentRoot, "memory");
+const defaultGlobalDir = path.join(agentRoot, "pi-hermes-memory");
+const configuredMemoryDir = config.memoryDir?.trim();
+const pointsToLegacyMemoryDir = configuredMemoryDir
+  ? path.resolve(configuredMemoryDir) === path.resolve(legacyGlobalDir)
+  : false;
+const globalDir = !configuredMemoryDir || pointsToLegacyMemoryDir
+  ? defaultGlobalDir
+  : configuredMemoryDir;
+const shouldMigrateExtensionRoot = !configuredMemoryDir || pointsToLegacyMemoryDir;
+```
+
+**修改后：**
+```typescript
+const baseDir = detectMemoryRoot(import.meta.url);
+// agentRoot = .pi 目录（全局: ~/.pi/agent, 项目级: <proj>/.pi）
+const agentRoot = path.dirname(baseDir);
+const legacyGlobalDir = path.join(agentRoot, "memory");
+const shouldMigrateExtensionRoot = true; // 始终尝试迁移（项目级无旧数据，无害）
+```
+
+然后将文件中所有 `globalDir` 替换为 `baseDir`。
+
+| 原变量 | 新值 | 说明 |
+|--------|------|------|
+| `AGENT_ROOT` 常量 | `path.dirname(baseDir)` | 从 .pi 目录自动推导 |
+| `legacyGlobalDir` | 保留，用新 `agentRoot` 推导 | 项目级时指向 `<proj>/.pi/memory`（无害） |
+| `defaultGlobalDir` + `configuredMemoryDir` 逻辑 | `detectMemoryRoot()` | 路径不再可配 |
+| `globalDir` | `baseDir` | 语义一致，来源变了 |
+
+## Installation (README Update)
+
+```markdown
+## Quick Start
+
+# 全局安装（所有项目共享记忆）
+pi install npm:pi-hermes-memory
+
+# 项目级安装（记忆留在项目 .pi/hermes-memory/ 中）
+pi install -l npm:pi-hermes-memory
+```
+
+## Behavior Matrix
+
+| 安装方式 | 命令 | 记忆根目录 | 激活范围 | 原有用户感知 |
+|----------|------|-----------|----------|:--:|
+| 全局 | `pi install npm:pi-hermes-memory` | `~/.pi/agent/pi-hermes-memory/` | 所有项目 | 完全不变 |
+| 项目级 | `pi install -l npm:pi-hermes-memory` | `<proj>/.pi/hermes-memory/` | 仅该项目 | 新增功能 |
+
+## What Does NOT Change
+
+- ✅ 所有 handler、tool、command：零改动
+- ✅ 双层记忆（global + project）：零改动
+- ✅ SkillStore、DatabaseManager：零改动
+- ✅ 配置系统（hermes-memory-config.json）：零改动
+- ✅ content-scanner、memory-tool、skill-tool：零改动
+- ✅ 全局安装用户体验：完全不变
+
+## Testing
+
+- 现有测试：入口处的 `MemoryStore` 构造函数接收 `memoryDir` 配置，通过 mock `detectMemoryRoot` 保持现有测试通过
+- 新增测试：`tests/paths.test.ts` 中验证 `detectMemoryRoot` 的项目级 vs 全局路径检测
+
+## Implementation Notes
+
+- `import.meta.url` 在 jiti 中返回 `file://` URL，需 `fileURLToPath()` 转换
+- `detectMemoryRoot()` 需引入 `existsSync` from `node:fs`
+- `agentRoot` = `path.dirname(baseDir)`，全局时为 `~/.pi/agent`，项目级时为 `<proj>/.pi`
+- `shouldMigrateExtensionRoot` 恒为 `true`：全局时迁移旧数据，项目级时无害 no-op
+- `legacyGlobalDir` = `path.join(agentRoot, "memory")`：项目级时指向 `<proj>/.pi/memory`，SkillStore 迁移忽略不存在的目录
+
+## Risk Assessment
+
+| 风险 | 缓解 |
+|------|------|
+| `import.meta.url` 在 jiti 中返回 `file://` URL | 用 `fileURLToPath` 转换 |
+| 入口文件路径不包含 `.pi/` | 回退到 `~/.pi/agent/pi-hermes-memory/` |
+| `existsSync` 同步 I/O | 入口处只调用一次，不影响运行时性能 |
+| SkillStore 用项目级 `legacyGlobalDir`（不存在的路径）| SkillStore 迁移是 best-effort，不存在则跳过 |

--- a/docs/superpowers/specs/2026-06-12-project-local-memory-design.md
+++ b/docs/superpowers/specs/2026-06-12-project-local-memory-design.md
@@ -49,20 +49,24 @@ import { existsSync } from "node:fs";
  * 从 extension 入口文件路径检测记忆根目录。
  *
  * 全局安装: ~/.pi/agent/extensions/.../index.ts
- *   → 记忆根: ~/.pi/agent/pi-hermes-memory/
+ *   → 向上找到 ~/.pi（含 agent/子目录）→ ~/.pi/agent/pi-hermes-memory/
  * 项目级安装: <proj>/.pi/extensions/.../index.ts
- *   → 记忆根: <proj>/.pi/hermes-memory/
+ *   → 向上找到 <proj>/.pi（不含 agent/）→ <proj>/.pi/hermes-memory/
  */
 export function detectMemoryRoot(entryFile: string): string {
   let dir = path.dirname(entryFile);
   while (dir !== path.dirname(dir)) {
     const piDir = path.join(dir, ".pi");
     if (existsSync(piDir)) {
+      // ~/.pi 有 agent/ 子目录（全局 Pi home）; 项目 .pi 没有
+      if (existsSync(path.join(piDir, "agent"))) {
+        return path.join(piDir, "agent", "pi-hermes-memory");
+      }
       return path.join(piDir, "hermes-memory");
     }
     dir = path.dirname(dir);
   }
-  // 回退到全局默认（不应到达，但保守处理）
+  // 回退（不应到达）
   return path.join(os.homedir(), ".pi", "agent", "pi-hermes-memory");
 }
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,8 @@ import { detectProject, detectProjectSkills } from "./project.js";
 import { buildPromptContext } from "./prompt-context.js";
 import { migrateLegacyProjectMemoryDirs } from "./project-memory-migration.js";
 import { migrateExtensionRoot } from "./extension-root-migration.js";
-import { AGENT_ROOT } from "./paths.js";
+import { fileURLToPath } from "node:url";
+import { detectMemoryRoot } from "./paths.js";
 
 export function resolveProjectSkillDiscovery(
   skillStore: SkillStore,
@@ -79,34 +80,24 @@ export function registerProjectSkillDiscoveryHandler(
 export default function (pi: ExtensionAPI) {
   const config = loadConfig();
 
-  const agentRoot = AGENT_ROOT;
+  const baseDir = detectMemoryRoot(fileURLToPath(import.meta.url));
+  const agentRoot = path.dirname(baseDir);
   const legacyGlobalDir = path.join(agentRoot, "memory");
-  const defaultGlobalDir = path.join(agentRoot, "pi-hermes-memory");
-
-  const configuredMemoryDir = config.memoryDir?.trim();
-  const pointsToLegacyMemoryDir = configuredMemoryDir
-    ? path.resolve(configuredMemoryDir) === path.resolve(legacyGlobalDir)
-    : false;
-
-  const globalDir = !configuredMemoryDir || pointsToLegacyMemoryDir
-    ? defaultGlobalDir
-    : configuredMemoryDir;
-
-  const shouldMigrateExtensionRoot = !configuredMemoryDir || pointsToLegacyMemoryDir;
+  const shouldMigrateExtensionRoot = true;
   let extensionRootMigrated = false;
 
-  const store = new MemoryStore({ ...config, memoryDir: globalDir });
+  const store = new MemoryStore({ ...config, memoryDir: baseDir });
   const project = detectProject(config.projectsMemoryDir);
   const projectName = project.name ?? "";
   const skillStore = new SkillStore({
-    globalSkillsDir: path.join(globalDir, "skills"),
+    globalSkillsDir: path.join(baseDir, "skills"),
     projectSkillsDir: project.memoryDir ? path.join(project.memoryDir, "skills") : null,
     projectName: project.name,
     legacySkillsDir: path.join(legacyGlobalDir, "skills"),
     legacyPiGlobalSkillsDir: path.join(agentRoot, "skills"),
-    migrationSentinelPath: path.join(globalDir, ".skills-migrated-to-extension-storage"),
+    migrationSentinelPath: path.join(baseDir, ".skills-migrated-to-extension-storage"),
   });
-  const dbManager = new DatabaseManager(globalDir);
+  const dbManager = new DatabaseManager(baseDir);
 
   const refreshSkillProjectContext = (cwd?: string) => {
     const resource = resolveProjectSkillDiscovery(skillStore, config.projectsMemoryDir, cwd);
@@ -122,7 +113,7 @@ export default function (pi: ExtensionAPI) {
   // remain in place while entries are copied/merged into projects-memory/.
   migrateLegacyProjectMemoryDirs(agentRoot, config.projectsMemoryDir);
   try {
-    syncMarkdownMemoriesToSqlite(dbManager, globalDir, config.projectsMemoryDir, agentRoot);
+    syncMarkdownMemoriesToSqlite(dbManager, baseDir, config.projectsMemoryDir, agentRoot);
   } catch {
     // Best-effort only: failed SQLite backfill should not block extension startup.
   }
@@ -138,7 +129,7 @@ export default function (pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     if (shouldMigrateExtensionRoot && !extensionRootMigrated) {
       try {
-        await migrateExtensionRoot(legacyGlobalDir, globalDir);
+        await migrateExtensionRoot(legacyGlobalDir, baseDir);
       } catch {
         // best effort migration only
       }
@@ -198,7 +189,7 @@ export default function (pi: ExtensionAPI) {
   registerInterviewCommand(pi, store);
   registerSwitchProjectCommand(pi, config);
   registerLearnMemoryCommand(pi);
-  registerSyncMarkdownMemoriesCommand(pi, dbManager, globalDir, config.projectsMemoryDir, agentRoot);
+  registerSyncMarkdownMemoriesCommand(pi, dbManager, baseDir, config.projectsMemoryDir, agentRoot);
   registerPreviewContextCommand(pi, store, projectStore, projectName, config);
 
   // ── 10. SQLite session search + extended memory ──

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,5 +1,6 @@
 import * as os from "node:os";
 import * as path from "node:path";
+import { existsSync } from "node:fs";
 import { DEFAULT_PROJECTS_MEMORY_DIR } from "./constants.js";
 
 export const AGENT_ROOT = path.join(os.homedir(), ".pi", "agent");
@@ -54,4 +55,27 @@ export function normalizeProjectsMemoryDir(input: string): string | undefined {
 export function resolveProjectsRoot(projectsMemoryDir = DEFAULT_PROJECTS_MEMORY_DIR): string {
   const normalized = normalizeProjectsMemoryDir(projectsMemoryDir) ?? DEFAULT_PROJECTS_MEMORY_DIR;
   return path.join(AGENT_ROOT, normalized);
+}
+
+/**
+ * 从 extension 入口文件路径检测记忆根目录。
+ *
+ * 全局安装: ~/.pi/agent/extensions/.../index.ts
+ *   → 向上找到 ~/.pi（含 agent/子目录）→ ~/.pi/agent/pi-hermes-memory/
+ * 项目级安装: <proj>/.pi/extensions/.../index.ts
+ *   → 向上找到 <proj>/.pi（不含 agent/）→ <proj>/.pi/hermes-memory/
+ */
+export function detectMemoryRoot(entryFile: string): string {
+  let dir = path.dirname(entryFile);
+  while (dir !== path.dirname(dir)) {
+    const piDir = path.join(dir, ".pi");
+    if (existsSync(piDir)) {
+      if (existsSync(path.join(piDir, "agent"))) {
+        return path.join(piDir, "agent", "pi-hermes-memory");
+      }
+      return path.join(piDir, "hermes-memory");
+    }
+    dir = path.dirname(dir);
+  }
+  return path.join(os.homedir(), ".pi", "agent", "pi-hermes-memory");
 }

--- a/tests/paths.test.ts
+++ b/tests/paths.test.ts
@@ -1,0 +1,50 @@
+import * as path from "node:path";
+import * as os from "node:os";
+import * as fs from "node:fs";
+import * as assert from "node:assert/strict";
+import { describe, it, before, after } from "node:test";
+import { detectMemoryRoot } from "../src/paths.js";
+
+const TEST_DIR = path.join(os.tmpdir(), `hermes-paths-test-${Date.now()}`);
+
+describe("detectMemoryRoot", () => {
+  before(() => {
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  after(() => {
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("项目级安装: 返回 <proj>/.pi/hermes-memory/", () => {
+    const projectDir = path.join(TEST_DIR, "my-project");
+    const piDir = path.join(projectDir, ".pi");
+    const extensionsDir = path.join(piDir, "extensions");
+    const npmDir = path.join(extensionsDir, "npm", "pi-hermes-memory", "src");
+    fs.mkdirSync(npmDir, { recursive: true });
+
+    const entryFile = path.join(npmDir, "index.ts");
+    const result = detectMemoryRoot(entryFile);
+    assert.equal(result, path.join(piDir, "hermes-memory"));
+  });
+
+  it("全局安装: 返回 ~/.pi/agent/pi-hermes-memory/", () => {
+    const homePiDir = path.join(TEST_DIR, ".pi-global");
+    const agentDir = path.join(homePiDir, ".pi", "agent");
+    const extensionsDir = path.join(agentDir, "extensions", "npm", "pi-hermes-memory", "src");
+    fs.mkdirSync(extensionsDir, { recursive: true });
+
+    const entryFile = path.join(extensionsDir, "index.ts");
+    const result = detectMemoryRoot(entryFile);
+    assert.equal(result, path.join(agentDir, "pi-hermes-memory"));
+  });
+
+  it("找不到 .pi/ 目录时回退到默认路径", () => {
+    const entryFile = path.join(TEST_DIR, "no-pi-dir", "some-ext", "index.ts");
+    fs.mkdirSync(path.dirname(entryFile), { recursive: true });
+
+    const result = detectMemoryRoot(entryFile);
+    const expected = path.join(os.homedir(), ".pi", "agent", "pi-hermes-memory");
+    assert.equal(result, expected);
+  });
+});


### PR DESCRIPTION
Support pi install -l for project-local installation. Memory stays in project .pi/hermes-memory/, zero pollution to ~/.pi.

## Changes

- src/paths.ts: +24 — new detectMemoryRoot() from entry file path
- src/index.ts: +12/-21 — replace AGENT_ROOT + configuredMemoryDir with detectMemoryRoot()
- tests/paths.test.ts: +50 — 3 tests: project-local, global, fallback
- README.md: +4/-1 — document pi install -l

## How It Works

detectMemoryRoot() walks up from entry file, checks .pi/agent/ existence to discriminate global vs project-local.

Global install (unchanged): ~/.pi/agent/pi-hermes-memory/
Project-local (new): <proj>/.pi/hermes-memory/

## Backward Compatibility

Zero breaking changes. Global install behavior identical.