### PR TITLE
fix: spawn child Pi via node on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hermes-memory",
-      "version": "0.7.17",
+      "version": "0.7.18",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-tui": "^0.74.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "description": "🧠 Persistent memory + 🔍 session search + 🛡️ secret scanning for Pi. Token-aware policy-only memory by default, SQLite FTS5 search, auto-consolidation, procedural skills. 368 tests. Ported from Hermes agent.",
   "type": "module",
   "main": "src/index.ts",

--- a/src/handlers/pi-child-process.ts
+++ b/src/handlers/pi-child-process.ts
@@ -1,3 +1,6 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { MemoryConfig, ThinkingLevel } from "../types.js";
 
@@ -13,6 +16,18 @@ interface ExecChildPromptOptions {
   signal?: AbortSignal;
   timeoutMs: number;
   retryWithoutOverrides?: boolean;
+}
+
+export interface ChildPiInvocation {
+  command: string;
+  args: string[];
+}
+
+interface ResolveChildPiInvocationOptions {
+  platform?: NodeJS.Platform;
+  execPath?: string;
+  argv?: string[];
+  piCliPath?: string | null;
 }
 
 const OVERRIDE_FAILURE_SUBJECT = /\b(model|provider|thinking)\b/i;
@@ -71,6 +86,56 @@ function basePromptArgs(prompt: string): string[] {
   return ["-p", "--no-session", prompt];
 }
 
+function isCliJsPath(value: string | undefined): value is string {
+  if (!value) return false;
+  return value.replace(/\\/g, "/").toLowerCase().endsWith("/cli.js");
+}
+
+function resolvedInstalledPiCliPath(): string | undefined {
+  try {
+    const packageEntry = import.meta.resolve("@earendil-works/pi-coding-agent");
+    const entryPath = fileURLToPath(packageEntry);
+    const cliPath = join(dirname(entryPath), "cli.js");
+    return existsSync(cliPath) ? cliPath : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolvedPiCliPath(options: ResolveChildPiInvocationOptions): string | undefined {
+  if (options.piCliPath !== undefined) {
+    return options.piCliPath ?? undefined;
+  }
+
+  const argv = options.argv ?? process.argv;
+  const currentCli = argv[1];
+  if (isCliJsPath(currentCli) && existsSync(currentCli)) {
+    return currentCli;
+  }
+
+  return resolvedInstalledPiCliPath();
+}
+
+export function resolveChildPiInvocation(
+  args: string[],
+  options: ResolveChildPiInvocationOptions = {},
+): ChildPiInvocation {
+  const platform = options.platform ?? process.platform;
+  if (platform !== "win32") {
+    return { command: "pi", args };
+  }
+
+  const piCliPath = resolvedPiCliPath(options);
+  if (!piCliPath) {
+    return { command: "pi", args };
+  }
+
+  return {
+    command: options.execPath ?? process.execPath,
+    args: [piCliPath, ...args],
+  };
+}
+
 function shouldRetryWithoutOverridesFromText(text: string | undefined): boolean {
   if (!text) return false;
   return OVERRIDE_FAILURE_SUBJECT.test(text) && OVERRIDE_FAILURE_REASON.test(text);
@@ -96,7 +161,8 @@ export async function execChildPrompt(
   };
 
   try {
-    const result = await pi.exec("pi", buildChildPiPromptArgs(prompt, config), execOptions) as PiExecResult;
+    const invocation = resolveChildPiInvocation(buildChildPiPromptArgs(prompt, config));
+    const result = await pi.exec(invocation.command, invocation.args, execOptions) as PiExecResult;
     if (
       result.code === 0 ||
       !options.retryWithoutOverrides ||
@@ -115,5 +181,6 @@ export async function execChildPrompt(
     }
   }
 
-  return pi.exec("pi", basePromptArgs(prompt), execOptions) as Promise<PiExecResult>;
+  const retryInvocation = resolveChildPiInvocation(basePromptArgs(prompt));
+  return pi.exec(retryInvocation.command, retryInvocation.args, execOptions) as Promise<PiExecResult>;
 }

--- a/tests/handlers/auto-consolidate.test.ts
+++ b/tests/handlers/auto-consolidate.test.ts
@@ -8,11 +8,26 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";
 import { registerConsolidateCommand, triggerConsolidation } from "../../src/handlers/auto-consolidate.js";
+import { resolveChildPiInvocation } from "../../src/handlers/pi-child-process.js";
 import { ENTRY_DELIMITER } from "../../src/constants.js";
 
 // ─── Mock infrastructure ───
 
 let execCalls: any[];
+
+function logicalChildArgs(call: any[]): string[] {
+  const [cmd, args] = call;
+  const logicalArgs = cmd === "pi" ? args : args.slice(1);
+  const expected = resolveChildPiInvocation(logicalArgs);
+  assert.strictEqual(cmd, expected.command);
+  assert.deepStrictEqual(args, expected.args);
+  return logicalArgs;
+}
+
+function childPrompt(call: any[]): string {
+  const args = logicalChildArgs(call);
+  return args[args.length - 1];
+}
 
 function createMockPi(execReturn?: { code: number; stdout: string; stderr: string }) {
   const ret = execReturn ?? { code: 0, stdout: "Consolidated", stderr: "" };
@@ -50,8 +65,7 @@ describe("triggerConsolidation", () => {
     await triggerConsolidation(pi, mockStore, "memory");
 
     assert.strictEqual(execCalls.length, 1, "should call pi.exec once");
-    const [cmd, args] = execCalls[0];
-    assert.strictEqual(cmd, "pi");
+    const args = logicalChildArgs(execCalls[0]);
     assert.ok(args[0] === "-p", "should use -p flag");
     assert.ok(args.includes("--no-session"), "should include --no-session");
 
@@ -105,7 +119,7 @@ describe("triggerConsolidation", () => {
     const pi = createMockPi();
     await triggerConsolidation(pi, mockStore, "user");
 
-    const prompt = execCalls[0][1][execCalls[0][1].length - 1];
+    const prompt = childPrompt(execCalls[0]);
     assert.ok(prompt.includes("user fact 1"), "prompt should include user entries");
     assert.ok(prompt.includes("User Profile"), "prompt should reference user profile");
   });
@@ -114,7 +128,7 @@ describe("triggerConsolidation", () => {
     const pi = createMockPi();
     await triggerConsolidation(pi, mockStore, "failure");
 
-    const prompt = execCalls[0][1][execCalls[0][1].length - 1];
+    const prompt = childPrompt(execCalls[0]);
     assert.ok(prompt.includes("failure lesson 1"), "prompt should include failure entries");
     assert.ok(prompt.includes("Failure Memory"), "prompt should reference failure memory");
     assert.ok(prompt.includes("Target: 'failure'"), "prompt should tell the child agent to use target='failure'");
@@ -124,7 +138,7 @@ describe("triggerConsolidation", () => {
     const pi = createMockPi();
     await triggerConsolidation(pi, mockStore, "memory", undefined, 60000, "project");
 
-    const prompt = execCalls[0][1][execCalls[0][1].length - 1];
+    const prompt = childPrompt(execCalls[0]);
     assert.ok(prompt.includes("old entry 1"), "prompt should include project memory entries");
     assert.ok(prompt.includes("Project Memory"), "prompt should label project memory");
     assert.ok(prompt.includes("Target: 'project'"), "prompt should tell the child agent to use target='project'");
@@ -156,7 +170,7 @@ describe("triggerConsolidation", () => {
 
     assert.strictEqual(result.consolidated, true);
     assert.strictEqual(execCalls.length, 2, "should retry once without overrides");
-    assert.deepStrictEqual(execCalls[0][1].slice(0, 6), [
+    assert.deepStrictEqual(logicalChildArgs(execCalls[0]).slice(0, 6), [
       "-p",
       "--no-session",
       "--model",
@@ -164,8 +178,9 @@ describe("triggerConsolidation", () => {
       "--thinking",
       "off",
     ]);
-    assert.deepStrictEqual(execCalls[1][1].slice(0, 2), ["-p", "--no-session"]);
-    assert.strictEqual(execCalls[1][1].length, 3, "fallback retry should drop model/thinking overrides");
+    const retryArgs = logicalChildArgs(execCalls[1]);
+    assert.deepStrictEqual(retryArgs.slice(0, 2), ["-p", "--no-session"]);
+    assert.strictEqual(retryArgs.length, 3, "fallback retry should drop model/thinking overrides");
   });
 
   it("does not retry generic consolidation failures that are unrelated to override resolution", async () => {
@@ -203,7 +218,7 @@ describe("triggerConsolidation", () => {
     const pi = createMockPi();
     await triggerConsolidation(pi, emptyStore, "memory");
 
-    const prompt = execCalls[0][1][execCalls[0][1].length - 1];
+    const prompt = childPrompt(execCalls[0]);
     assert.ok(prompt.includes("(empty)"), "prompt should show (empty) for empty entries");
   });
 });
@@ -243,11 +258,11 @@ describe("registerConsolidateCommand", () => {
     });
 
     assert.strictEqual(execCalls.length, 4, "should consolidate memory, user, failure, and project stores");
-    const failurePrompt = execCalls[2][1][execCalls[2][1].length - 1];
+    const failurePrompt = childPrompt(execCalls[2]);
     assert.ok(failurePrompt.includes("Failure Memory"), "failure prompt should be labeled");
     assert.ok(failurePrompt.includes("failure lesson 1"), "failure prompt should include failure entries");
     assert.ok(failurePrompt.includes("Target: 'failure'"), "failure prompt should use target='failure'");
-    const projectPrompt = execCalls[3][1][execCalls[3][1].length - 1];
+    const projectPrompt = childPrompt(execCalls[3]);
     assert.ok(projectPrompt.includes("Project Memory"), "project prompt should be labeled");
     assert.ok(projectPrompt.includes("project fact"), "project prompt should include project entries");
     assert.ok(projectPrompt.includes("Target: 'project'"), "project prompt should use target='project'");

--- a/tests/handlers/background-review.test.ts
+++ b/tests/handlers/background-review.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert";
 import { setupBackgroundReview } from "../../src/handlers/background-review.js";
+import { resolveChildPiInvocation } from "../../src/handlers/pi-child-process.js";
 
 // ─── Mock infrastructure ───
 
@@ -112,8 +113,18 @@ async function settle(ms = 10) {
   await new Promise((r) => setTimeout(r, ms));
 }
 
+function logicalChildArgs(index = execCalls.length - 1): string[] {
+  const [cmd, args] = execCalls[index];
+  const logicalArgs = cmd === "pi" ? args : args.slice(1);
+  const expected = resolveChildPiInvocation(logicalArgs);
+  assert.strictEqual(cmd, expected.command);
+  assert.deepStrictEqual(args, expected.args);
+  return logicalArgs;
+}
+
 function reviewPrompt(index = execCalls.length - 1): string {
-  return execCalls[index][1][2];
+  const args = logicalChildArgs(index);
+  return args[args.length - 1];
 }
 
 // ─── Tests ───
@@ -165,9 +176,7 @@ describe("setupBackgroundReview", () => {
 
     assert.strictEqual(execCalls.length, 1, "exec should be called once at turn 10");
     // Verify it calls pi.exec with review prompt
-    const execArgs = execCalls[0];
-    assert.strictEqual(execArgs[0], "pi", "exec first arg should be 'pi'");
-    const cmdArgs: string[] = execArgs[1];
+    const cmdArgs = logicalChildArgs(0);
     assert.ok(cmdArgs[0] === "-p", "should use -p flag");
     assert.ok(cmdArgs.includes("--no-session"), "should include --no-session");
     const prompt = reviewPrompt(0);
@@ -192,7 +201,7 @@ describe("setupBackgroundReview", () => {
     }
     await settle();
 
-    const cmdArgs: string[] = execCalls[0][1];
+    const cmdArgs = logicalChildArgs(0);
     assert.deepStrictEqual(
       cmdArgs.slice(0, 6),
       ["-p", "--no-session", "--model", "openrouter/deepseek/deepseek-v4-flash", "--thinking", "minimal"],

--- a/tests/handlers/correction-detector.test.ts
+++ b/tests/handlers/correction-detector.test.ts
@@ -11,6 +11,7 @@ import path from "node:path";
 import { DatabaseManager } from "../../src/store/db.js";
 import { getMemories } from "../../src/store/sqlite-memory-store.js";
 import { isCorrection, setupCorrectionDetector } from "../../src/handlers/correction-detector.js";
+import { resolveChildPiInvocation } from "../../src/handlers/pi-child-process.js";
 
 // ─── Pattern matching tests ───
 
@@ -241,6 +242,15 @@ describe("setupCorrectionDetector handler", () => {
     } as any;
   }
 
+  function logicalChildArgs(call: any[]): string[] {
+    const [cmd, args] = call;
+    const logicalArgs = cmd === "pi" ? args : args.slice(1);
+    const expected = resolveChildPiInvocation(logicalArgs);
+    assert.strictEqual(cmd, expected.command);
+    assert.deepStrictEqual(args, expected.args);
+    return logicalArgs;
+  }
+
   const mockStore = {
     getMemoryEntries: () => ["existing entry"],
     getUserEntries: () => [],
@@ -339,7 +349,7 @@ describe("setupCorrectionDetector handler", () => {
     fireTurnEnd(branch);
     await settle();
 
-    const cmdArgs: string[] = execCalls[0][1];
+    const cmdArgs = logicalChildArgs(execCalls[0]);
     assert.deepStrictEqual(
       cmdArgs.slice(0, 6),
       ["-p", "--no-session", "--model", "openrouter/deepseek/deepseek-v4-flash", "--thinking", "off"],

--- a/tests/handlers/pi-child-process.test.ts
+++ b/tests/handlers/pi-child-process.test.ts
@@ -1,6 +1,13 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { buildChildPiPromptArgs, execChildPrompt, inheritedExtensionArgs } from "../../src/handlers/pi-child-process.js";
+import { buildChildPiPromptArgs, execChildPrompt, inheritedExtensionArgs, resolveChildPiInvocation } from "../../src/handlers/pi-child-process.js";
+
+function logicalChildArgs(call: { cmd: string; args: string[] }): string[] {
+  const expected = resolveChildPiInvocation(call.cmd === "pi" ? call.args : call.args.slice(1));
+  assert.strictEqual(call.cmd, expected.command);
+  assert.deepStrictEqual(call.args, expected.args);
+  return call.cmd === "pi" ? call.args : call.args.slice(1);
+}
 
 describe("inheritedExtensionArgs", () => {
   it("captures explicit -e and --extension parent args", () => {
@@ -48,6 +55,45 @@ describe("buildChildPiPromptArgs", () => {
   });
 });
 
+describe("resolveChildPiInvocation", () => {
+  it("keeps non-Windows child pi invocations unchanged", () => {
+    const args = ["-p", "--no-session", "hello"];
+
+    assert.deepStrictEqual(
+      resolveChildPiInvocation(args, { platform: "linux" }),
+      { command: "pi", args },
+    );
+  });
+
+  it("runs node.exe with cli.js first on Windows when a Pi CLI path is available", () => {
+    assert.deepStrictEqual(
+      resolveChildPiInvocation(["-p", "--no-session", "hello"], {
+        platform: "win32",
+        execPath: "C:\\Program Files\\nodejs\\node.exe",
+        piCliPath: "C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\@earendil-works\\pi-coding-agent\\dist\\cli.js",
+      }),
+      {
+        command: "C:\\Program Files\\nodejs\\node.exe",
+        args: [
+          "C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\@earendil-works\\pi-coding-agent\\dist\\cli.js",
+          "-p",
+          "--no-session",
+          "hello",
+        ],
+      },
+    );
+  });
+
+  it("falls back to the existing pi invocation on Windows if cli.js cannot be resolved", () => {
+    const args = ["-p", "--no-session", "hello"];
+
+    assert.deepStrictEqual(
+      resolveChildPiInvocation(args, { platform: "win32", piCliPath: null }),
+      { command: "pi", args },
+    );
+  });
+});
+
 describe("execChildPrompt", () => {
   it("retries once without overrides when requested and the override subprocess fails for model resolution reasons", async () => {
     const calls: Array<{ cmd: string; args: string[] }> = [];
@@ -69,10 +115,47 @@ describe("execChildPrompt", () => {
     });
 
     assert.strictEqual(result.code, 0);
-    assert.deepStrictEqual(calls.map((call) => call.args), [
+    assert.deepStrictEqual(calls.map(logicalChildArgs), [
       ["-p", "--no-session", "--model", "openrouter/deepseek/deepseek-v4-flash", "--thinking", "off", "hello"],
       ["-p", "--no-session", "hello"],
     ]);
+  });
+
+  it("uses the resolved Windows node.exe invocation for both override retry attempts", async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    try {
+      const calls: Array<{ cmd: string; args: string[] }> = [];
+      const pi = {
+        exec: async (cmd: string, args: string[]) => {
+          calls.push({ cmd, args });
+          if (calls.length === 1) {
+            return { code: 1, stdout: "", stderr: "model not found" };
+          }
+          return { code: 0, stdout: "ok", stderr: "" };
+        },
+      };
+
+      const result = await execChildPrompt(pi as any, "hello", {
+        llmModelOverride: "openrouter/deepseek/deepseek-v4-flash",
+      }, {
+        timeoutMs: 30000,
+        retryWithoutOverrides: true,
+      });
+
+      assert.strictEqual(result.code, 0);
+      assert.strictEqual(calls.length, 2);
+      assert.strictEqual(calls[0].cmd, process.execPath);
+      assert.strictEqual(calls[1].cmd, process.execPath);
+      assert.match(calls[0].args[0].replace(/\\/g, "/"), /\/cli\.js$/);
+      assert.match(calls[1].args[0].replace(/\\/g, "/"), /\/cli\.js$/);
+      assert.deepStrictEqual(calls.map((call) => call.args.slice(1)), [
+        ["-p", "--no-session", "--model", "openrouter/deepseek/deepseek-v4-flash", "--thinking", "off", "hello"],
+        ["-p", "--no-session", "hello"],
+      ]);
+    } finally {
+      if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
+    }
   });
 
   it("does not retry generic non-zero child failures that are unrelated to override resolution", async () => {

--- a/tests/handlers/session-flush.test.ts
+++ b/tests/handlers/session-flush.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import { setupSessionFlush } from "../../src/handlers/session-flush.js";
+import { resolveChildPiInvocation } from "../../src/handlers/pi-child-process.js";
 import { FLUSH_PROMPT } from "../../src/constants.js";
 import type { MemoryConfig } from "../../src/types.js";
 
@@ -86,6 +87,20 @@ async function emit(
 }
 
 const mockStore = { getMemoryEntries: () => [], getUserEntries: () => [] } as any;
+
+function logicalChildArgs(call: { args: any[] }): string[] {
+  const [cmd, args] = call.args;
+  const logicalArgs = cmd === "pi" ? args : args.slice(1);
+  const expected = resolveChildPiInvocation(logicalArgs);
+  assert.equal(cmd, expected.command);
+  assert.deepEqual(args, expected.args);
+  return logicalArgs;
+}
+
+function flushMessage(call: { args: any[] }): string {
+  const args = logicalChildArgs(call);
+  return args[args.length - 1];
+}
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
@@ -203,21 +218,20 @@ describe("setupSessionFlush", () => {
 
     assert.equal(mockPi.execCalls.length, 1);
 
-    const [cmd, args, opts] = mockPi.execCalls[0].args;
-    assert.equal(cmd, "pi");
-    assert.ok(Array.isArray(args));
+    const [, , opts] = mockPi.execCalls[0].args;
+    const args = logicalChildArgs(mockPi.execCalls[0]);
     assert.equal(args[0], "-p");
     assert.equal(args[1], "--no-session");
 
-    // The third arg is the flush message containing the prompt + conversation
-    const flushMessage = args[2];
-    assert.ok(flushMessage.includes(FLUSH_PROMPT), "flush message should contain FLUSH_PROMPT");
-    assert.ok(flushMessage.includes("[USER]"), "flush message should contain [USER] prefix");
+    // The final logical arg is the flush message containing the prompt + conversation
+    const message = args[args.length - 1];
+    assert.ok(message.includes(FLUSH_PROMPT), "flush message should contain FLUSH_PROMPT");
+    assert.ok(message.includes("[USER]"), "flush message should contain [USER] prefix");
     assert.ok(
-      flushMessage.includes("[ASSISTANT]"),
+      message.includes("[ASSISTANT]"),
       "flush message should contain [ASSISTANT] prefix",
     );
-    assert.ok(flushMessage.includes("msg 0"), "flush message should contain conversation text");
+    assert.ok(message.includes("msg 0"), "flush message should contain conversation text");
 
     // Options should include timeout
     assert.ok(opts, "options should be passed");
@@ -236,7 +250,7 @@ describe("setupSessionFlush", () => {
     const ctx = { sessionManager: { getBranch: () => mockBranch(4) } };
     await emit(mockPi.handlers, "session_before_compact", { signal: undefined }, ctx);
 
-    const [, args] = mockPi.execCalls[0].args;
+    const args = logicalChildArgs(mockPi.execCalls[0]);
     assert.deepStrictEqual(
       args.slice(0, 6),
       ["-p", "--no-session", "--model", "openrouter/deepseek/deepseek-v4-flash", "--thinking", "low"],
@@ -252,9 +266,9 @@ describe("setupSessionFlush", () => {
     const ctx = { sessionManager: { getBranch: () => mockBranch(8) } };
     await emit(mockPi.handlers, "session_before_compact", { signal: undefined }, ctx);
 
-    const flushMessage = mockPi.execCalls[0].args[1][2];
-    assert.ok(flushMessage.includes("msg 0"), "default should include older messages");
-    assert.ok(flushMessage.includes("msg 7"), "default should include latest messages");
+    const message = flushMessage(mockPi.execCalls[0]);
+    assert.ok(message.includes("msg 0"), "default should include older messages");
+    assert.ok(message.includes("msg 7"), "default should include latest messages");
   });
 
   it("Flush limits conversation to recent messages when configured", async () => {
@@ -266,11 +280,11 @@ describe("setupSessionFlush", () => {
     const ctx = { sessionManager: { getBranch: () => mockBranch(8) } };
     await emit(mockPi.handlers, "session_before_compact", { signal: undefined }, ctx);
 
-    const flushMessage = mockPi.execCalls[0].args[1][2];
-    assert.ok(!flushMessage.includes("msg 4"), "window should exclude older messages");
-    assert.ok(flushMessage.includes("msg 5"));
-    assert.ok(flushMessage.includes("msg 6"));
-    assert.ok(flushMessage.includes("msg 7"));
+    const message = flushMessage(mockPi.execCalls[0]);
+    assert.ok(!message.includes("msg 4"), "window should exclude older messages");
+    assert.ok(message.includes("msg 5"));
+    assert.ok(message.includes("msg 6"));
+    assert.ok(message.includes("msg 7"));
   });
 
   it("Flush does not use the review recent-message limit", async () => {
@@ -282,8 +296,8 @@ describe("setupSessionFlush", () => {
     const ctx = { sessionManager: { getBranch: () => mockBranch(8) } };
     await emit(mockPi.handlers, "session_before_compact", { signal: undefined }, ctx);
 
-    const flushMessage = mockPi.execCalls[0].args[1][2];
-    assert.ok(flushMessage.includes("msg 0"), "review limit must not affect flush");
+    const message = flushMessage(mockPi.execCalls[0]);
+    assert.ok(message.includes("msg 0"), "review limit must not affect flush");
   });
 
   // ── Error resilience ────────────────────────────────────────────────
@@ -340,10 +354,10 @@ describe("setupSessionFlush", () => {
     // exec is still called (flush message just has no conversation lines)
     assert.equal(mockPi.execCalls.length, 1);
 
-    const flushMessage = mockPi.execCalls[0].args[1][2];
-    assert.ok(flushMessage.includes(FLUSH_PROMPT));
+    const message = flushMessage(mockPi.execCalls[0]);
+    assert.ok(message.includes(FLUSH_PROMPT));
     // No [USER]/[ASSISTANT] prefixes in empty conversation
-    assert.ok(!flushMessage.includes("[USER]"), "empty branch should have no [USER]");
+    assert.ok(!message.includes("[USER]"), "empty branch should have no [USER]");
   });
 
   it("Concurrent compact + shutdown both flush", async () => {


### PR DESCRIPTION
## Summary
- Fix Windows child Pi subprocess spawning by resolving the Pi CLI JS file and invoking it via `node.exe` instead of spawning the `pi` shim directly.
- Keep non-Windows behavior unchanged and preserve existing fallback/retry/failure semantics.
- Bump package version to 0.7.18.

Fixes #69

## Verification
- `npm run check`
- `npm test`
- Isolated Pi smoke test: `PI_CODING_AGENT_DIR=$(mktemp -d) pi -e ./src/index.ts -p --no-session ...` returned expected output with exit 0
