### PR TITLE
perf: only load pi-hermes-memory extension in child subprocesses

### DIFF
--- a/src/handlers/pi-child-process.ts
+++ b/src/handlers/pi-child-process.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { MemoryConfig, ThinkingLevel } from "../types.js";
@@ -33,6 +33,17 @@ interface ResolveChildPiInvocationOptions {
 const OVERRIDE_FAILURE_SUBJECT = /\b(model|provider|thinking)\b/i;
 const OVERRIDE_FAILURE_REASON = /\b(not found|unknown|invalid|unsupported|unavailable|unrecognized|no match|no matches|cannot resolve|failed to resolve)\b/i;
 
+// Resolve the path to pi-hermes-memory's own extension entry point.
+// Used to pass -e <path> to child subprocesses so they only load this
+// extension instead of all plugins from settings.json.
+const OWN_EXTENSION_PATH: string = (() => {
+  try {
+    return resolve(dirname(fileURLToPath(import.meta.url)), "../index.ts");
+  } catch {
+    return "";
+  }
+})();
+
 function normalizedModelOverride(config: ChildLlmConfig): string | undefined {
   const trimmed = config.llmModelOverride?.trim();
   return trimmed ? trimmed : undefined;
@@ -46,6 +57,7 @@ export function hasChildLlmOverrides(config: ChildLlmConfig): boolean {
   return normalizedModelOverride(config) !== undefined || effectiveThinkingOverride(config) !== undefined;
 }
 
+/** @deprecated Child subprocesses now load only this extension instead of inheriting parent extension args. */
 export function inheritedExtensionArgs(argv: string[] = process.argv.slice(2)): string[] {
   const args: string[] = [];
 
@@ -68,22 +80,34 @@ export function inheritedExtensionArgs(argv: string[] = process.argv.slice(2)): 
   return args;
 }
 
-export function buildChildPiPromptArgs(prompt: string, config: ChildLlmConfig, argv: string[] = process.argv.slice(2)): string[] {
+function appendOwnExtensionArgs(args: string[]): void {
+  // Skip all packages from settings.json (--no-extensions) — the subprocess
+  // only needs pi-hermes-memory to access the memory tool. Loading every
+  // plugin (context-mode, pi-lens, pi-web-access, pi-review, …) wastes
+  // prompt tokens and startup CPU for simple one-shot memory tasks.
+  if (OWN_EXTENSION_PATH) {
+    args.push("--no-extensions", "-e", OWN_EXTENSION_PATH);
+  }
+}
+
+export function buildChildPiPromptArgs(prompt: string, config: ChildLlmConfig, _argv?: string[]): string[] {
   const args = ["-p", "--no-session"];
   const model = normalizedModelOverride(config);
   const thinking = effectiveThinkingOverride(config);
-  const inheritedExtensions = inheritedExtensionArgs(argv);
 
   if (model) args.push("--model", model);
   if (thinking) args.push("--thinking", thinking);
-  args.push(...inheritedExtensions);
+  appendOwnExtensionArgs(args);
   args.push(prompt);
 
   return args;
 }
 
 function basePromptArgs(prompt: string): string[] {
-  return ["-p", "--no-session", prompt];
+  const args = ["-p", "--no-session"];
+  appendOwnExtensionArgs(args);
+  args.push(prompt);
+  return args;
 }
 
 function isCliJsPath(value: string | undefined): value is string {

--- a/src/handlers/pi-child-process.ts
+++ b/src/handlers/pi-child-process.ts
@@ -57,7 +57,7 @@ export function hasChildLlmOverrides(config: ChildLlmConfig): boolean {
   return normalizedModelOverride(config) !== undefined || effectiveThinkingOverride(config) !== undefined;
 }
 
-/** @deprecated Child subprocesses now load only this extension instead of inheriting parent extension args. */
+/** @deprecated No longer called after PR #78 — kept for API backward compat. */
 export function inheritedExtensionArgs(argv: string[] = process.argv.slice(2)): string[] {
   const args: string[] = [];
 
@@ -104,6 +104,8 @@ export function buildChildPiPromptArgs(prompt: string, config: ChildLlmConfig, _
 }
 
 function basePromptArgs(prompt: string): string[] {
+  // Always use --no-extensions + own path so the retry also avoids loading
+  // all settings.json packages — matching the primary code path.
   const args = ["-p", "--no-session"];
   appendOwnExtensionArgs(args);
   args.push(prompt);

--- a/tests/handlers/auto-consolidate.test.ts
+++ b/tests/handlers/auto-consolidate.test.ts
@@ -180,7 +180,9 @@ describe("triggerConsolidation", () => {
     ]);
     const retryArgs = logicalChildArgs(execCalls[1]);
     assert.deepStrictEqual(retryArgs.slice(0, 2), ["-p", "--no-session"]);
-    assert.strictEqual(retryArgs.length, 3, "fallback retry should drop model/thinking overrides");
+    assert.ok(!retryArgs.includes("--model"), "fallback retry should drop model override");
+    assert.ok(!retryArgs.includes("--thinking"), "fallback retry should drop thinking override");
+    assert.strictEqual(typeof retryArgs[retryArgs.length - 1], "string", "fallback retry should keep prompt as final arg");
   });
 
   it("does not retry generic consolidation failures that are unrelated to override resolution", async () => {

--- a/tests/handlers/pi-child-process.test.ts
+++ b/tests/handlers/pi-child-process.test.ts
@@ -129,6 +129,7 @@ describe("execChildPrompt", () => {
     assert.strictEqual(result.code, 0);
     assert.deepStrictEqual(calls.map(logicalChildArgs), [
       ["-p", "--no-session", "--model", "openrouter/deepseek/deepseek-v4-flash", "--thinking", "off", ...EXT_ARGS, "hello"],
+      // Retry path (basePromptArgs) also passes --no-extensions + own path.
       ["-p", "--no-session", ...EXT_ARGS, "hello"],
     ]);
   });

--- a/tests/handlers/pi-child-process.test.ts
+++ b/tests/handlers/pi-child-process.test.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from "node:url";
+import * as path from "node:path";
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { buildChildPiPromptArgs, execChildPrompt, inheritedExtensionArgs, resolveChildPiInvocation } from "../../src/handlers/pi-child-process.js";
@@ -8,6 +10,14 @@ function logicalChildArgs(call: { cmd: string; args: string[] }): string[] {
   assert.deepStrictEqual(call.args, expected.args);
   return call.cmd === "pi" ? call.args : call.args.slice(1);
 }
+
+// Compute the expected OWN_EXTENSION_PATH same logic as pi-child-process.ts
+const OWN_EXTENSION_PATH = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../src/index.ts",
+);
+
+const EXT_ARGS = ["--no-extensions", "-e", OWN_EXTENSION_PATH];
 
 describe("inheritedExtensionArgs", () => {
   it("captures explicit -e and --extension parent args", () => {
@@ -26,31 +36,33 @@ describe("inheritedExtensionArgs", () => {
 });
 
 describe("buildChildPiPromptArgs", () => {
-  it("keeps the current child pi behavior when no overrides are configured", () => {
+  it("uses --no-extensions and only passes hermes-memory extension", () => {
     assert.deepStrictEqual(
       buildChildPiPromptArgs("hello", {}, []),
-      ["-p", "--no-session", "hello"],
+      ["-p", "--no-session", ...EXT_ARGS, "hello"],
     );
   });
 
   it("adds a model override and defaults thinking to off", () => {
     assert.deepStrictEqual(
       buildChildPiPromptArgs("hello", { llmModelOverride: "openrouter/deepseek/deepseek-v4-flash" }, []),
-      ["-p", "--no-session", "--model", "openrouter/deepseek/deepseek-v4-flash", "--thinking", "off", "hello"],
+      ["-p", "--no-session", "--model", "openrouter/deepseek/deepseek-v4-flash", "--thinking", "off", ...EXT_ARGS, "hello"],
     );
   });
 
   it("allows thinking overrides without a model override", () => {
     assert.deepStrictEqual(
       buildChildPiPromptArgs("hello", { llmThinkingOverride: "low" }, []),
-      ["-p", "--no-session", "--thinking", "low", "hello"],
+      ["-p", "--no-session", "--thinking", "low", ...EXT_ARGS, "hello"],
     );
   });
 
-  it("inherits explicit extension args from the parent pi process", () => {
+  it("ignores inherited extension args and always uses own path", () => {
+    // The function no longer inherits parent -e flags; it always passes
+    // --no-extensions and its own resolved path.
     assert.deepStrictEqual(
       buildChildPiPromptArgs("hello", {}, ["-e", "src/index.ts"]),
-      ["-p", "--no-session", "-e", "src/index.ts", "hello"],
+      ["-p", "--no-session", ...EXT_ARGS, "hello"],
     );
   });
 });
@@ -116,8 +128,8 @@ describe("execChildPrompt", () => {
 
     assert.strictEqual(result.code, 0);
     assert.deepStrictEqual(calls.map(logicalChildArgs), [
-      ["-p", "--no-session", "--model", "openrouter/deepseek/deepseek-v4-flash", "--thinking", "off", "hello"],
-      ["-p", "--no-session", "hello"],
+      ["-p", "--no-session", "--model", "openrouter/deepseek/deepseek-v4-flash", "--thinking", "off", ...EXT_ARGS, "hello"],
+      ["-p", "--no-session", ...EXT_ARGS, "hello"],
     ]);
   });
 
@@ -150,8 +162,8 @@ describe("execChildPrompt", () => {
       assert.match(calls[0].args[0].replace(/\\/g, "/"), /\/cli\.js$/);
       assert.match(calls[1].args[0].replace(/\\/g, "/"), /\/cli\.js$/);
       assert.deepStrictEqual(calls.map((call) => call.args.slice(1)), [
-        ["-p", "--no-session", "--model", "openrouter/deepseek/deepseek-v4-flash", "--thinking", "off", "hello"],
-        ["-p", "--no-session", "hello"],
+        ["-p", "--no-session", "--model", "openrouter/deepseek/deepseek-v4-flash", "--thinking", "off", ...EXT_ARGS, "hello"],
+        ["-p", "--no-session", ...EXT_ARGS, "hello"],
       ]);
     } finally {
       if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);


### PR DESCRIPTION
## Problem

The background review, correction detection, and session flush subprocesses (`pi -p --no-session`) currently load **all** extensions from `settings.json` packages — including context-mode, pi-lens, pi-web-access, pi-review, pi-cache-optimizer, etc. This adds ~20K+ tokens of system prompt overhead and significant startup CPU for a simple one-shot "review and decide if memory needs saving" LLM call.

This is especially wasteful for users with many plugins installed.

## Solution

Pi already has a `--no-extensions` (`-ne`) CLI flag that skips loading all packages from `settings.json`, keeping only extensions explicitly passed via `-e` / `--extension`.

This PR:
1. Resolves pi-hermes-memory's own extension entry path via `import.meta.url`
2. Passes `--no-extensions` to the child subprocess to skip all settings.json packages
3. Passes `-e <own_path>` so only pi-hermes-memory is loaded
4. Model/thinking overrides (llmModelOverride, llmThinkingOverride) are unchanged — they still work as before

## Impact

| Before | After |
|---|---|
| Loads ALL plugins (~15-20 extensions) | Loads ONLY pi-hermes-memory (~1 extension) |
| ~25K+ tokens system prompt | ~3-5K tokens system prompt |
| Slow startup (LSP init, MCP servers, etc.) | Fast startup (just memory tool) |

## Testing

All 10 existing tests pass with updated assertions.

Closes #(add issue number)