### PR TITLE
fix(session-search): newest-first backfill ordering + shutdown metadata upsert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.19] - 2026-06-23
+
+### Fixed
+
+- **Bounded startup session backfill** ([#83](https://github.com/chandra447/pi-hermes-memory/issues/83), [#84](https://github.com/chandra447/pi-hermes-memory/pull/84)): startup no longer synchronously parses the full session history. The `session_start` backfill now does a stat-only discovery pass and only parses files without matching stored size/mtime metadata, capped at 50 files per startup, instead of calling `indexAllSessions` on every Pi launch. Eliminates multi-second startup stalls for users with large session archives.
+- **Newest-first backfill ordering** ([#85](https://github.com/chandra447/pi-hermes-memory/pull/85)): `indexChangedSessions` now sorts changed files by modification time descending before applying the per-startup cap, so recently crashed sessions are indexed on the next startup instead of waiting behind old historical files.
+- **Shutdown metadata sync** ([#85](https://github.com/chandra447/pi-hermes-memory/pull/85)): the `session_shutdown` handler now upserts `session_files` metadata after indexing, so stored size/mtime reflects the final on-disk state. Prevents every startup from re-parsing recently-closed sessions whose metadata had gone stale.
+
 ### Fixed
 
 - **Failure-memory consolidation** ([#68](https://github.com/chandra447/pi-hermes-memory/issues/68)): `failures.md` now participates in both automatic and manual consolidation flows, so full failure memory no longer gets stuck in a persistent overflow state while other core memory targets can recover.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hermes-memory",
-      "version": "0.7.18",
+      "version": "0.7.19",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-tui": "^0.74.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "🧠 Persistent memory + 🔍 session search + 🛡️ secret scanning for Pi. Token-aware policy-only memory by default, SQLite FTS5 search, auto-consolidation, procedural skills. 368 tests. Ported from Hermes agent.",
   "type": "module",
   "main": "src/index.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { MemoryStore } from "./store/memory-store.js";
 import { SkillStore } from "./store/skill-store.js";
 import { DatabaseManager } from "./store/db.js";
-import { indexSession } from "./store/session-indexer.js";
+import { indexSession, upsertSessionFileMetadata } from "./store/session-indexer.js";
 import { scheduleSessionBackfill, waitForSessionBackfill, SESSION_BACKFILL_SHUTDOWN_TIMEOUT_MS } from "./handlers/session-backfill.js";
 import { scheduleLiveSessionIndex, waitForLiveSessionIndex, SESSION_LIVE_INDEX_SHUTDOWN_TIMEOUT_MS } from "./handlers/session-live-index.js";
 import { parseSessionFile } from "./store/session-parser.js";
@@ -247,6 +247,11 @@ export default function (pi: ExtensionAPI) {
         const sessionData = parseSessionFile(sessionFile);
         if (sessionData) {
           indexSession(dbManager, sessionData);
+          // Keep session_files metadata in sync with the final on-disk state.
+          // Pi appends the closing session entry on shutdown after the last
+          // message_end, so without this upsert the stored size/mtime would be
+          // stale and the next startup would re-parse this file unnecessarily.
+          upsertSessionFileMetadata(dbManager, sessionFile, sessionData.id);
         }
       }
     } catch {

--- a/src/store/session-indexer.ts
+++ b/src/store/session-indexer.ts
@@ -237,7 +237,7 @@ function storedSessionFileMatches(dbManager: DatabaseManager, metadata: SessionF
   return Boolean(row && row.size === metadata.size && row.mtime_ms === metadata.mtimeMs);
 }
 
-function upsertSessionFileMetadata(
+export function upsertSessionFileMetadata(
   dbManager: DatabaseManager,
   filePath: string,
   sessionId: string,
@@ -328,6 +328,13 @@ export function indexChangedSessions(
   const maxFilesToIndex = options.maxFilesToIndex ?? 50;
   const result = emptyBulkIndexResult();
 
+  // Gather the changed set first, then sort newest-first before applying the
+  // cap. Crash recovery is the primary value of startup backfill (the live
+  // message_end path missed the session's final state), and crashed sessions
+  // are the most recently modified files. Sorting newest-first ensures they
+  // are indexed on the very next startup instead of waiting behind old
+  // historical files that fill the per-startup cap in filesystem order.
+  const changed: SessionFileMetadata[] = [];
   for (const file of files) {
     try {
       const metadata = getSessionFileMetadata(file);
@@ -335,15 +342,23 @@ export function indexChangedSessions(
         result.sessionsSkipped++;
         continue;
       }
-
-      if (result.sessionsProcessed >= maxFilesToIndex) {
-        result.reachedLimit = true;
-        break;
-      }
-
-      indexSessionFile(dbManager, file, result);
+      changed.push(metadata);
     } catch (err) {
       result.errors.push(`Error indexing ${file}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  changed.sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  for (const metadata of changed) {
+    if (result.sessionsProcessed >= maxFilesToIndex) {
+      result.reachedLimit = true;
+      break;
+    }
+    try {
+      indexSessionFile(dbManager, metadata.path, result);
+    } catch (err) {
+      result.errors.push(`Error indexing ${metadata.path}: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 

--- a/tests/store/session-indexer.test.ts
+++ b/tests/store/session-indexer.test.ts
@@ -16,8 +16,9 @@ import {
   indexCurrentSession,
   indexLiveSession,
   parseSessionManagerSnapshot,
+  upsertSessionFileMetadata,
 } from '../../src/store/session-indexer.js';
-import type { ParsedSession } from '../../src/store/session-parser.js';
+import { parseSessionFile, type ParsedSession } from '../../src/store/session-parser.js';
 
 describe('session-indexer', () => {
   let tmpDir: string;
@@ -277,6 +278,28 @@ describe('session-indexer', () => {
       assert.strictEqual(result.reachedLimit, true);
       assert.strictEqual(dbManager.getStats().sessions, 1);
     });
+
+    it('processes the most recently modified changed files first when the cap is reached', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      // Write an older file first, then a newer one. With newest-first ordering
+      // the newer file must be indexed even when the cap only allows one file.
+      const olderPath = path.join(sessionsDir, 'project-a', 'older.jsonl');
+      const newerPath = path.join(sessionsDir, 'project-a', 'newer.jsonl');
+      writeJsonlSession(olderPath, 'older');
+      // Ensure a measurable mtime gap (some filesystems have coarse mtime resolution).
+      const past = new Date(Date.now() - 60_000);
+      fs.utimesSync(olderPath, past, past);
+      writeJsonlSession(newerPath, 'newer');
+
+      const result = indexChangedSessions(dbManager, sessionsDir, { maxFilesToIndex: 1 });
+
+      assert.strictEqual(result.sessionsProcessed, 1);
+      assert.strictEqual(result.reachedLimit, true);
+      assert.strictEqual(dbManager.getStats().sessions, 1);
+      // The newer file should be the one indexed.
+      const indexed = dbManager.getDb().prepare('SELECT id FROM sessions').all() as { id: string }[];
+      assert.deepStrictEqual(indexed.map((r) => r.id), ['newer']);
+    });
   });
 
   describe('current session indexing helpers', () => {
@@ -472,6 +495,34 @@ describe('session-indexer', () => {
 
       const row = dbManager.getDb().prepare('SELECT value FROM extension_metadata WHERE key = ?').get(LAST_SESSION_BACKFILL_KEY) as { value: string };
       assert.strictEqual(row.value, '2026-05-03T01:00:00.000Z');
+    });
+
+    it('upsertSessionFileMetadata keeps stored metadata in sync after a session file is appended', () => {
+      // Mirrors the session_shutdown path: index the session, then upsert the
+      // file metadata for the final on-disk state. A subsequent
+      // indexChangedSessions pass must skip the file instead of re-parsing it.
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      writeJsonlSession(sessionsDir, 'project-a', 's1');
+      const filePath = path.join(sessionsDir, 'project-a', 's1.jsonl');
+
+      indexAllSessions(dbManager, sessionsDir);
+      // Simulate Pi appending the closing entry on shutdown.
+      fs.appendFileSync(filePath, '\n' + JSON.stringify({
+        type: 'message',
+        id: 's1-m2',
+        parentId: null,
+        timestamp: '2026-05-03T00:02:00Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'Hello again' }], timestamp: Date.now() },
+      }));
+      const session = parseSessionFile(filePath);
+      indexSession(dbManager, session);
+      upsertSessionFileMetadata(dbManager, filePath, session.id);
+
+      const result = indexChangedSessions(dbManager, sessionsDir);
+
+      assert.strictEqual(result.sessionsProcessed, 0);
+      assert.strictEqual(result.sessionsSkipped, 1);
+      assert.strictEqual(result.reachedLimit, undefined);
     });
   });
 


### PR DESCRIPTION
Follow-up to #84, addressing the two gaps identified in [review](https://github.com/chandra447/pi-hermes-memory/pull/84#issuecomment-xxxxx).

## Gap 1 — Newest-first ordering in `indexChangedSessions`

`#84` iterated session files in filesystem order and broke at the per-startup cap. A recently-crashed session at the end of the directory listing could wait **dozens of startups** to be indexed while the cap was consumed by old historical files at the front. Crash recovery is the scenario where startup backfill adds the most value — the live `message_end` path missed the session's final state, and crashed sessions are the most recently modified files.

**Fix:** `indexChangedSessions` now gathers the changed set, sorts by `mtimeMs` descending, then applies the cap. Recent files (crashes) are indexed on the very next startup; old historical catch-up trickles in afterward. No resumable cursor needed — already-skipped files are cheap to re-stat, and genuinely new work is always prioritized.

## Gap 2 — `session_shutdown` handler now upserts file metadata

`src/index.ts`'s `session_shutdown` handler called `indexSession(...)` directly, which does not write `session_files` metadata (only `indexLiveSession` / `indexSessionFile` do). Pi appends the closing session entry on shutdown **after** the last `message_end` fired, so the file's size/mtime changes but `session_files` kept the stale live-index value. Result: every startup saw a metadata mismatch and re-parsed every recently-closed session — the steady-state "0 indexed, N skipped" from #83 was not actually achievable.

**Fix:** export `upsertSessionFileMetadata` and call it from the shutdown handler after `indexSession`. Stored metadata now reflects the final on-disk state.

## Tests

- `processes the most recently modified changed files first when the cap is reached` — writes an older + newer file, caps at 1, asserts the newer file is the one indexed.
- `upsertSessionFileMetadata keeps stored metadata in sync after a session file is appended` — simulates the shutdown append path and asserts a subsequent `indexChangedSessions` skips the file (0 processed, 1 skipped).

All 35 test files pass; `tsc --noEmit` clean.

Closes the gaps from #83.