### PR TITLE
fix(session-search): bound startup backfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Search behavior notes:
 - Exact phrases can be requested with quotes, for example `"memory search"`.
 - Advanced FTS queries with operators like `OR` still work when you need them.
 
-Session history is indexed automatically during the active session and on session shutdown. Startup also runs a bounded incremental backfill for missed sessions: it compares stored file metadata and only parses new or changed JSONL files, capped per startup. To bulk-import existing sessions manually:
+Session history is indexed automatically during the active session and on session shutdown. Startup also runs a bounded incremental backfill for missed sessions: it compares stored file metadata and only parses files without matching metadata, capped per startup. To bulk-import existing sessions manually:
 
 ```
 /memory-index-sessions

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Search behavior notes:
 - Exact phrases can be requested with quotes, for example `"memory search"`.
 - Advanced FTS queries with operators like `OR` still work when you need them.
 
-Session history is indexed automatically on session shutdown. To bulk-import existing sessions:
+Session history is indexed automatically during the active session and on session shutdown. Startup also runs a bounded incremental backfill for missed sessions: it compares stored file metadata and only parses new or changed JSONL files, capped per startup. To bulk-import existing sessions manually:
 
 ```
 /memory-index-sessions

--- a/src/handlers/session-backfill.ts
+++ b/src/handlers/session-backfill.ts
@@ -1,12 +1,13 @@
 import type { DatabaseManager } from '../store/db.js';
 import {
-  indexAllSessions,
+  indexChangedSessions,
   needsBackfill,
   touchBackfillTimestamp,
   type BulkIndexResult,
 } from '../store/session-indexer.js';
 
 export const SESSION_BACKFILL_SHUTDOWN_TIMEOUT_MS = 5000;
+export const SESSION_BACKFILL_MAX_FILES = 50;
 
 type NotifyLevel = 'info' | 'warning' | 'error';
 type NotifyFn = (message: string, level: NotifyLevel) => void;
@@ -28,13 +29,15 @@ export interface ScheduleSessionBackfillOptions {
   state?: SessionBackfillState;
   setTimeoutFn?: SetTimeoutFn;
   needsBackfillFn?: typeof needsBackfill;
-  indexAllSessionsFn?: typeof indexAllSessions;
+  indexSessionsFn?: typeof indexChangedSessions;
+  maxFilesToIndex?: number;
   touchBackfillTimestampFn?: typeof touchBackfillTimestamp;
 }
 
 function formatBackfillResult(result: BulkIndexResult): string {
   const errorSuffix = result.errors.length > 0 ? ` (${result.errors.length} file error${result.errors.length === 1 ? '' : 's'})` : '';
-  return `🧠 Session backfill complete: ${result.sessionsIndexed} indexed, ${result.sessionsSkipped} skipped, ${result.messagesIndexed} messages${errorSuffix}.`;
+  const limitSuffix = result.reachedLimit ? ' (startup limit reached)' : '';
+  return `🧠 Session backfill complete: ${result.sessionsIndexed} indexed, ${result.sessionsSkipped} skipped, ${result.messagesIndexed} messages${errorSuffix}${limitSuffix}.`;
 }
 
 function notifyBestEffort(notify: NotifyFn | undefined, message: string, level: NotifyLevel): void {
@@ -46,11 +49,11 @@ function notifyBestEffort(notify: NotifyFn | undefined, message: string, level: 
 }
 
 /**
- * Schedule a best-effort, non-blocking backfill of unindexed Pi sessions.
+ * Schedule a best-effort, bounded incremental backfill of unindexed Pi sessions.
  *
- * The expensive indexAllSessions() pass is always deferred with setTimeout(0)
- * so session_start can resolve before disk parsing/indexing begins. A shared
- * state guard prevents concurrent backfills within this extension instance.
+ * The JSONL parsing work is deferred with setTimeout(0) so session_start can
+ * resolve first. The scheduled pass only parses new/changed files and caps the
+ * number of files parsed per startup.
  *
  * @returns true when a backfill task was scheduled; false when it was skipped.
  */
@@ -62,7 +65,8 @@ export function scheduleSessionBackfill(
   const state = options.state ?? sessionBackfillState;
   const setTimeoutFn = options.setTimeoutFn ?? setTimeout;
   const needsBackfillFn = options.needsBackfillFn ?? needsBackfill;
-  const indexAllSessionsFn = options.indexAllSessionsFn ?? indexAllSessions;
+  const indexSessionsFn = options.indexSessionsFn ?? indexChangedSessions;
+  const maxFilesToIndex = options.maxFilesToIndex ?? SESSION_BACKFILL_MAX_FILES;
   const touchBackfillTimestampFn = options.touchBackfillTimestampFn ?? touchBackfillTimestamp;
 
   if (state.inProgress) {
@@ -86,9 +90,9 @@ export function scheduleSessionBackfill(
   state.promise = new Promise<void>((resolve) => {
     setTimeoutFn(() => {
       try {
-        const result = indexAllSessionsFn(dbManager, sessionsDir);
-        touchBackfillTimestampFn(dbManager);
-        notifyBestEffort(options.notify, formatBackfillResult(result), result.errors.length > 0 ? 'warning' : 'info');
+        const result = indexSessionsFn(dbManager, sessionsDir, { maxFilesToIndex });
+        if (!result.reachedLimit) touchBackfillTimestampFn(dbManager);
+        notifyBestEffort(options.notify, formatBackfillResult(result), result.errors.length > 0 || result.reachedLimit ? 'warning' : 'info');
       } catch (err) {
         notifyBestEffort(
           options.notify,

--- a/src/handlers/session-backfill.ts
+++ b/src/handlers/session-backfill.ts
@@ -52,8 +52,8 @@ function notifyBestEffort(notify: NotifyFn | undefined, message: string, level: 
  * Schedule a best-effort, bounded incremental backfill of unindexed Pi sessions.
  *
  * The JSONL parsing work is deferred with setTimeout(0) so session_start can
- * resolve first. The scheduled pass only parses new/changed files and caps the
- * number of files parsed per startup.
+ * resolve first. The scheduled pass only parses files without matching stored
+ * metadata and caps the number of files parsed per startup.
  *
  * @returns true when a backfill task was scheduled; false when it was skipped.
  */

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -3,6 +3,7 @@
  *
  * Tables:
  * - sessions — Pi session metadata
+ * - session_files — indexed JSONL metadata for incremental backfill
  * - messages — all conversation messages
  * - message_fts — FTS5 index for full-text search across messages
  * - memories — extended memory entries (unlimited, searchable)

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -26,6 +26,15 @@ export const SCHEMA_SQL = `
     message_count INTEGER DEFAULT 0
   );
 
+  -- Indexed session file metadata for cheap incremental backfill
+  CREATE TABLE IF NOT EXISTS session_files (
+    path TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    size INTEGER NOT NULL,
+    mtime_ms INTEGER NOT NULL,
+    indexed_at TEXT NOT NULL
+  );
+
   -- All messages from all sessions
   CREATE TABLE IF NOT EXISTS messages (
     id TEXT PRIMARY KEY,
@@ -102,4 +111,5 @@ export const SCHEMA_SQL = `
   CREATE INDEX IF NOT EXISTS idx_memories_category ON memories(category);
   CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project);
   CREATE INDEX IF NOT EXISTS idx_sessions_started_at ON sessions(started_at);
+  CREATE INDEX IF NOT EXISTS idx_session_files_session_id ON session_files(session_id);
 `;

--- a/src/store/session-indexer.ts
+++ b/src/store/session-indexer.ts
@@ -223,15 +223,6 @@ export function indexLiveSession(dbManager: DatabaseManager, sessionManager: Ses
   return indexCurrentSession(dbManager, sessionManager);
 }
 
-export function sessionIdFromFilePath(filePath: string): string | null {
-  const fileName = filePath.split(/[\\/]/).pop();
-  if (!fileName?.endsWith('.jsonl')) return null;
-  const base = fileName.slice(0, -'.jsonl'.length);
-  if (!base) return null;
-  const underscore = base.lastIndexOf('_');
-  return underscore >= 0 ? base.slice(underscore + 1) : base;
-}
-
 function getSessionFileMetadata(filePath: string): SessionFileMetadata {
   const stat = fs.statSync(filePath);
   return { path: filePath, size: stat.size, mtimeMs: Math.trunc(stat.mtimeMs) };
@@ -263,20 +254,6 @@ function upsertSessionFileMetadata(
       mtime_ms = excluded.mtime_ms,
       indexed_at = excluded.indexed_at
   `).run(metadata.path, sessionId, metadata.size, metadata.mtimeMs, indexedAt.toISOString());
-}
-
-function seedMetadataForExistingSession(dbManager: DatabaseManager, filePath: string, metadata: SessionFileMetadata): boolean {
-  if (getStoredSessionFileMetadata(dbManager, filePath)) return false;
-
-  const sessionId = sessionIdFromFilePath(filePath);
-  if (!sessionId) return false;
-
-  const db = dbManager.getDb();
-  const existing = db.prepare('SELECT id FROM sessions WHERE id = ?').get(sessionId) as { id: string } | undefined;
-  if (!existing) return false;
-
-  upsertSessionFileMetadata(dbManager, filePath, existing.id, metadata);
-  return true;
 }
 
 function emptyBulkIndexResult(): BulkIndexResult {
@@ -336,12 +313,11 @@ export function indexAllSessions(
 }
 
 /**
- * Incrementally index only new or changed session JSONL files.
+ * Incrementally index session JSONL files without matching stored metadata.
  *
  * This is intentionally cheaper than indexAllSessions() for startup backfill:
- * unchanged files are skipped by stored size/mtime metadata, and files that
- * were indexed before metadata existed are seeded from the session id encoded
- * in Pi's filename without parsing the whole JSONL file.
+ * files with matching stored size/mtime metadata are skipped, and all other
+ * files are parsed under the startup cap.
  */
 export function indexChangedSessions(
   dbManager: DatabaseManager,
@@ -355,7 +331,7 @@ export function indexChangedSessions(
   for (const file of files) {
     try {
       const metadata = getSessionFileMetadata(file);
-      if (storedSessionFileMatches(dbManager, metadata) || seedMetadataForExistingSession(dbManager, file, metadata)) {
+      if (storedSessionFileMatches(dbManager, metadata)) {
         result.sessionsSkipped++;
         continue;
       }
@@ -397,9 +373,8 @@ function isRecentBackfillTimestamp(value: string | null, nowMs: number): boolean
 /**
  * Determine whether a background session backfill should run.
  *
- * The check stays cheap: it compares file counts, stored file size/mtime
- * metadata, and session ids encoded in Pi JSONL filenames. Full JSONL parsing
- * is left to the scheduled incremental backfill.
+ * The check stays cheap: it compares file counts and stored file size/mtime
+ * metadata. Full JSONL parsing is left to the scheduled incremental backfill.
  */
 export function needsBackfill(dbManager: DatabaseManager, sessionsDir: string, now = new Date()): boolean {
   const db = dbManager.getDb();
@@ -414,13 +389,6 @@ export function needsBackfill(dbManager: DatabaseManager, sessionsDir: string, n
     try {
       const metadata = getSessionFileMetadata(file);
       if (storedSessionFileMatches(dbManager, metadata)) continue;
-
-      const sessionId = sessionIdFromFilePath(file);
-      if (sessionId) {
-        const existing = db.prepare('SELECT id FROM sessions WHERE id = ?').get(sessionId) as { id: string } | undefined;
-        if (existing) continue;
-      }
-
       return true;
     } catch {
       return true;

--- a/src/store/session-indexer.ts
+++ b/src/store/session-indexer.ts
@@ -23,6 +23,18 @@ export interface BulkIndexResult {
   sessionsSkipped: number;
   messagesIndexed: number;
   errors: string[];
+  reachedLimit?: boolean;
+}
+
+interface SessionFileMetadata {
+  path: string;
+  size: number;
+  mtimeMs: number;
+}
+
+export interface IncrementalIndexOptions {
+  projectDir?: string;
+  maxFilesToIndex?: number;
 }
 
 /**
@@ -201,10 +213,99 @@ export function indexLiveSession(dbManager: DatabaseManager, sessionManager: Ses
   const sessionFile = sessionManager.getSessionFile?.();
   if (sessionFile && fs.existsSync(sessionFile)) {
     const session = parseSessionFile(sessionFile);
-    if (session) return indexSession(dbManager, session);
+    if (session) {
+      const result = indexSession(dbManager, session);
+      upsertSessionFileMetadata(dbManager, sessionFile, session.id);
+      return result;
+    }
   }
 
   return indexCurrentSession(dbManager, sessionManager);
+}
+
+export function sessionIdFromFilePath(filePath: string): string | null {
+  const fileName = filePath.split(/[\\/]/).pop();
+  if (!fileName?.endsWith('.jsonl')) return null;
+  const base = fileName.slice(0, -'.jsonl'.length);
+  if (!base) return null;
+  const underscore = base.lastIndexOf('_');
+  return underscore >= 0 ? base.slice(underscore + 1) : base;
+}
+
+function getSessionFileMetadata(filePath: string): SessionFileMetadata {
+  const stat = fs.statSync(filePath);
+  return { path: filePath, size: stat.size, mtimeMs: Math.trunc(stat.mtimeMs) };
+}
+
+function getStoredSessionFileMetadata(dbManager: DatabaseManager, filePath: string): { size: number; mtime_ms: number } | undefined {
+  return dbManager.getDb().prepare('SELECT size, mtime_ms FROM session_files WHERE path = ?').get(filePath) as { size: number; mtime_ms: number } | undefined;
+}
+
+function storedSessionFileMatches(dbManager: DatabaseManager, metadata: SessionFileMetadata): boolean {
+  const row = getStoredSessionFileMetadata(dbManager, metadata.path);
+  return Boolean(row && row.size === metadata.size && row.mtime_ms === metadata.mtimeMs);
+}
+
+function upsertSessionFileMetadata(
+  dbManager: DatabaseManager,
+  filePath: string,
+  sessionId: string,
+  metadata = getSessionFileMetadata(filePath),
+  indexedAt = new Date(),
+): void {
+  const db = dbManager.getDb();
+  db.prepare(`
+    INSERT INTO session_files (path, session_id, size, mtime_ms, indexed_at)
+    VALUES (?, ?, ?, ?, ?)
+    ON CONFLICT(path) DO UPDATE SET
+      session_id = excluded.session_id,
+      size = excluded.size,
+      mtime_ms = excluded.mtime_ms,
+      indexed_at = excluded.indexed_at
+  `).run(metadata.path, sessionId, metadata.size, metadata.mtimeMs, indexedAt.toISOString());
+}
+
+function seedMetadataForExistingSession(dbManager: DatabaseManager, filePath: string, metadata: SessionFileMetadata): boolean {
+  if (getStoredSessionFileMetadata(dbManager, filePath)) return false;
+
+  const sessionId = sessionIdFromFilePath(filePath);
+  if (!sessionId) return false;
+
+  const db = dbManager.getDb();
+  const existing = db.prepare('SELECT id FROM sessions WHERE id = ?').get(sessionId) as { id: string } | undefined;
+  if (!existing) return false;
+
+  upsertSessionFileMetadata(dbManager, filePath, existing.id, metadata);
+  return true;
+}
+
+function emptyBulkIndexResult(): BulkIndexResult {
+  return {
+    sessionsProcessed: 0,
+    sessionsIndexed: 0,
+    sessionsSkipped: 0,
+    messagesIndexed: 0,
+    errors: [],
+  };
+}
+
+function indexSessionFile(dbManager: DatabaseManager, file: string, result: BulkIndexResult): void {
+  result.sessionsProcessed++;
+
+  const session = parseSessionFile(file);
+  if (!session) {
+    result.errors.push(`Failed to parse: ${file}`);
+    return;
+  }
+
+  const indexResult = indexSession(dbManager, session);
+  upsertSessionFileMetadata(dbManager, file, session.id);
+  if (indexResult.skipped) {
+    result.sessionsSkipped++;
+  } else {
+    result.sessionsIndexed++;
+    result.messagesIndexed += indexResult.messagesIndexed;
+  }
 }
 
 /**
@@ -221,31 +322,50 @@ export function indexAllSessions(
   projectDir?: string
 ): BulkIndexResult {
   const files = getSessionFiles(sessionsDir, projectDir);
-  const result: BulkIndexResult = {
-    sessionsProcessed: 0,
-    sessionsIndexed: 0,
-    sessionsSkipped: 0,
-    messagesIndexed: 0,
-    errors: [],
-  };
+  const result = emptyBulkIndexResult();
 
   for (const file of files) {
-    result.sessionsProcessed++;
-
     try {
-      const session = parseSessionFile(file);
-      if (!session) {
-        result.errors.push(`Failed to parse: ${file}`);
+      indexSessionFile(dbManager, file, result);
+    } catch (err) {
+      result.errors.push(`Error indexing ${file}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Incrementally index only new or changed session JSONL files.
+ *
+ * This is intentionally cheaper than indexAllSessions() for startup backfill:
+ * unchanged files are skipped by stored size/mtime metadata, and files that
+ * were indexed before metadata existed are seeded from the session id encoded
+ * in Pi's filename without parsing the whole JSONL file.
+ */
+export function indexChangedSessions(
+  dbManager: DatabaseManager,
+  sessionsDir: string,
+  options: IncrementalIndexOptions = {},
+): BulkIndexResult {
+  const files = getSessionFiles(sessionsDir, options.projectDir);
+  const maxFilesToIndex = options.maxFilesToIndex ?? 50;
+  const result = emptyBulkIndexResult();
+
+  for (const file of files) {
+    try {
+      const metadata = getSessionFileMetadata(file);
+      if (storedSessionFileMatches(dbManager, metadata) || seedMetadataForExistingSession(dbManager, file, metadata)) {
+        result.sessionsSkipped++;
         continue;
       }
 
-      const indexResult = indexSession(dbManager, session);
-      if (indexResult.skipped) {
-        result.sessionsSkipped++;
-      } else {
-        result.sessionsIndexed++;
-        result.messagesIndexed += indexResult.messagesIndexed;
+      if (result.sessionsProcessed >= maxFilesToIndex) {
+        result.reachedLimit = true;
+        break;
       }
+
+      indexSessionFile(dbManager, file, result);
     } catch (err) {
       result.errors.push(`Error indexing ${file}: ${err instanceof Error ? err.message : String(err)}`);
     }
@@ -277,18 +397,34 @@ function isRecentBackfillTimestamp(value: string | null, nowMs: number): boolean
 /**
  * Determine whether a background session backfill should run.
  *
- * A backfill is needed when the number of JSONL session files differs from
- * the indexed session count, or when no successful backfill has completed in
- * the last 24 hours. The count check catches crashed/abnormal sessions; the
- * timestamp check periodically repairs parse errors or manual DB edits.
+ * The check stays cheap: it compares file counts, stored file size/mtime
+ * metadata, and session ids encoded in Pi JSONL filenames. Full JSONL parsing
+ * is left to the scheduled incremental backfill.
  */
 export function needsBackfill(dbManager: DatabaseManager, sessionsDir: string, now = new Date()): boolean {
   const db = dbManager.getDb();
-  const fileCount = countSessionFiles(sessionsDir);
+  const files = getSessionFiles(sessionsDir);
   const indexed = db.prepare('SELECT COUNT(*) as count FROM sessions').get() as { count: number };
 
-  if (fileCount !== indexed.count) {
+  if (files.length > indexed.count) {
     return true;
+  }
+
+  for (const file of files) {
+    try {
+      const metadata = getSessionFileMetadata(file);
+      if (storedSessionFileMatches(dbManager, metadata)) continue;
+
+      const sessionId = sessionIdFromFilePath(file);
+      if (sessionId) {
+        const existing = db.prepare('SELECT id FROM sessions WHERE id = ?').get(sessionId) as { id: string } | undefined;
+        if (existing) continue;
+      }
+
+      return true;
+    } catch {
+      return true;
+    }
   }
 
   return !isRecentBackfillTimestamp(getLastBackfillTimestamp(dbManager), now.getTime());

--- a/tests/handlers/session-backfill.test.ts
+++ b/tests/handlers/session-backfill.test.ts
@@ -109,6 +109,37 @@ describe('session backfill handler', () => {
     assert.equal(manualResult.sessionsIndexed, 0);
   });
 
+  it('does not mark backfill complete when startup parse limit is reached', async () => {
+    const state: SessionBackfillState = { inProgress: false, promise: null };
+    let touched = false;
+    const notifications: { message: string; level: string }[] = [];
+
+    const scheduled = scheduleSessionBackfill(dbManager, sessionsDir, {
+      state,
+      needsBackfillFn: () => true,
+      indexSessionsFn: () => ({
+        sessionsProcessed: 1,
+        sessionsIndexed: 1,
+        sessionsSkipped: 0,
+        messagesIndexed: 1,
+        errors: [],
+        reachedLimit: true,
+      }),
+      touchBackfillTimestampFn: () => { touched = true; },
+      notify: (message, level) => notifications.push({ message, level }),
+      setTimeoutFn: (callback) => {
+        queueMicrotask(callback);
+        return 0;
+      },
+    });
+
+    assert.equal(scheduled, true);
+    await state.promise;
+    assert.equal(touched, false);
+    assert.equal(notifications[0].level, 'warning');
+    assert.match(notifications[0].message, /startup limit reached/);
+  });
+
   it('scheduled task is best-effort and does not reject when indexing throws', async () => {
     const state: SessionBackfillState = { inProgress: false, promise: null };
     const notifications: { message: string; level: string }[] = [];
@@ -116,7 +147,7 @@ describe('session backfill handler', () => {
     const scheduled = scheduleSessionBackfill(dbManager, sessionsDir, {
       state,
       needsBackfillFn: () => true,
-      indexAllSessionsFn: () => {
+      indexSessionsFn: () => {
         throw new Error('boom');
       },
       notify: (message, level) => notifications.push({ message, level }),

--- a/tests/store/session-indexer.test.ts
+++ b/tests/store/session-indexer.test.ts
@@ -16,7 +16,6 @@ import {
   indexCurrentSession,
   indexLiveSession,
   parseSessionManagerSnapshot,
-  sessionIdFromFilePath,
 } from '../../src/store/session-indexer.js';
 import type { ParsedSession } from '../../src/store/session-parser.js';
 
@@ -220,12 +219,6 @@ describe('session-indexer', () => {
       fs.writeFileSync(filePath, lines.join('\n'));
     }
 
-    it('extracts Pi session ids from root and project JSONL filenames', () => {
-      assert.strictEqual(sessionIdFromFilePath('/sessions/project/2026-06-20T10-03-35-024Z_019ee47c-58f0-77dd-8b73-940c0cf8c8bf.jsonl'), '019ee47c-58f0-77dd-8b73-940c0cf8c8bf');
-      assert.strictEqual(sessionIdFromFilePath('/sessions/project/s1.jsonl'), 's1');
-      assert.strictEqual(sessionIdFromFilePath('/sessions/project/readme.txt'), null);
-    });
-
     it('skips unchanged files using stored size and mtime metadata without parsing them', () => {
       const sessionsDir = path.join(tmpDir, 'sessions');
       const filePath = path.join(sessionsDir, 'project-a', 's1.jsonl');
@@ -254,18 +247,23 @@ describe('session-indexer', () => {
       assert.strictEqual(dbManager.getStats().messages, 2);
     });
 
-    it('seeds metadata for previously indexed sessions without parsing the JSONL body', () => {
+    it('parses existing sessions without file metadata and appends missed messages', () => {
       const sessionsDir = path.join(tmpDir, 'sessions');
-      const filePath = path.join(sessionsDir, 'project-a', 'prefix_s1.jsonl');
-      indexSession(dbManager, createTestSession({ id: 's1' }));
-      fs.mkdirSync(path.dirname(filePath), { recursive: true });
-      fs.writeFileSync(filePath, 'not jsonl');
+      const filePath = path.join(sessionsDir, 'project-a', 's1.jsonl');
+      indexSession(dbManager, createTestSession({
+        id: 's1',
+        messages: [
+          { id: 's1-m1', role: 'user', content: 'Hello s1-m1', timestamp: '2026-05-03T00:01:00Z' },
+        ],
+      }));
+      writeJsonlSession(filePath, 's1', ['s1-m1', 's1-m2']);
 
       const result = indexChangedSessions(dbManager, sessionsDir);
 
-      assert.strictEqual(result.sessionsProcessed, 0);
-      assert.strictEqual(result.sessionsSkipped, 1);
-      assert.strictEqual(result.errors.length, 0);
+      assert.strictEqual(result.sessionsProcessed, 1);
+      assert.strictEqual(result.sessionsIndexed, 1);
+      assert.strictEqual(result.messagesIndexed, 1);
+      assert.strictEqual(dbManager.getStats().messages, 2);
     });
 
     it('caps parsed files during startup incremental backfill', () => {
@@ -429,6 +427,32 @@ describe('session-indexer', () => {
       touchBackfillTimestamp(dbManager, new Date('2026-05-03T00:30:00Z'));
 
       assert.strictEqual(needsBackfill(dbManager, sessionsDir, new Date('2026-05-03T01:00:00Z')), false);
+    });
+
+    it('needsBackfill is true when file metadata changes even with a recent timestamp', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      writeJsonlSession(sessionsDir, 'project-a', 's1');
+      indexAllSessions(dbManager, sessionsDir);
+      touchBackfillTimestamp(dbManager, new Date('2026-05-03T00:30:00Z'));
+
+      fs.appendFileSync(path.join(sessionsDir, 'project-a', 's1.jsonl'), '\n' + JSON.stringify({
+        type: 'message',
+        id: 's1-m2',
+        parentId: null,
+        timestamp: '2026-05-03T00:02:00Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'Hello again' }], timestamp: Date.now() },
+      }));
+
+      assert.strictEqual(needsBackfill(dbManager, sessionsDir, new Date('2026-05-03T01:00:00Z')), true);
+    });
+
+    it('needsBackfill is true for existing sessions without file metadata even with a recent timestamp', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      writeJsonlSession(sessionsDir, 'project-a', 's1');
+      indexSession(dbManager, createTestSession({ id: 's1', messages: [] }));
+      touchBackfillTimestamp(dbManager, new Date('2026-05-03T00:30:00Z'));
+
+      assert.strictEqual(needsBackfill(dbManager, sessionsDir, new Date('2026-05-03T01:00:00Z')), true);
     });
 
     it('needsBackfill is true when timestamp is missing or older than 24 hours', () => {

--- a/tests/store/session-indexer.test.ts
+++ b/tests/store/session-indexer.test.ts
@@ -7,6 +7,7 @@ import { DatabaseManager } from '../../src/store/db.js';
 import {
   indexSession,
   indexAllSessions,
+  indexChangedSessions,
   getSessionStats,
   countSessionFiles,
   needsBackfill,
@@ -15,6 +16,7 @@ import {
   indexCurrentSession,
   indexLiveSession,
   parseSessionManagerSnapshot,
+  sessionIdFromFilePath,
 } from '../../src/store/session-indexer.js';
 import type { ParsedSession } from '../../src/store/session-parser.js';
 
@@ -199,6 +201,83 @@ describe('session-indexer', () => {
     it('should handle non-existent sessions directory', () => {
       const result = indexAllSessions(dbManager, '/nonexistent/path');
       assert.strictEqual(result.sessionsProcessed, 0);
+    });
+  });
+
+  describe('indexChangedSessions', () => {
+    function writeJsonlSession(filePath: string, sessionId: string, messageIds = [`${sessionId}-m1`]): void {
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      const lines = [
+        JSON.stringify({ type: 'session', id: sessionId, timestamp: '2026-05-03T00:00:00Z', cwd: `/test/${sessionId}` }),
+        ...messageIds.map((id, index) => JSON.stringify({
+          type: 'message',
+          id,
+          parentId: null,
+          timestamp: `2026-05-03T00:0${index + 1}:00Z`,
+          message: { role: 'user', content: [{ type: 'text', text: `Hello ${id}` }], timestamp: Date.now() },
+        })),
+      ];
+      fs.writeFileSync(filePath, lines.join('\n'));
+    }
+
+    it('extracts Pi session ids from root and project JSONL filenames', () => {
+      assert.strictEqual(sessionIdFromFilePath('/sessions/project/2026-06-20T10-03-35-024Z_019ee47c-58f0-77dd-8b73-940c0cf8c8bf.jsonl'), '019ee47c-58f0-77dd-8b73-940c0cf8c8bf');
+      assert.strictEqual(sessionIdFromFilePath('/sessions/project/s1.jsonl'), 's1');
+      assert.strictEqual(sessionIdFromFilePath('/sessions/project/readme.txt'), null);
+    });
+
+    it('skips unchanged files using stored size and mtime metadata without parsing them', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      const filePath = path.join(sessionsDir, 'project-a', 's1.jsonl');
+      writeJsonlSession(filePath, 's1');
+      indexAllSessions(dbManager, sessionsDir);
+
+      const result = indexChangedSessions(dbManager, sessionsDir);
+
+      assert.strictEqual(result.sessionsProcessed, 0);
+      assert.strictEqual(result.sessionsSkipped, 1);
+      assert.strictEqual(result.errors.length, 0);
+    });
+
+    it('indexes changed files and appends newly persisted messages', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      const filePath = path.join(sessionsDir, 'project-a', 's1.jsonl');
+      writeJsonlSession(filePath, 's1', ['s1-m1']);
+      indexAllSessions(dbManager, sessionsDir);
+
+      writeJsonlSession(filePath, 's1', ['s1-m1', 's1-m2']);
+      const result = indexChangedSessions(dbManager, sessionsDir);
+
+      assert.strictEqual(result.sessionsProcessed, 1);
+      assert.strictEqual(result.sessionsIndexed, 1);
+      assert.strictEqual(result.messagesIndexed, 1);
+      assert.strictEqual(dbManager.getStats().messages, 2);
+    });
+
+    it('seeds metadata for previously indexed sessions without parsing the JSONL body', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      const filePath = path.join(sessionsDir, 'project-a', 'prefix_s1.jsonl');
+      indexSession(dbManager, createTestSession({ id: 's1' }));
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, 'not jsonl');
+
+      const result = indexChangedSessions(dbManager, sessionsDir);
+
+      assert.strictEqual(result.sessionsProcessed, 0);
+      assert.strictEqual(result.sessionsSkipped, 1);
+      assert.strictEqual(result.errors.length, 0);
+    });
+
+    it('caps parsed files during startup incremental backfill', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      writeJsonlSession(path.join(sessionsDir, 'project-a', 's1.jsonl'), 's1');
+      writeJsonlSession(path.join(sessionsDir, 'project-a', 's2.jsonl'), 's2');
+
+      const result = indexChangedSessions(dbManager, sessionsDir, { maxFilesToIndex: 1 });
+
+      assert.strictEqual(result.sessionsProcessed, 1);
+      assert.strictEqual(result.reachedLimit, true);
+      assert.strictEqual(dbManager.getStats().sessions, 1);
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #83 by changing startup session backfill from a full JSONL archive parse into a bounded incremental pass.

## What changed

- Add a `session_files` metadata table with path, session id, size, mtime, and indexed timestamp.
- Record file metadata during full/manual session indexing and live session indexing.
- Add `indexChangedSessions()` for startup backfill:
  - skips unchanged files by stored size/mtime
  - seeds metadata for already-indexed sessions from Pi JSONL filenames without parsing the body
  - parses only new/changed files
  - caps parsed files per startup at 50
- Keep `/memory-index-sessions` using full `indexAllSessions()` for explicit manual backfill.
- Avoid marking startup backfill complete when the cap is reached, so future startups can continue.
- Document the bounded incremental startup backfill behavior.

## Validation

- [x] `npm run check`
- [x] `npm test`
