### PR TITLE
fix(session-search): live index current session

### DIFF
--- a/src/handlers/session-backfill.ts
+++ b/src/handlers/session-backfill.ts
@@ -1,0 +1,135 @@
+import type { DatabaseManager } from '../store/db.js';
+import {
+  indexAllSessions,
+  needsBackfill,
+  touchBackfillTimestamp,
+  type BulkIndexResult,
+} from '../store/session-indexer.js';
+
+export const SESSION_BACKFILL_SHUTDOWN_TIMEOUT_MS = 5000;
+
+type NotifyLevel = 'info' | 'warning' | 'error';
+type NotifyFn = (message: string, level: NotifyLevel) => void;
+
+type SetTimeoutFn = (callback: () => void, ms: number) => unknown;
+
+export interface SessionBackfillState {
+  inProgress: boolean;
+  promise: Promise<void> | null;
+}
+
+export const sessionBackfillState: SessionBackfillState = {
+  inProgress: false,
+  promise: null,
+};
+
+export interface ScheduleSessionBackfillOptions {
+  notify?: NotifyFn;
+  state?: SessionBackfillState;
+  setTimeoutFn?: SetTimeoutFn;
+  needsBackfillFn?: typeof needsBackfill;
+  indexAllSessionsFn?: typeof indexAllSessions;
+  touchBackfillTimestampFn?: typeof touchBackfillTimestamp;
+}
+
+function formatBackfillResult(result: BulkIndexResult): string {
+  const errorSuffix = result.errors.length > 0 ? ` (${result.errors.length} file error${result.errors.length === 1 ? '' : 's'})` : '';
+  return `🧠 Session backfill complete: ${result.sessionsIndexed} indexed, ${result.sessionsSkipped} skipped, ${result.messagesIndexed} messages${errorSuffix}.`;
+}
+
+function notifyBestEffort(notify: NotifyFn | undefined, message: string, level: NotifyLevel): void {
+  try {
+    notify?.(message, level);
+  } catch {
+    // Notification failures must never affect backfill.
+  }
+}
+
+/**
+ * Schedule a best-effort, non-blocking backfill of unindexed Pi sessions.
+ *
+ * The expensive indexAllSessions() pass is always deferred with setTimeout(0)
+ * so session_start can resolve before disk parsing/indexing begins. A shared
+ * state guard prevents concurrent backfills within this extension instance.
+ *
+ * @returns true when a backfill task was scheduled; false when it was skipped.
+ */
+export function scheduleSessionBackfill(
+  dbManager: DatabaseManager,
+  sessionsDir: string,
+  options: ScheduleSessionBackfillOptions = {},
+): boolean {
+  const state = options.state ?? sessionBackfillState;
+  const setTimeoutFn = options.setTimeoutFn ?? setTimeout;
+  const needsBackfillFn = options.needsBackfillFn ?? needsBackfill;
+  const indexAllSessionsFn = options.indexAllSessionsFn ?? indexAllSessions;
+  const touchBackfillTimestampFn = options.touchBackfillTimestampFn ?? touchBackfillTimestamp;
+
+  if (state.inProgress) {
+    return false;
+  }
+
+  try {
+    if (!needsBackfillFn(dbManager, sessionsDir)) {
+      return false;
+    }
+  } catch (err) {
+    notifyBestEffort(
+      options.notify,
+      `⚠️ Session backfill check failed: ${err instanceof Error ? err.message : String(err)}`,
+      'warning',
+    );
+    return false;
+  }
+
+  state.inProgress = true;
+  state.promise = new Promise<void>((resolve) => {
+    setTimeoutFn(() => {
+      try {
+        const result = indexAllSessionsFn(dbManager, sessionsDir);
+        touchBackfillTimestampFn(dbManager);
+        notifyBestEffort(options.notify, formatBackfillResult(result), result.errors.length > 0 ? 'warning' : 'info');
+      } catch (err) {
+        notifyBestEffort(
+          options.notify,
+          `⚠️ Session backfill failed: ${err instanceof Error ? err.message : String(err)}`,
+          'warning',
+        );
+      } finally {
+        state.inProgress = false;
+        state.promise = null;
+        resolve();
+      }
+    }, 0);
+  });
+
+  return true;
+}
+
+/**
+ * Wait briefly for an in-progress backfill before shutdown closes SQLite.
+ *
+ * @returns true if no backfill was running or it completed before the timeout;
+ * false if the timeout elapsed first.
+ */
+export async function waitForSessionBackfill(
+  timeoutMs = SESSION_BACKFILL_SHUTDOWN_TIMEOUT_MS,
+  state: SessionBackfillState = sessionBackfillState,
+): Promise<boolean> {
+  const promise = state.promise;
+  if (!state.inProgress || !promise) {
+    return true;
+  }
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then(() => true),
+      new Promise<boolean>((resolve) => {
+        timeout = setTimeout(() => resolve(false), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}

--- a/src/handlers/session-live-index.ts
+++ b/src/handlers/session-live-index.ts
@@ -1,0 +1,89 @@
+import type { DatabaseManager } from '../store/db.js';
+import { indexLiveSession } from '../store/session-indexer.js';
+
+export const SESSION_LIVE_INDEX_DELAY_MS = 50;
+export const SESSION_LIVE_INDEX_SHUTDOWN_TIMEOUT_MS = 5000;
+
+type SetTimeoutFn = (callback: () => void, ms: number) => unknown;
+
+type SessionManagerSnapshot = Parameters<typeof indexLiveSession>[1];
+
+export interface SessionLiveIndexState {
+  inProgress: boolean;
+  promise: Promise<void> | null;
+}
+
+export const sessionLiveIndexState: SessionLiveIndexState = {
+  inProgress: false,
+  promise: null,
+};
+
+export interface ScheduleLiveSessionIndexOptions {
+  state?: SessionLiveIndexState;
+  setTimeoutFn?: SetTimeoutFn;
+  indexLiveSessionFn?: typeof indexLiveSession;
+  delayMs?: number;
+  onError?: (error: unknown) => void;
+}
+
+/**
+ * Schedule non-blocking indexing of the current live session.
+ *
+ * Pi emits message_end before it appends the finalized message to the JSONL
+ * session file/session manager. Deferring briefly lets Pi persist the entry
+ * first, then we index any message ids not already present in SQLite. Multiple
+ * message_end events in the same window coalesce into one all-missing sync.
+ */
+export function scheduleLiveSessionIndex(
+  dbManager: DatabaseManager,
+  sessionManager: SessionManagerSnapshot,
+  options: ScheduleLiveSessionIndexOptions = {},
+): boolean {
+  const state = options.state ?? sessionLiveIndexState;
+  if (state.inProgress) {
+    return false;
+  }
+
+  const setTimeoutFn = options.setTimeoutFn ?? setTimeout;
+  const indexLiveSessionFn = options.indexLiveSessionFn ?? indexLiveSession;
+  const delayMs = options.delayMs ?? SESSION_LIVE_INDEX_DELAY_MS;
+
+  state.inProgress = true;
+  state.promise = new Promise<void>((resolve) => {
+    setTimeoutFn(() => {
+      try {
+        indexLiveSessionFn(dbManager, sessionManager);
+      } catch (err) {
+        try { options.onError?.(err); } catch { /* best effort */ }
+      } finally {
+        state.inProgress = false;
+        state.promise = null;
+        resolve();
+      }
+    }, delayMs);
+  });
+
+  return true;
+}
+
+export async function waitForLiveSessionIndex(
+  timeoutMs = SESSION_LIVE_INDEX_SHUTDOWN_TIMEOUT_MS,
+  state: SessionLiveIndexState = sessionLiveIndexState,
+): Promise<boolean> {
+  const promise = state.promise;
+  if (!state.inProgress || !promise) {
+    return true;
+  }
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then(() => true),
+      new Promise<boolean>((resolve) => {
+        timeout = setTimeout(() => resolve(false), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,8 @@ import { MemoryStore } from "./store/memory-store.js";
 import { SkillStore } from "./store/skill-store.js";
 import { DatabaseManager } from "./store/db.js";
 import { indexSession } from "./store/session-indexer.js";
+import { scheduleSessionBackfill, waitForSessionBackfill, SESSION_BACKFILL_SHUTDOWN_TIMEOUT_MS } from "./handlers/session-backfill.js";
+import { scheduleLiveSessionIndex, waitForLiveSessionIndex, SESSION_LIVE_INDEX_SHUTDOWN_TIMEOUT_MS } from "./handlers/session-live-index.js";
 import { parseSessionFile } from "./store/session-parser.js";
 import { registerMemoryTool } from "./tools/memory-tool.js";
 import { registerSkillTool } from "./tools/skill-tool.js";
@@ -107,6 +109,7 @@ export default function (pi: ExtensionAPI) {
     migrationSentinelPath: path.join(globalDir, ".skills-migrated-to-extension-storage"),
   });
   const dbManager = new DatabaseManager(globalDir);
+  const sessionsDir = path.join(agentRoot, "sessions");
 
   const refreshSkillProjectContext = (cwd?: string) => {
     const resource = resolveProjectSkillDiscovery(skillStore, config.projectsMemoryDir, cwd);
@@ -150,6 +153,19 @@ export default function (pi: ExtensionAPI) {
     await skillStore.ensureDiscoveredRoots();
     await store.loadFromDisk();
     if (projectStore) await projectStore.loadFromDisk();
+
+    scheduleSessionBackfill(dbManager, sessionsDir, {
+      notify: (message, level) => {
+        const ui = (ctx as { ui?: { notify?: (message: string, level?: string) => void } }).ui;
+        if (ui?.notify) {
+          ui.notify(message, level);
+        } else if (level === "error" || level === "warning") {
+          console.warn(message);
+        } else {
+          console.info(message);
+        }
+      },
+    });
   });
 
   registerProjectSkillDiscoveryHandler(pi, skillStore, config.projectsMemoryDir);
@@ -201,12 +217,19 @@ export default function (pi: ExtensionAPI) {
   registerSyncMarkdownMemoriesCommand(pi, dbManager, globalDir, config.projectsMemoryDir, agentRoot);
   registerPreviewContextCommand(pi, store, projectStore, projectName, config);
 
-  // ── 10. SQLite session search + extended memory ──
+  // ── 10. Live session indexing ──
+  pi.on("message_end", async (_event, ctx) => {
+    scheduleLiveSessionIndex(dbManager, ctx.sessionManager, {
+      onError: (err) => console.warn(`⚠️ Live session indexing failed: ${err instanceof Error ? err.message : String(err)}`),
+    });
+  });
+
+  // ── 11. SQLite session search + extended memory ──
   registerSessionSearchTool(pi, dbManager, config.sessionSearch ?? { variant: "legacy" });
   registerMemorySearchTool(pi, dbManager);
   registerIndexSessionsCommand(pi);
 
-  // ── 11. Auto-index session on shutdown ──
+  // ── 12. Auto-index session on shutdown ──
   // Registered last, so this runs after the session-flush shutdown handler and
   // is the final DB activity. Closing here truncates the WAL via
   // PRAGMA wal_checkpoint(TRUNCATE); without it the WAL only grows to its
@@ -229,6 +252,14 @@ export default function (pi: ExtensionAPI) {
     } catch {
       // Silent fail — don't block shutdown
     } finally {
+      try {
+        await Promise.all([
+          waitForSessionBackfill(SESSION_BACKFILL_SHUTDOWN_TIMEOUT_MS),
+          waitForLiveSessionIndex(SESSION_LIVE_INDEX_SHUTDOWN_TIMEOUT_MS),
+        ]);
+      } catch {
+        // Best effort only — shutdown should not be held up by indexing errors.
+      }
       try { dbManager.close(); } catch { /* best effort — never block shutdown */ }
     }
   });

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -10,6 +10,12 @@
  */
 
 export const SCHEMA_SQL = `
+  -- Extension key/value metadata
+  CREATE TABLE IF NOT EXISTS extension_metadata (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+  );
+
   -- Session metadata
   CREATE TABLE IF NOT EXISTS sessions (
     id TEXT PRIMARY KEY,

--- a/src/store/session-indexer.ts
+++ b/src/store/session-indexer.ts
@@ -1,5 +1,9 @@
+import fs from 'node:fs';
 import { DatabaseManager } from './db.js';
 import { parseSessionFile, getSessionFiles, type ParsedSession } from './session-parser.js';
+
+export const LAST_SESSION_BACKFILL_KEY = 'last_session_backfill';
+export const SESSION_BACKFILL_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 /**
  * Index result for a single session.
@@ -7,7 +11,7 @@ import { parseSessionFile, getSessionFiles, type ParsedSession } from './session
 export interface IndexResult {
   sessionId: string;
   messagesIndexed: number;
-  skipped: boolean; // true if already indexed
+  skipped: boolean; // true if the session already existed and no new messages were indexed
 }
 
 /**
@@ -29,33 +33,39 @@ export interface BulkIndexResult {
 export function indexSession(dbManager: DatabaseManager, session: ParsedSession): IndexResult {
   const db = dbManager.getDb();
 
-  // Check if already indexed
-  const existing = db.prepare('SELECT id FROM sessions WHERE id = ?').get(session.id) as { id: string } | undefined;
-  if (existing) {
-    return { sessionId: session.id, messagesIndexed: 0, skipped: true };
-  }
+  const existingSession = db.prepare('SELECT id FROM sessions WHERE id = ?').get(session.id) as { id: string } | undefined;
+  const before = db.prepare('SELECT COUNT(*) as count FROM messages WHERE session_id = ?').get(session.id) as { count: number };
 
-  // Insert session
-  db.prepare(`
-    INSERT INTO sessions (id, project, cwd, started_at, ended_at, message_count)
-    VALUES (?, ?, ?, ?, ?, ?)
-  `).run(
-    session.id,
-    session.project,
-    session.cwd,
-    session.startedAt,
-    session.endedAt,
-    session.messages.length
-  );
-
-  // Insert messages in a transaction for performance
-  const insertMsg = db.prepare(`
-    INSERT INTO messages (id, session_id, role, content, timestamp, tool_calls)
+  const insertSession = db.prepare(`
+    INSERT OR IGNORE INTO sessions (id, project, cwd, started_at, ended_at, message_count)
     VALUES (?, ?, ?, ?, ?, ?)
   `);
 
-  const writeMessages = (messages: ParsedSession['messages']) => {
-    for (const msg of messages) {
+  const insertMsg = db.prepare(`
+    INSERT OR IGNORE INTO messages (id, session_id, role, content, timestamp, tool_calls)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `);
+
+  const updateSession = db.prepare(`
+    UPDATE sessions
+    SET project = ?,
+        cwd = ?,
+        ended_at = COALESCE(?, ended_at),
+        message_count = (SELECT COUNT(*) FROM messages WHERE session_id = ?)
+    WHERE id = ?
+  `);
+
+  const writeSession = () => {
+    insertSession.run(
+      session.id,
+      session.project,
+      session.cwd,
+      session.startedAt,
+      session.endedAt,
+      session.messages.length
+    );
+
+    for (const msg of session.messages) {
       insertMsg.run(
         msg.id,
         session.id,
@@ -65,16 +75,136 @@ export function indexSession(dbManager: DatabaseManager, session: ParsedSession)
         msg.toolCalls ? JSON.stringify(msg.toolCalls) : null
       );
     }
+
+    updateSession.run(session.project, session.cwd, session.endedAt, session.id, session.id);
   };
 
   if (db.transaction) {
-    const insertMany = db.transaction(writeMessages);
-    insertMany(session.messages);
+    const tx = db.transaction(writeSession);
+    tx();
   } else {
-    writeMessages(session.messages);
+    writeSession();
   }
 
-  return { sessionId: session.id, messagesIndexed: session.messages.length, skipped: false };
+  const after = db.prepare('SELECT COUNT(*) as count FROM messages WHERE session_id = ?').get(session.id) as { count: number };
+  const messagesIndexed = after.count - before.count;
+
+  return { sessionId: session.id, messagesIndexed, skipped: Boolean(existingSession) && messagesIndexed === 0 };
+}
+
+type SessionManagerSnapshot = {
+  getHeader: () => { id: string; timestamp: string; cwd: string } | null;
+  getEntries: () => unknown[];
+  getSessionFile?: () => string | undefined;
+};
+
+type SessionMessageEntryLike = {
+  type?: unknown;
+  id?: unknown;
+  timestamp?: unknown;
+  message?: {
+    role?: unknown;
+    content?: unknown;
+  };
+};
+
+function extractTextContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue;
+    const b = block as Record<string, unknown>;
+
+    switch (b.type) {
+      case 'text':
+        if (typeof b.text === 'string') parts.push(b.text);
+        break;
+      case 'tool_result':
+        if (typeof b.content === 'string') {
+          parts.push(b.content);
+        } else if (Array.isArray(b.content)) {
+          for (const item of b.content) {
+            if (item && typeof item === 'object' && (item as Record<string, unknown>).type === 'text') {
+              const text = (item as Record<string, unknown>).text;
+              if (typeof text === 'string') parts.push(text);
+            }
+          }
+        }
+        break;
+    }
+  }
+
+  return parts.join('\n').trim();
+}
+
+function extractToolCalls(content: unknown): string[] | undefined {
+  if (!Array.isArray(content)) return undefined;
+
+  const toolNames: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue;
+    const b = block as Record<string, unknown>;
+    if ((b.type === 'toolCall' || b.type === 'tool_use') && typeof b.name === 'string') {
+      toolNames.push(b.name);
+    }
+  }
+  return toolNames.length > 0 ? toolNames : undefined;
+}
+
+function parseMessageEntry(entry: unknown): ParsedSession['messages'][number] | null {
+  if (!entry || typeof entry !== 'object') return null;
+  const e = entry as SessionMessageEntryLike;
+  if (e.type !== 'message' || typeof e.id !== 'string' || typeof e.timestamp !== 'string' || !e.message) return null;
+
+  const role = e.message.role;
+  if (role !== 'user' && role !== 'assistant' && role !== 'system') return null;
+
+  const content = extractTextContent(e.message.content);
+  if (!content) return null;
+
+  return {
+    id: e.id,
+    role,
+    content,
+    timestamp: e.timestamp,
+    toolCalls: role === 'assistant' ? extractToolCalls(e.message.content) : undefined,
+  };
+}
+
+export function parseSessionManagerSnapshot(sessionManager: SessionManagerSnapshot): ParsedSession | null {
+  const header = sessionManager.getHeader();
+  if (!header?.id || !header.cwd || !header.timestamp) return null;
+
+  const messages = sessionManager.getEntries()
+    .map(parseMessageEntry)
+    .filter((msg): msg is ParsedSession['messages'][number] => msg !== null);
+
+  return {
+    id: header.id,
+    project: header.cwd.split('/').pop() ?? header.cwd,
+    cwd: header.cwd,
+    startedAt: header.timestamp,
+    endedAt: null,
+    messages,
+  };
+}
+
+export function indexCurrentSession(dbManager: DatabaseManager, sessionManager: SessionManagerSnapshot): IndexResult | null {
+  const session = parseSessionManagerSnapshot(sessionManager);
+  if (!session) return null;
+  return indexSession(dbManager, session);
+}
+
+export function indexLiveSession(dbManager: DatabaseManager, sessionManager: SessionManagerSnapshot): IndexResult | null {
+  const sessionFile = sessionManager.getSessionFile?.();
+  if (sessionFile && fs.existsSync(sessionFile)) {
+    const session = parseSessionFile(sessionFile);
+    if (session) return indexSession(dbManager, session);
+  }
+
+  return indexCurrentSession(dbManager, sessionManager);
 }
 
 /**
@@ -122,6 +252,58 @@ export function indexAllSessions(
   }
 
   return result;
+}
+
+/**
+ * Cheaply count session JSONL files in the same scope indexAllSessions scans.
+ */
+export function countSessionFiles(sessionsDir: string): number {
+  return getSessionFiles(sessionsDir).length;
+}
+
+function getLastBackfillTimestamp(dbManager: DatabaseManager): string | null {
+  const db = dbManager.getDb();
+  const row = db.prepare('SELECT value FROM extension_metadata WHERE key = ?').get(LAST_SESSION_BACKFILL_KEY) as { value: string } | undefined;
+  return row?.value ?? null;
+}
+
+function isRecentBackfillTimestamp(value: string | null, nowMs: number): boolean {
+  if (!value) return false;
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return false;
+  return nowMs - parsed < SESSION_BACKFILL_INTERVAL_MS;
+}
+
+/**
+ * Determine whether a background session backfill should run.
+ *
+ * A backfill is needed when the number of JSONL session files differs from
+ * the indexed session count, or when no successful backfill has completed in
+ * the last 24 hours. The count check catches crashed/abnormal sessions; the
+ * timestamp check periodically repairs parse errors or manual DB edits.
+ */
+export function needsBackfill(dbManager: DatabaseManager, sessionsDir: string, now = new Date()): boolean {
+  const db = dbManager.getDb();
+  const fileCount = countSessionFiles(sessionsDir);
+  const indexed = db.prepare('SELECT COUNT(*) as count FROM sessions').get() as { count: number };
+
+  if (fileCount !== indexed.count) {
+    return true;
+  }
+
+  return !isRecentBackfillTimestamp(getLastBackfillTimestamp(dbManager), now.getTime());
+}
+
+/**
+ * Record a successful session backfill completion timestamp.
+ */
+export function touchBackfillTimestamp(dbManager: DatabaseManager, timestamp = new Date()): void {
+  const db = dbManager.getDb();
+  db.prepare(`
+    INSERT INTO extension_metadata (key, value)
+    VALUES (?, ?)
+    ON CONFLICT(key) DO UPDATE SET value = excluded.value
+  `).run(LAST_SESSION_BACKFILL_KEY, timestamp.toISOString());
 }
 
 /**

--- a/src/store/session-parser.ts
+++ b/src/store/session-parser.ts
@@ -90,7 +90,7 @@ function extractToolCalls(content: unknown): string[] | undefined {
   for (const block of content) {
     if (!block || typeof block !== 'object') continue;
     const b = block as Record<string, unknown>;
-    if (b.type === 'tool_use' && typeof b.name === 'string') {
+    if ((b.type === 'tool_use' || b.type === 'toolCall') && typeof b.name === 'string') {
       toolNames.push(b.name);
     }
   }

--- a/tests/handlers/session-backfill.test.ts
+++ b/tests/handlers/session-backfill.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { DatabaseManager } from '../../src/store/db.js';
+import {
+  scheduleSessionBackfill,
+  waitForSessionBackfill,
+  type SessionBackfillState,
+} from '../../src/handlers/session-backfill.js';
+import { indexAllSessions, touchBackfillTimestamp } from '../../src/store/session-indexer.js';
+
+function writeJsonlSession(sessionsDir: string, projectDir: string, sessionId: string, text = 'Hello from backfill'): void {
+  const projDir = path.join(sessionsDir, projectDir);
+  fs.mkdirSync(projDir, { recursive: true });
+  const lines = [
+    JSON.stringify({ type: 'session', id: sessionId, timestamp: '2026-05-03T00:00:00Z', cwd: `/work/${projectDir}` }),
+    JSON.stringify({
+      type: 'message',
+      id: `${sessionId}-m1`,
+      parentId: null,
+      timestamp: '2026-05-03T00:01:00Z',
+      message: { role: 'user', content: [{ type: 'text', text }], timestamp: Date.now() },
+    }),
+  ];
+  fs.writeFileSync(path.join(projDir, `${sessionId}.jsonl`), lines.join('\n'));
+}
+
+describe('session backfill handler', () => {
+  let tmpDir: string;
+  let sessionsDir: string;
+  let dbManager: DatabaseManager;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'session-backfill-test-'));
+    sessionsDir = path.join(tmpDir, 'sessions');
+    dbManager = new DatabaseManager(path.join(tmpDir, 'memory'));
+  });
+
+  afterEach(() => {
+    dbManager.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('schedules backfill without indexing synchronously, then indexes unindexed sessions', async () => {
+    writeJsonlSession(sessionsDir, 'project-a', 's1');
+    const callbacks: (() => void)[] = [];
+    const state: SessionBackfillState = { inProgress: false, promise: null };
+
+    const scheduled = scheduleSessionBackfill(dbManager, sessionsDir, {
+      state,
+      setTimeoutFn: (callback) => {
+        callbacks.push(callback);
+        return 0;
+      },
+    });
+
+    assert.equal(scheduled, true);
+    assert.equal(callbacks.length, 1);
+    assert.equal(dbManager.getStats().sessions, 0, 'session_start should not index synchronously');
+
+    const promise = state.promise;
+    assert.ok(promise);
+    callbacks[0]();
+    await promise;
+
+    assert.equal(dbManager.getStats().sessions, 1);
+    assert.equal(dbManager.getStats().messages, 1);
+  });
+
+  it('does not schedule backfill when counts match and timestamp is recent', () => {
+    writeJsonlSession(sessionsDir, 'project-a', 's1');
+    indexAllSessions(dbManager, sessionsDir);
+    touchBackfillTimestamp(dbManager);
+
+    const callbacks: (() => void)[] = [];
+    const state: SessionBackfillState = { inProgress: false, promise: null };
+    const scheduled = scheduleSessionBackfill(dbManager, sessionsDir, {
+      state,
+      setTimeoutFn: (callback) => {
+        callbacks.push(callback);
+        return 0;
+      },
+    });
+
+    assert.equal(scheduled, false);
+    assert.equal(callbacks.length, 0);
+    assert.equal(state.inProgress, false);
+  });
+
+  it('keeps manual indexAllSessions idempotent with auto-backfill', async () => {
+    writeJsonlSession(sessionsDir, 'project-a', 's1');
+    const state: SessionBackfillState = { inProgress: false, promise: null };
+
+    const scheduled = scheduleSessionBackfill(dbManager, sessionsDir, {
+      state,
+      setTimeoutFn: (callback) => {
+        queueMicrotask(callback);
+        return 0;
+      },
+    });
+    assert.equal(scheduled, true);
+    await state.promise;
+
+    const manualResult = indexAllSessions(dbManager, sessionsDir);
+    assert.equal(manualResult.sessionsProcessed, 1);
+    assert.equal(manualResult.sessionsSkipped, 1);
+    assert.equal(manualResult.sessionsIndexed, 0);
+  });
+
+  it('scheduled task is best-effort and does not reject when indexing throws', async () => {
+    const state: SessionBackfillState = { inProgress: false, promise: null };
+    const notifications: { message: string; level: string }[] = [];
+
+    const scheduled = scheduleSessionBackfill(dbManager, sessionsDir, {
+      state,
+      needsBackfillFn: () => true,
+      indexAllSessionsFn: () => {
+        throw new Error('boom');
+      },
+      notify: (message, level) => notifications.push({ message, level }),
+      setTimeoutFn: (callback) => {
+        queueMicrotask(callback);
+        return 0;
+      },
+    });
+
+    assert.equal(scheduled, true);
+    await state.promise;
+    assert.equal(state.inProgress, false);
+    assert.match(notifications[0].message, /Session backfill failed: boom/);
+    assert.equal(notifications[0].level, 'warning');
+  });
+
+  it('shutdown wait resolves true when an in-progress backfill completes before timeout', async () => {
+    let resolveBackfill!: () => void;
+    const state: SessionBackfillState = {
+      inProgress: true,
+      promise: new Promise<void>((resolve) => {
+        resolveBackfill = resolve;
+      }),
+    };
+
+    setTimeout(resolveBackfill, 5);
+    const completed = await waitForSessionBackfill(100, state);
+
+    assert.equal(completed, true);
+  });
+
+  it('shutdown wait resolves false when an in-progress backfill exceeds timeout', async () => {
+    const state: SessionBackfillState = {
+      inProgress: true,
+      promise: new Promise<void>(() => {}),
+    };
+
+    const completed = await waitForSessionBackfill(5, state);
+
+    assert.equal(completed, false);
+  });
+});

--- a/tests/handlers/session-live-index.test.ts
+++ b/tests/handlers/session-live-index.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { DatabaseManager } from '../../src/store/db.js';
+import {
+  scheduleLiveSessionIndex,
+  waitForLiveSessionIndex,
+  type SessionLiveIndexState,
+} from '../../src/handlers/session-live-index.js';
+
+describe('session live indexing handler', () => {
+  let tmpDir: string;
+  let dbManager: DatabaseManager;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'session-live-index-test-'));
+    dbManager = new DatabaseManager(path.join(tmpDir, 'memory'));
+  });
+
+  afterEach(() => {
+    dbManager.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function createSnapshot(entries: unknown[]) {
+    return {
+      getHeader: () => ({ id: 'live-session', timestamp: '2026-05-03T00:00:00Z', cwd: '/work/live-project' }),
+      getEntries: () => entries,
+    };
+  }
+
+  it('defers indexing so message_end does not block and then indexes live messages', async () => {
+    const entries = [{
+      type: 'message',
+      id: 'entry-1',
+      timestamp: '2026-05-03T00:01:00Z',
+      message: { role: 'user', content: 'hello after message_end' },
+    }];
+    const callbacks: (() => void)[] = [];
+    const state: SessionLiveIndexState = { inProgress: false, promise: null };
+
+    const scheduled = scheduleLiveSessionIndex(dbManager, createSnapshot(entries), {
+      state,
+      delayMs: 0,
+      setTimeoutFn: (callback) => {
+        callbacks.push(callback);
+        return 0;
+      },
+    });
+
+    assert.equal(scheduled, true);
+    assert.equal(callbacks.length, 1);
+    assert.equal(dbManager.getStats().messages, 0, 'message_end handler should not index synchronously');
+
+    const promise = state.promise;
+    assert.ok(promise);
+    callbacks[0]();
+    await promise;
+
+    assert.equal(dbManager.getStats().sessions, 1);
+    assert.equal(dbManager.getStats().messages, 1);
+  });
+
+  it('coalesces multiple scheduled message_end events and indexes all missing entries', async () => {
+    const entries = [{
+      type: 'message',
+      id: 'entry-1',
+      timestamp: '2026-05-03T00:01:00Z',
+      message: { role: 'user', content: 'first' },
+    }];
+    const callbacks: (() => void)[] = [];
+    const state: SessionLiveIndexState = { inProgress: false, promise: null };
+    const snapshot = createSnapshot(entries);
+
+    assert.equal(scheduleLiveSessionIndex(dbManager, snapshot, {
+      state,
+      delayMs: 0,
+      setTimeoutFn: (callback) => {
+        callbacks.push(callback);
+        return 0;
+      },
+    }), true);
+
+    entries.push({
+      type: 'message',
+      id: 'entry-2',
+      timestamp: '2026-05-03T00:02:00Z',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'second' }] },
+    });
+    assert.equal(scheduleLiveSessionIndex(dbManager, snapshot, { state, delayMs: 0 }), false);
+
+    const promise = state.promise;
+    callbacks[0]();
+    await promise;
+
+    assert.equal(dbManager.getStats().sessions, 1);
+    assert.equal(dbManager.getStats().messages, 2);
+  });
+
+  it('indexes appended messages for an already indexed resumed session', async () => {
+    const entries = [{
+      type: 'message',
+      id: 'entry-1',
+      timestamp: '2026-05-03T00:01:00Z',
+      message: { role: 'user', content: 'before resume' },
+    }];
+    const snapshot = createSnapshot(entries);
+    const state: SessionLiveIndexState = { inProgress: false, promise: null };
+
+    scheduleLiveSessionIndex(dbManager, snapshot, {
+      state,
+      delayMs: 0,
+      setTimeoutFn: (callback) => {
+        queueMicrotask(callback);
+        return 0;
+      },
+    });
+    await state.promise;
+    assert.equal(dbManager.getStats().messages, 1);
+
+    entries.push({
+      type: 'message',
+      id: 'entry-2',
+      timestamp: '2026-05-03T00:02:00Z',
+      message: { role: 'user', content: 'after resume' },
+    });
+    scheduleLiveSessionIndex(dbManager, snapshot, {
+      state,
+      delayMs: 0,
+      setTimeoutFn: (callback) => {
+        queueMicrotask(callback);
+        return 0;
+      },
+    });
+    await state.promise;
+
+    assert.equal(dbManager.getStats().sessions, 1);
+    assert.equal(dbManager.getStats().messages, 2);
+  });
+
+  it('scheduled live indexing is best-effort and does not reject on errors', async () => {
+    const state: SessionLiveIndexState = { inProgress: false, promise: null };
+    const errors: unknown[] = [];
+
+    const scheduled = scheduleLiveSessionIndex(dbManager, createSnapshot([]), {
+      state,
+      indexLiveSessionFn: () => {
+        throw new Error('boom');
+      },
+      onError: (err) => errors.push(err),
+      delayMs: 0,
+      setTimeoutFn: (callback) => {
+        queueMicrotask(callback);
+        return 0;
+      },
+    });
+
+    assert.equal(scheduled, true);
+    await state.promise;
+    assert.equal(state.inProgress, false);
+    assert.equal(errors.length, 1);
+    assert.match(errors[0] instanceof Error ? errors[0].message : String(errors[0]), /boom/);
+  });
+
+  it('shutdown wait resolves true when live indexing completes before timeout', async () => {
+    let resolveIndex!: () => void;
+    const state: SessionLiveIndexState = {
+      inProgress: true,
+      promise: new Promise<void>((resolve) => {
+        resolveIndex = resolve;
+      }),
+    };
+
+    setTimeout(resolveIndex, 5);
+    const completed = await waitForLiveSessionIndex(100, state);
+
+    assert.equal(completed, true);
+  });
+
+  it('shutdown wait resolves false when live indexing exceeds timeout', async () => {
+    const state: SessionLiveIndexState = {
+      inProgress: true,
+      promise: new Promise<void>(() => {}),
+    };
+
+    const completed = await waitForLiveSessionIndex(5, state);
+
+    assert.equal(completed, false);
+  });
+});

--- a/tests/store/session-indexer.test.ts
+++ b/tests/store/session-indexer.test.ts
@@ -4,7 +4,18 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { DatabaseManager } from '../../src/store/db.js';
-import { indexSession, indexAllSessions, getSessionStats } from '../../src/store/session-indexer.js';
+import {
+  indexSession,
+  indexAllSessions,
+  getSessionStats,
+  countSessionFiles,
+  needsBackfill,
+  touchBackfillTimestamp,
+  LAST_SESSION_BACKFILL_KEY,
+  indexCurrentSession,
+  indexLiveSession,
+  parseSessionManagerSnapshot,
+} from '../../src/store/session-indexer.js';
 import type { ParsedSession } from '../../src/store/session-parser.js';
 
 describe('session-indexer', () => {
@@ -68,7 +79,7 @@ describe('session-indexer', () => {
       assert.deepStrictEqual(JSON.parse(msg.tool_calls), ['read']);
     });
 
-    it('should skip already-indexed sessions', () => {
+    it('should skip already-indexed sessions with no new messages', () => {
       const session = createTestSession();
 
       const result1 = indexSession(dbManager, session);
@@ -77,6 +88,27 @@ describe('session-indexer', () => {
       const result2 = indexSession(dbManager, session);
       assert.strictEqual(result2.skipped, true);
       assert.strictEqual(result2.messagesIndexed, 0);
+    });
+
+    it('should append missing messages for an already-indexed resumed session', () => {
+      const session = createTestSession();
+      indexSession(dbManager, session);
+
+      const resumed = createTestSession({
+        messages: [
+          ...session.messages,
+          { id: 'session-1-msg-3', role: 'user', content: 'Resumed later', timestamp: '2026-05-03T00:02:00Z' },
+        ],
+      });
+      const result = indexSession(dbManager, resumed);
+
+      assert.strictEqual(result.skipped, false);
+      assert.strictEqual(result.messagesIndexed, 1);
+      assert.strictEqual(dbManager.getStats().sessions, 1);
+      assert.strictEqual(dbManager.getStats().messages, 3);
+
+      const dbSession = dbManager.getDb().prepare('SELECT message_count FROM sessions WHERE id = ?').get('session-1') as { message_count: number };
+      assert.strictEqual(dbSession.message_count, 3);
     });
 
     it('should handle sessions with no messages', () => {
@@ -167,6 +199,176 @@ describe('session-indexer', () => {
     it('should handle non-existent sessions directory', () => {
       const result = indexAllSessions(dbManager, '/nonexistent/path');
       assert.strictEqual(result.sessionsProcessed, 0);
+    });
+  });
+
+  describe('current session indexing helpers', () => {
+    function writeSessionFile(filePath: string): void {
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      const lines = [
+        JSON.stringify({ type: 'session', id: 'file-session-1', timestamp: '2026-05-03T00:00:00Z', cwd: '/work/file-project' }),
+        JSON.stringify({
+          type: 'message',
+          id: 'file-entry-1',
+          parentId: null,
+          timestamp: '2026-05-03T00:01:00Z',
+          message: { role: 'user', content: [{ type: 'text', text: 'from persisted file' }], timestamp: Date.now() },
+        }),
+      ];
+      fs.writeFileSync(filePath, lines.join('\n'));
+    }
+
+    function createSessionManagerSnapshot(entries: unknown[] = []) {
+      return {
+        getHeader: () => ({ id: 'live-session-1', timestamp: '2026-05-03T00:00:00Z', cwd: '/work/live-project' }),
+        getEntries: () => entries,
+      };
+    }
+
+    it('parseSessionManagerSnapshot converts current session entries into ParsedSession', () => {
+      const snapshot = createSessionManagerSnapshot([
+        {
+          type: 'message',
+          id: 'entry-1',
+          timestamp: '2026-05-03T00:01:00Z',
+          message: { role: 'user', content: 'Hello live session' },
+        },
+        {
+          type: 'message',
+          id: 'entry-2',
+          timestamp: '2026-05-03T00:02:00Z',
+          message: { role: 'assistant', content: [{ type: 'text', text: 'Hi' }, { type: 'toolCall', name: 'read' }] },
+        },
+        {
+          type: 'message',
+          id: 'entry-3',
+          timestamp: '2026-05-03T00:03:00Z',
+          message: { role: 'toolResult', content: [{ type: 'text', text: 'tool output is not indexed by current schema' }] },
+        },
+      ]);
+
+      const parsed = parseSessionManagerSnapshot(snapshot);
+
+      assert.ok(parsed);
+      assert.strictEqual(parsed.id, 'live-session-1');
+      assert.strictEqual(parsed.project, 'live-project');
+      assert.strictEqual(parsed.messages.length, 2);
+      assert.deepStrictEqual(parsed.messages[1].toolCalls, ['read']);
+    });
+
+    it('indexLiveSession prefers the persisted JSONL file when available', () => {
+      const filePath = path.join(tmpDir, 'sessions', 'project', 'file-session.jsonl');
+      writeSessionFile(filePath);
+      const snapshot = {
+        getHeader: () => ({ id: 'stale-memory-session', timestamp: '2026-05-03T00:00:00Z', cwd: '/work/stale' }),
+        getEntries: () => [],
+        getSessionFile: () => filePath,
+      };
+
+      const result = indexLiveSession(dbManager, snapshot);
+
+      assert.ok(result);
+      assert.strictEqual(result.sessionId, 'file-session-1');
+      assert.strictEqual(result.messagesIndexed, 1);
+      const indexed = dbManager.getDb().prepare('SELECT id, cwd FROM sessions WHERE id = ?').get('file-session-1') as { id: string; cwd: string };
+      assert.strictEqual(indexed.cwd, '/work/file-project');
+    });
+
+    it('indexCurrentSession indexes missing live messages idempotently', () => {
+      const entries = [
+        {
+          type: 'message',
+          id: 'entry-1',
+          timestamp: '2026-05-03T00:01:00Z',
+          message: { role: 'user', content: 'Hello live session' },
+        },
+      ];
+      const snapshot = createSessionManagerSnapshot(entries);
+
+      const result1 = indexCurrentSession(dbManager, snapshot);
+      assert.ok(result1);
+      assert.strictEqual(result1.messagesIndexed, 1);
+      assert.strictEqual(dbManager.getStats().sessions, 1);
+      assert.strictEqual(dbManager.getStats().messages, 1);
+
+      entries.push({
+        type: 'message',
+        id: 'entry-2',
+        timestamp: '2026-05-03T00:02:00Z',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'Hi again' }] },
+      });
+      const result2 = indexCurrentSession(dbManager, snapshot);
+      assert.ok(result2);
+      assert.strictEqual(result2.messagesIndexed, 1);
+      assert.strictEqual(dbManager.getStats().sessions, 1);
+      assert.strictEqual(dbManager.getStats().messages, 2);
+
+      const result3 = indexCurrentSession(dbManager, snapshot);
+      assert.ok(result3);
+      assert.strictEqual(result3.skipped, true);
+      assert.strictEqual(result3.messagesIndexed, 0);
+    });
+  });
+
+  describe('backfill metadata helpers', () => {
+    function writeJsonlSession(sessionsDir: string, projectDir: string, sessionId: string): void {
+      const projDir = path.join(sessionsDir, projectDir);
+      fs.mkdirSync(projDir, { recursive: true });
+      const lines = [
+        JSON.stringify({ type: 'session', id: sessionId, timestamp: '2026-05-03T00:00:00Z', cwd: `/test/${projectDir}` }),
+        JSON.stringify({
+          type: 'message',
+          id: `${sessionId}-m1`,
+          parentId: null,
+          timestamp: '2026-05-03T00:01:00Z',
+          message: { role: 'user', content: [{ type: 'text', text: 'Hello' }], timestamp: Date.now() },
+        }),
+      ];
+      fs.writeFileSync(path.join(projDir, `${sessionId}.jsonl`), lines.join('\n'));
+    }
+
+    it('countSessionFiles counts JSONL files in session project directories', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      writeJsonlSession(sessionsDir, 'project-a', 's1');
+      writeJsonlSession(sessionsDir, 'project-b', 's2');
+      fs.writeFileSync(path.join(sessionsDir, 'project-b', 'notes.txt'), 'not a session');
+
+      assert.strictEqual(countSessionFiles(sessionsDir), 2);
+    });
+
+    it('needsBackfill is true when session file count exceeds indexed sessions', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      writeJsonlSession(sessionsDir, 'project-a', 's1');
+
+      assert.strictEqual(needsBackfill(dbManager, sessionsDir, new Date('2026-05-03T01:00:00Z')), true);
+    });
+
+    it('needsBackfill is false when counts match and timestamp is recent', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      writeJsonlSession(sessionsDir, 'project-a', 's1');
+      indexAllSessions(dbManager, sessionsDir);
+      touchBackfillTimestamp(dbManager, new Date('2026-05-03T00:30:00Z'));
+
+      assert.strictEqual(needsBackfill(dbManager, sessionsDir, new Date('2026-05-03T01:00:00Z')), false);
+    });
+
+    it('needsBackfill is true when timestamp is missing or older than 24 hours', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      writeJsonlSession(sessionsDir, 'project-a', 's1');
+      indexAllSessions(dbManager, sessionsDir);
+
+      assert.strictEqual(needsBackfill(dbManager, sessionsDir, new Date('2026-05-03T01:00:00Z')), true);
+
+      touchBackfillTimestamp(dbManager, new Date('2026-05-01T00:00:00Z'));
+      assert.strictEqual(needsBackfill(dbManager, sessionsDir, new Date('2026-05-03T01:00:00Z')), true);
+    });
+
+    it('touchBackfillTimestamp upserts the metadata row', () => {
+      touchBackfillTimestamp(dbManager, new Date('2026-05-03T00:00:00Z'));
+      touchBackfillTimestamp(dbManager, new Date('2026-05-03T01:00:00Z'));
+
+      const row = dbManager.getDb().prepare('SELECT value FROM extension_metadata WHERE key = ?').get(LAST_SESSION_BACKFILL_KEY) as { value: string };
+      assert.strictEqual(row.value, '2026-05-03T01:00:00.000Z');
     });
   });
 


### PR DESCRIPTION
## Summary

This PR fixes session-search freshness by adding non-blocking live indexing for the active Pi session and a startup backfill path for sessions that were missed before the live indexer was available.

Previously, the session index was primarily populated by explicit/manual indexing or shutdown indexing. That meant the current conversation could exist in the JSONL session file but not yet be visible in SQLite-backed session search. It also meant resumed sessions could be skipped wholesale once their session id already existed in SQLite, leaving newly appended messages unindexed.

## What changed

### Live indexing on `message_end`

- Adds `src/handlers/session-live-index.ts`.
- Registers a `message_end` handler in `src/index.ts`.
- Schedules indexing asynchronously instead of blocking the message lifecycle.
- Defers briefly before reading the session so Pi has time to persist the finalized message to JSONL/session state.
- Coalesces quick repeated `message_end` events behind an in-progress guard.
- Keeps failures best-effort: indexing errors are reported as warnings and do not interrupt the agent turn.

### Startup session backfill

- Adds `src/handlers/session-backfill.ts`.
- Schedules a non-blocking backfill at session start when indexed session counts differ from JSONL files or when the last successful backfill is stale.
- Stores `last_session_backfill` in the new `extension_metadata` table.
- Reports completion/failure via best-effort notifications.

### Idempotent resumed-session indexing

- Updates `indexSession()` so an existing session id is no longer skipped wholesale.
- Inserts only missing message ids with `INSERT OR IGNORE`.
- Updates `sessions.message_count` from the actual indexed message count.
- Preserves idempotency for repeated indexing runs.

### Live/current session helpers

- Adds helpers to parse the current `SessionManager` snapshot.
- `indexLiveSession()` prefers the persisted JSONL session file when available and falls back to the in-memory session manager snapshot.
- Keeps content extraction aligned with JSONL parsing, including text and tool result blocks while skipping internal thinking/tool-use content from searchable message text.

### Shutdown safety

- Shutdown now briefly waits for pending startup backfill and live indexing work before closing SQLite.
- Timeouts keep shutdown best-effort and bounded.

## Files changed

- `src/index.ts` — wires startup backfill, live `message_end` indexing, and shutdown waits.
- `src/handlers/session-backfill.ts` — new background backfill scheduler and shutdown wait helper.
- `src/handlers/session-live-index.ts` — new live session indexing scheduler and shutdown wait helper.
- `src/store/session-indexer.ts` — idempotent append indexing, current-session parsing, live indexing helpers, backfill metadata helpers.
- `src/store/schema.ts` — adds `extension_metadata` key/value table.
- `src/store/session-parser.ts` — recognizes both `tool_use` and `toolCall` tool-call block names.
- `tests/handlers/session-backfill.test.ts` — coverage for scheduling, idempotency, error handling, and shutdown wait behavior.
- `tests/handlers/session-live-index.test.ts` — coverage for deferred live indexing, coalescing, resumed-session appends, and shutdown waits.
- `tests/store/session-indexer.test.ts` — coverage for append-only indexing of existing sessions, current-session parsing, live indexing, and backfill metadata.

## Manual verification

After implementing the fix, I checked the active Pi session against its JSONL file and the SQLite database used by the running extension:

- JSONL session: `~/.pi/agent/sessions/--Users-chandrateja-Documents-pi-hermes-memory--/2026-06-20T10-03-35-024Z_019ee47c-58f0-77dd-8b73-940c0cf8c8bf.jsonl`
- SQLite DB: `~/.pi/agent/pi-hermes-memory/sessions.db`
- Session id: `019ee47c-58f0-77dd-8b73-940c0cf8c8bf`

Result:

- JSONL indexable messages: `17`
- SQLite message rows: `17`
- `sessions.message_count`: `17`
- Missing rows: `0`
- Extra rows: `0`
- Role/timestamp/content/tool-call mismatches: `0`

This confirms the live `message_end` indexing path is updating SQLite during the active session.

## Validation

- [x] `npm run check`
- [x] `npm test` — all 35 test files passed
- [x] `git diff --check`
- [x] Manual JSONL ↔ SQLite current-session comparison

## Notes

There are currently two local SQLite files from the legacy storage transition:

- Legacy: `~/.pi/agent/memory/sessions.db`
- Active extension root: `~/.pi/agent/pi-hermes-memory/sessions.db`

The current/live session is correctly indexed in the active extension-root DB.