### PR TITLE
Fix: add FTS5→OR→LIKE fallback for CJK session search

### DIFF
--- a/src/store/fts-query.ts
+++ b/src/store/fts-query.ts
@@ -2,6 +2,10 @@ const FTS5_OPERATOR_PATTERN = /\b(OR|AND|NOT|NEAR)\b/;
 const FTS5_TOKEN_PATTERN = /"([^"]*)"|(\S+)/g;
 const NATURAL_LANGUAGE_CONNECTORS = new Set(['and', 'or', 'not', 'near']);
 
+export function hasExplicitFts5Operator(query: string): boolean {
+  return FTS5_OPERATOR_PATTERN.test(query.trim());
+}
+
 function collectNaturalLanguageTerms(query: string): string[] {
   const terms: string[] = [];
 
@@ -29,7 +33,7 @@ export function normalizeFts5Query(query: string): string {
   const trimmed = query.trim();
   if (trimmed.length === 0) return '';
 
-  if (FTS5_OPERATOR_PATTERN.test(trimmed)) {
+  if (hasExplicitFts5Operator(trimmed)) {
     return trimmed;
   }
 
@@ -45,7 +49,7 @@ export function normalizeFts5Query(query: string): string {
  */
 export function buildFallbackFts5Query(query: string): string | null {
   const trimmed = query.trim();
-  if (trimmed.length === 0 || FTS5_OPERATOR_PATTERN.test(trimmed)) {
+  if (trimmed.length === 0 || hasExplicitFts5Operator(trimmed)) {
     return null;
   }
 

--- a/src/store/session-search.ts
+++ b/src/store/session-search.ts
@@ -1,5 +1,5 @@
 import { DatabaseManager } from './db.js';
-import { isFts5QueryError, normalizeFts5Query } from './fts-query.js';
+import { buildFallbackFts5Query, hasExplicitFts5Operator, isFts5QueryError, normalizeFts5Query } from './fts-query.js';
 
 /**
  * Search result from session history.
@@ -27,6 +27,52 @@ export interface SessionSearchOptions {
   since?: string;
 }
 
+type SearchMatch =
+  | { type: 'fts'; query: string }
+  | { type: 'like'; terms: string[] };
+
+const QUERY_TOKEN_PATTERN = /"([^"]*)"|(\S+)/g;
+const NATURAL_LANGUAGE_CONNECTORS = new Set(['and', 'or', 'not', 'near']);
+
+function escapeLikePattern(text: string): string {
+  return text.replace(/[\\%_]/g, '\\$&');
+}
+
+function collectLikeTerms(query: string): string[] {
+  const terms: string[] = [];
+
+  for (const match of query.matchAll(QUERY_TOKEN_PATTERN)) {
+    const phrase = match[1];
+    const term = match[2];
+    if (phrase === undefined && term && NATURAL_LANGUAGE_CONNECTORS.has(term.toLowerCase())) {
+      continue;
+    }
+
+    const rawValue = phrase ?? term ?? '';
+    if (rawValue.length > 0) terms.push(rawValue);
+  }
+
+  return terms;
+}
+
+function mapRows(rows: Array<{
+  session_id: string;
+  project: string;
+  role: string;
+  content: string;
+  timestamp: string;
+  snippet: string;
+}>): SessionSearchResult[] {
+  return rows.map(row => ({
+    sessionId: row.session_id,
+    project: row.project,
+    role: row.role,
+    content: row.content,
+    timestamp: row.timestamp,
+    snippet: row.snippet,
+  }));
+}
+
 /**
  * Search across indexed session messages using FTS5.
  *
@@ -47,79 +93,104 @@ export function searchSessions(
   const db = dbManager.getDb();
   const { limit = 10, project, role, since } = options;
 
-  // Build the query dynamically based on filters
-  const conditions: string[] = [];
-  const params: unknown[] = [];
+  const executeSearch = (match: SearchMatch): SessionSearchResult[] => {
+    const conditions: string[] = [];
+    const params: unknown[] = [];
 
-  // FTS5 match condition — use subquery for reliable rowid matching
+    if (match.type === 'fts') {
+      // FTS5 match condition — use subquery for reliable rowid matching
+      conditions.push('m.rowid IN (SELECT rowid FROM message_fts WHERE message_fts MATCH ?)');
+      params.push(match.query);
+    } else {
+      if (match.terms.length === 0) {
+        return [];
+      }
+      const likeConditions = match.terms.map(() => `m.content LIKE ? ESCAPE '\\'`);
+      conditions.push(`(${likeConditions.join(' OR ')})`);
+      for (const term of match.terms) {
+        params.push(`%${escapeLikePattern(term)}%`);
+      }
+    }
+
+    // Project filter
+    if (project) {
+      conditions.push('s.project = ?');
+      params.push(project);
+    }
+
+    // Role filter
+    if (role) {
+      conditions.push('m.role = ?');
+      params.push(role);
+    }
+
+    // Date filter
+    if (since) {
+      conditions.push('m.timestamp >= ?');
+      params.push(since);
+    }
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    const sql = `
+      SELECT
+        m.session_id,
+        s.project,
+        m.role,
+        m.content,
+        m.timestamp,
+        m.content as snippet
+      FROM messages m
+      JOIN sessions s ON s.id = m.session_id
+      ${whereClause}
+      ORDER BY m.timestamp DESC
+      LIMIT ?
+    `;
+
+    try {
+      const rows = db.prepare(sql).all(...params, limit) as Array<{
+        session_id: string;
+        project: string;
+        role: string;
+        content: string;
+        timestamp: string;
+        snippet: string;
+      }>;
+
+      return mapRows(rows);
+    } catch (err) {
+      if (match.type === 'fts' && isFts5QueryError(err)) {
+        return [];
+      }
+      throw err;
+    }
+  };
+
   const normalizedQuery = normalizeFts5Query(query);
   if (normalizedQuery.length === 0) {
     return [];
   }
-  conditions.push('m.rowid IN (SELECT rowid FROM message_fts WHERE message_fts MATCH ?)');
-  params.push(normalizedQuery);
 
-  // Project filter
-  if (project) {
-    conditions.push('s.project = ?');
-    params.push(project);
+  const exactResults = executeSearch({ type: 'fts', query: normalizedQuery });
+  if (exactResults.length > 0) {
+    return exactResults;
   }
 
-  // Role filter
-  if (role) {
-    conditions.push('m.role = ?');
-    params.push(role);
+  const explicitOperatorQuery = hasExplicitFts5Operator(query);
+  if (explicitOperatorQuery) {
+    return exactResults;
   }
 
-  // Date filter
-  if (since) {
-    conditions.push('m.timestamp >= ?');
-    params.push(since);
-  }
-
-  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
-
-  const sql = `
-    SELECT
-      m.session_id,
-      s.project,
-      m.role,
-      m.content,
-      m.timestamp,
-      m.content as snippet
-    FROM messages m
-    JOIN sessions s ON s.id = m.session_id
-    ${whereClause}
-    ORDER BY m.timestamp DESC
-    LIMIT ?
-  `;
-  params.push(limit);
-
-  try {
-    const rows = db.prepare(sql).all(...params) as Array<{
-      session_id: string;
-      project: string;
-      role: string;
-      content: string;
-      timestamp: string;
-      snippet: string;
-    }>;
-
-    // Map snake_case column names to camelCase
-    return rows.map(row => ({
-      sessionId: row.session_id,
-      project: row.project,
-      role: row.role,
-      content: row.content,
-      timestamp: row.timestamp,
-      snippet: row.snippet,
-    }));
-  } catch (err) {
-    if (isFts5QueryError(err)) {
-      return [];
+  const fallbackQuery = buildFallbackFts5Query(query);
+  if (fallbackQuery && fallbackQuery !== normalizedQuery) {
+    const fallbackResults = executeSearch({ type: 'fts', query: fallbackQuery });
+    if (fallbackResults.length > 0) {
+      return fallbackResults;
     }
-    throw err;
   }
+
+  const likeTerms = collectLikeTerms(query);
+  return executeSearch({ type: 'like', terms: likeTerms });
 }
 
 /**

--- a/tests/store/session-search.test.ts
+++ b/tests/store/session-search.test.ts
@@ -145,6 +145,82 @@ describe('session-search', () => {
       assert.ok(results.some((r) => r.content.includes('gpu timeout issue')));
     });
 
+    it('should fall back to broader natural-language FTS matching when strict term matching misses', () => {
+      indexSession(dbManager, createTestSession({ id: 'fallback-session', messages: [
+        { id: 'fallback-session-msg-1', role: 'assistant', content: "The user's name is Naruto", timestamp: '2026-05-03T00:01:00Z' },
+      ] }));
+
+      const results = searchSessions(dbManager, 'name identity Naruto');
+
+      assert.ok(results.length > 0);
+      assert.ok(results.some((r) => r.content.includes('Naruto')));
+    });
+
+    it('should find mixed Chinese/English queries via fallback', () => {
+      indexSession(dbManager, createTestSession({ id: 'mixed-cjk-session', messages: [
+        { id: 'mixed-cjk-session-msg-1', role: 'assistant', content: 'codex 已经开始执行探索任务了', timestamp: '2026-05-03T00:01:00Z' },
+      ] }));
+
+      const results = searchSessions(dbManager, 'codex 执行 任务');
+
+      assert.ok(results.length > 0);
+      assert.ok(results.some((r) => r.content.includes('codex 已经开始执行探索任务了')));
+    });
+
+    it('should find Chinese-only substrings via LIKE fallback', () => {
+      indexSession(dbManager, createTestSession({ id: 'cjk-only-session', messages: [
+        { id: 'cjk-only-session-msg-1', role: 'assistant', content: '已经开始执行探索任务了', timestamp: '2026-05-03T00:01:00Z' },
+      ] }));
+
+      const results = searchSessions(dbManager, '执行');
+
+      assert.ok(results.length > 0);
+      assert.ok(results.some((r) => r.content.includes('已经开始执行探索任务了')));
+    });
+
+    it('should preserve filters, ordering, and limit during LIKE fallback', () => {
+      indexSession(dbManager, createTestSession({ id: 'cjk-filter-a', project: 'project-a', messages: [
+        { id: 'cjk-filter-a-msg-1', role: 'user', content: '早期已经开始执行探索任务了', timestamp: '2026-05-03T00:01:00Z' },
+        { id: 'cjk-filter-a-msg-2', role: 'user', content: '后续继续执行更多任务', timestamp: '2026-05-03T00:03:00Z' },
+      ] }));
+      indexSession(dbManager, createTestSession({ id: 'cjk-filter-b', project: 'project-b', messages: [
+        { id: 'cjk-filter-b-msg-1', role: 'assistant', content: '另一个项目也执行任务', timestamp: '2026-05-03T00:04:00Z' },
+      ] }));
+
+      const results = searchSessions(dbManager, '执行', {
+        project: 'project-a',
+        role: 'user',
+        since: '2026-05-03T00:02:00Z',
+        limit: 1,
+      });
+
+      assert.strictEqual(results.length, 1);
+      assert.strictEqual(results[0].project, 'project-a');
+      assert.strictEqual(results[0].role, 'user');
+      assert.strictEqual(results[0].timestamp, '2026-05-03T00:03:00Z');
+      assert.ok(results[0].content.includes('后续继续执行更多任务'));
+    });
+
+    it('should escape LIKE wildcard characters during fallback', () => {
+      indexSession(dbManager, createTestSession({ id: 'like-escape-session', messages: [
+        { id: 'like-escape-session-msg-1', role: 'user', content: 'Progress reached 100% today', timestamp: '2026-05-03T00:01:00Z' },
+        { id: 'like-escape-session-msg-2', role: 'user', content: 'A plain message without the wildcard character', timestamp: '2026-05-03T00:02:00Z' },
+      ] }));
+
+      const results = searchSessions(dbManager, '%');
+
+      assert.ok(results.length > 0);
+      assert.ok(results.every((r) => r.content.includes('%')));
+    });
+
+    it('should not broaden explicit operator queries', () => {
+      indexSession(dbManager, createTestSession());
+
+      const results = searchSessions(dbManager, 'Prisma AND nonexistent');
+
+      assert.strictEqual(results.length, 0);
+    });
+
     it('should handle malformed FTS5 queries gracefully', () => {
       indexSession(dbManager, createTestSession());
 


### PR DESCRIPTION
## Summary

Fixes silent empty results for mixed Chinese/English and Chinese-only queries in `session_search`.

Closes #77

## Problem

`session_search` returns 0 results for queries like `codex 执行 任务` even when matching messages exist (e.g. `codex 已经开始执行探索任务了`). English-only queries such as `codex` work fine.

## Root cause

FTS5's default `unicode61` tokenizer does not segment CJK text into individual characters. A Chinese phrase such as `已经开始执行探索任务了` is stored as a single opaque token. When the user searches for `执行`, it is embedded inside that larger token and never matches.

The existing `normalizeFts5Query()` wraps each term in double quotes and joins them with spaces (implicit FTS5 AND). If any Chinese term fails to match, the entire query returns nothing, and there was no broader fallback.

## Changes

In `src/store/session-search.ts`:

1. **Primary path:** run the existing normalized FTS5 AND query.
2. **OR fallback:** if AND returns nothing *and* the query is a natural-language query (no explicit uppercase `AND`/`OR`/`NOT`/`NEAR`), retry with `buildFallbackFts5Query()` from `src/store/fts-query.ts`.
3. **LIKE fallback:** if both FTS attempts return nothing, fall back to safe SQL `LIKE ? ESCAPE '\'` substring matching for each natural-language term. This catches CJK terms that are embedded inside larger FTS tokens.
4. Refactored query building into a shared `executeSearch()` helper so filters (`project`, `role`, `since`), timestamp ordering, and `limit` are applied identically across FTS and LIKE paths.

In `src/store/fts-query.ts`:

- Exported `hasExplicitFts5Operator()` so `session-search.ts` can preserve the FTS-only path for explicit operator queries.

In `tests/store/session-search.test.ts`:

- mixed Chinese/English query fallback
- Chinese-only substring fallback
- filter/limit/ordering preservation during LIKE fallback
- LIKE wildcard escaping (`%`)
- explicit operator queries stay on FTS-only path

## Out of scope

This PR intentionally does **not** add automatic session backfill on extension startup. The original report also noted that sessions between manual `/memory-index-sessions` runs are not indexed; fixing that is tracked separately to avoid slowing Pi startup.

A long-term improvement would be a CJK-aware FTS5 tokenizer (ICU-linked SQLite or a custom tokenizer), which would make Chinese search more precise than substring matching.

## Testing

- `npm run check` passes
- `npm test` passes (33/33 test files)
- New regression tests cover the CJK and fallback scenarios listed above

## Checklist

- [x] Code follows the existing store patterns
- [x] No Pi extension API surfaces changed
- [x] `LIKE` patterns are escaped to prevent wildcard injection
- [x] Explicit FTS5 operator queries are not broadened unexpectedly
- [x] Tests added for new fallback behavior
