### PR TITLE
fix(db): close SQLite on session shutdown to truncate the WAL

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -211,6 +211,12 @@ export default function (pi: ExtensionAPI) {
   // is the final DB activity. Closing here truncates the WAL via
   // PRAGMA wal_checkpoint(TRUNCATE); without it the WAL only grows to its
   // high-water mark and is never reclaimed across sessions.
+  //
+  // Ordering is safe: Pi's ExtensionRunner.emit() runs same-extension handlers
+  // sequentially in registration order and awaits each one, so the flush above
+  // fully completes before close() runs. WARNING: do not register another
+  // DB-writing session_shutdown handler after this block — it would run after
+  // close() and silently no-op.
   pi.on("session_shutdown", async (_event, ctx) => {
     try {
       const sessionFile = ctx.sessionManager.getSessionFile();

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,6 +207,10 @@ export default function (pi: ExtensionAPI) {
   registerIndexSessionsCommand(pi);
 
   // ── 11. Auto-index session on shutdown ──
+  // Registered last, so this runs after the session-flush shutdown handler and
+  // is the final DB activity. Closing here truncates the WAL via
+  // PRAGMA wal_checkpoint(TRUNCATE); without it the WAL only grows to its
+  // high-water mark and is never reclaimed across sessions.
   pi.on("session_shutdown", async (_event, ctx) => {
     try {
       const sessionFile = ctx.sessionManager.getSessionFile();
@@ -218,6 +222,8 @@ export default function (pi: ExtensionAPI) {
       }
     } catch {
       // Silent fail — don't block shutdown
+    } finally {
+      try { dbManager.close(); } catch { /* best effort — never block shutdown */ }
     }
   });
 }

--- a/tests/store/db.test.ts
+++ b/tests/store/db.test.ts
@@ -192,7 +192,7 @@ describe('DatabaseManager', () => {
 
     it('should truncate the WAL file on close so it is not retained across sessions', () => {
       const db = dbManager.getDb();
-      const walPath = path.join(tmpDir, 'sessions.db-wal');
+      const walPath = `${dbManager.getPath()}-wal`;
 
       // Generate enough WAL traffic to materialize a non-trivial WAL file.
       const insert = db.prepare(`

--- a/tests/store/db.test.ts
+++ b/tests/store/db.test.ts
@@ -189,6 +189,28 @@ describe('DatabaseManager', () => {
         dbManager.close();
       });
     });
+
+    it('should truncate the WAL file on close so it is not retained across sessions', () => {
+      const db = dbManager.getDb();
+      const walPath = path.join(tmpDir, 'sessions.db-wal');
+
+      // Generate enough WAL traffic to materialize a non-trivial WAL file.
+      const insert = db.prepare(`
+        INSERT INTO memories (project, target, content, created, last_referenced)
+        VALUES (?, ?, ?, ?, ?)
+      `);
+      for (let i = 0; i < 500; i++) {
+        insert.run(null, 'memory', `entry ${i} ${'x'.repeat(200)}`, '2026-05-03', '2026-05-03');
+      }
+      assert.ok(fs.existsSync(walPath), 'WAL file should exist after writes');
+      assert.ok(fs.statSync(walPath).size > 0, 'WAL should be non-empty before close');
+
+      // close() runs PRAGMA wal_checkpoint(TRUNCATE), which shrinks the WAL to 0.
+      dbManager.close();
+
+      const walSizeAfter = fs.existsSync(walPath) ? fs.statSync(walPath).size : 0;
+      assert.strictEqual(walSizeAfter, 0, 'WAL should be truncated to 0 bytes after close');
+    });
   });
 
   describe('getStats', () => {


### PR DESCRIPTION
Fixes #74.

## Problem

`DatabaseManager.close()` runs `PRAGMA wal_checkpoint(TRUNCATE)`, but `close()` is never called. The `session_shutdown` auto-index handler indexes the session and returns without closing the connection, so the `-wal` file grows to its high-water mark and is never reclaimed across sessions (observed ~4.3 MB next to a 6.1 MB `sessions.db`). The `wal_autocheckpoint` added in #56 passively checkpoints pages but does not truncate the WAL file; only a `TRUNCATE` checkpoint / clean close does.

## Fix

Close the DB connection in a `finally` block of the auto-index `session_shutdown` handler. It is registered last, so it runs after the session-flush handler's writes and is the final DB activity — the correct point to checkpoint. `close()` already issues the `TRUNCATE` checkpoint and is safe to call repeatedly.

The ordering is guaranteed, not assumed: Pi's `ExtensionRunner.emit()` runs same-extension `session_shutdown` handlers sequentially in registration order and `await`s each one (no `Promise.all`), so the flush writes fully complete before `close()` runs. A maintainer warning in the comment notes not to register a DB-writing `session_shutdown` handler after the close block.

## Test

Adds `tests/store/db.test.ts` coverage: writes enough rows to grow a non-trivial WAL, then asserts the `-wal` file is 0 bytes after `close()`. The WAL path is derived from `dbManager.getPath()` rather than hardcoded.

## Verification

- `npm run check` (tsc) — clean
- full suite via `tests/run-all.sh` — 32/32 files pass, including the new test
