### PR TITLE
chore: sync package-lock version to 0.7.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.20] - 2026-06-25
+
+### Fixed
+
+- **Self-healing corrupt SQLite database** ([#86](https://github.com/chandra447/pi-hermes-memory/issues/86)): `DatabaseManager.open()` now runs `PRAGMA quick_check` before and after schema initialization and performs a lossless row-level rebuild (read readable rows → fresh DB → `foreign_key_check` + `quick_check` → atomic swap → quarantine original) when corruption is detected, falling back to recreate-empty only if the rebuild fails. A new `withCorruptionRecovery()` wrapper catches `SQLITE_CORRUPT`/"malformed" errors on writes (including the `message_end` live indexer and `session_shutdown` upsert paths) and heals + retries once, so a torn DB self-heals instead of logging `⚠️ Live session indexing failed` on every turn indefinitely. Also restores `wal_autocheckpoint` to SQLite's default (1000, was 100) to narrow the torn-write window.
+- **Graceful close on corrupt handle**: `DatabaseManager.close()` now wraps `this.db.close()` in a try/catch so the recovery `close()` → reopen path doesn't propagate a throw from a corrupt database handle.
+
 ## [0.7.19] - 2026-06-23
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hermes-memory",
-      "version": "0.7.19",
+      "version": "0.7.20",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-tui": "^0.74.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "description": "🧠 Persistent memory + 🔍 session search + 🛡️ secret scanning for Pi. Token-aware policy-only memory by default, SQLite FTS5 search, auto-consolidation, procedural skills. 368 tests. Ported from Hermes agent.",
   "type": "module",
   "main": "src/index.ts",

--- a/src/handlers/session-live-index.ts
+++ b/src/handlers/session-live-index.ts
@@ -52,7 +52,9 @@ export function scheduleLiveSessionIndex(
   state.promise = new Promise<void>((resolve) => {
     setTimeoutFn(() => {
       try {
-        indexLiveSessionFn(dbManager, sessionManager);
+        dbManager.withCorruptionRecovery(() => {
+          indexLiveSessionFn(dbManager, sessionManager);
+        });
       } catch (err) {
         try { options.onError?.(err); } catch { /* best effort */ }
       } finally {

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,12 +246,14 @@ export default function (pi: ExtensionAPI) {
       if (sessionFile && require("node:fs").existsSync(sessionFile)) {
         const sessionData = parseSessionFile(sessionFile);
         if (sessionData) {
-          indexSession(dbManager, sessionData);
-          // Keep session_files metadata in sync with the final on-disk state.
-          // Pi appends the closing session entry on shutdown after the last
-          // message_end, so without this upsert the stored size/mtime would be
-          // stale and the next startup would re-parse this file unnecessarily.
-          upsertSessionFileMetadata(dbManager, sessionFile, sessionData.id);
+          dbManager.withCorruptionRecovery(() => {
+            indexSession(dbManager, sessionData);
+            // Keep session_files metadata in sync with the final on-disk state.
+            // Pi appends the closing session entry on shutdown after the last
+            // message_end, so without this upsert the stored size/mtime would be
+            // stale and the next startup would re-parse this file unnecessarily.
+            upsertSessionFileMetadata(dbManager, sessionFile, sessionData.id);
+          });
         }
       }
     } catch {

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -7,6 +7,7 @@ type StatementLike = {
   run: (...args: any[]) => any;
   get: (...args: any[]) => any;
   all: (...args: any[]) => any;
+  iterate?: (...args: any[]) => Iterable<Record<string, unknown>>;
 };
 
 type DatabaseLike = {
@@ -24,6 +25,39 @@ type BunDatabaseInstance = {
   close: (throwOnError?: boolean) => void;
   transaction?: (fn: any) => any;
 };
+
+type DatabaseFileSuffix = '' | '-wal' | '-shm';
+
+type MovedDatabaseFile = {
+  original: string;
+  backup: string;
+};
+
+export interface DatabaseRecoveryResult {
+  strategy: 'rebuilt' | 'recreated-empty';
+  backupPaths: string[];
+  recoveredRows?: Record<string, number>;
+  error?: string;
+}
+
+class DatabaseCorruptionError extends Error {
+  code = 'SQLITE_CORRUPT';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'DatabaseCorruptionError';
+  }
+}
+
+export const SQLITE_WAL_AUTOCHECKPOINT_PAGES = 1000;
+
+const DATABASE_FILE_SUFFIXES: readonly DatabaseFileSuffix[] = ['', '-wal', '-shm'];
+const MEMORY_TARGETS = new Set(['memory', 'user', 'failure']);
+const MEMORY_CATEGORIES = new Set(['failure', 'correction', 'insight', 'preference', 'convention', 'tool-quirk']);
+
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replace(/"/g, '""')}"`;
+}
 
 function createBunCompatDatabaseCtor(require: NodeRequire): DatabaseCtor {
   const bunSqlite = require('bun:sqlite') as { Database: new (dbPath: string) => BunDatabaseInstance };
@@ -77,9 +111,35 @@ const Database = loadDatabaseCtor();
 export class DatabaseManager {
   private db: DatabaseLike | null = null;
   private readonly dbPath: string;
+  private lastRecovery: DatabaseRecoveryResult | null = null;
 
   constructor(memoryDir: string) {
     this.dbPath = path.join(memoryDir, 'sessions.db');
+  }
+
+  /**
+   * True when an error indicates SQLite file/page corruption rather than a
+   * normal constraint, migration, or query failure.
+   */
+  static isCorruptionError(err: unknown): boolean {
+    if (!err) return false;
+
+    const code = typeof err === 'object' && 'code' in err ? String((err as { code?: unknown }).code) : '';
+    if (code === 'SQLITE_CORRUPT' || code === 'SQLITE_NOTADB') return true;
+
+    const message = DatabaseManager.errorMessage(err).toLowerCase();
+    return message.includes('database disk image is malformed')
+      || message.includes('file is not a database')
+      || message.includes('database schema is corrupt')
+      || message.includes('malformed database schema')
+      || message.includes('btreeinitpage')
+      || message.includes('sqlite_corrupt')
+      || message.includes('sqlite_notadb');
+  }
+
+  private static errorMessage(err: unknown): string {
+    if (err instanceof Error) return err.message;
+    return String(err);
   }
 
   /**
@@ -93,23 +153,94 @@ export class DatabaseManager {
   }
 
   /**
+   * Last self-heal performed by this manager, if any. Exposed for diagnostics
+   * and tests; normal callers do not need it.
+   */
+  getLastRecovery(): DatabaseRecoveryResult | null {
+    return this.lastRecovery;
+  }
+
+  /**
+   * Retry a DB operation once after quarantining/rebuilding a corrupt DB.
+   */
+  withCorruptionRecovery<T>(operation: () => T): T {
+    try {
+      return operation();
+    } catch (err) {
+      if (!DatabaseManager.isCorruptionError(err)) {
+        throw err;
+      }
+      this.recoverFromCorruption(err);
+      return operation();
+    }
+  }
+
+  /**
+   * Close any open handle, rebuild/quarantine the DB file set, and let the next
+   * getDb() reopen a clean database.
+   */
+  recoverFromCorruption(cause?: unknown): DatabaseRecoveryResult {
+    this.close();
+    const recovery = this.recoverDatabaseFile(cause);
+    this.lastRecovery = recovery;
+    return recovery;
+  }
+
+  /**
    * Open the database and initialize schema.
    */
   private open(): DatabaseLike {
-    // Ensure directory exists
     const dir = path.dirname(this.dbPath);
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir, { recursive: true });
     }
 
-    const db = new Database(this.dbPath);
+    try {
+      return this.openUnchecked();
+    } catch (err) {
+      if (!DatabaseManager.isCorruptionError(err)) {
+        throw err;
+      }
 
-    // Enable WAL mode + FK enforcement for each connection.
+      const recovery = this.recoverDatabaseFile(err);
+      this.lastRecovery = recovery;
+      return this.openUnchecked();
+    }
+  }
+
+  private openUnchecked(): DatabaseLike {
+    const existed = this.hasExistingMainDatabaseFile();
+    const db = new Database(this.dbPath);
+    let ok = false;
+
+    try {
+      if (existed) {
+        this.assertIntegrityOk(db, 'quick_check', 'before schema initialization');
+      }
+
+      this.configureConnection(db);
+      this.initializeSchema(db);
+      this.assertIntegrityOk(db, 'quick_check', 'after schema initialization');
+      ok = true;
+      return db;
+    } finally {
+      if (!ok) {
+        this.safeClose(db);
+      }
+    }
+  }
+
+  private configureConnection(db: DatabaseLike): void {
+    // Enable WAL mode + FK enforcement for each connection. Keep SQLite's
+    // default WAL autocheckpoint size; a very aggressive checkpoint cadence
+    // increases the chance that abrupt VM/host shutdown catches a checkpoint.
     db.exec('PRAGMA journal_mode = WAL');
-    db.exec('PRAGMA wal_autocheckpoint = 100');
+    db.exec(`PRAGMA wal_autocheckpoint = ${SQLITE_WAL_AUTOCHECKPOINT_PAGES}`);
     db.exec('PRAGMA journal_size_limit = 5242880');
     db.exec('PRAGMA foreign_keys = ON');
+  }
 
+  private initializeSchema(db: DatabaseLike): void {
     // Create tables and triggers
     try {
       db.exec(SCHEMA_SQL);
@@ -129,8 +260,334 @@ export class DatabaseManager {
     this.ensureMemoriesColumns(db);
     this.migrateLegacyMemoriesTargetConstraint(db);
     this.rebuildMemoryFts(db);
+  }
 
-    return db;
+  private hasExistingMainDatabaseFile(): boolean {
+    try {
+      return fs.existsSync(this.dbPath) && fs.statSync(this.dbPath).size > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  private databaseFileSetExists(): boolean {
+    return DATABASE_FILE_SUFFIXES.some((suffix) => fs.existsSync(`${this.dbPath}${suffix}`));
+  }
+
+  private assertIntegrityOk(
+    db: DatabaseLike,
+    check: 'quick_check' | 'integrity_check' = 'quick_check',
+    context = '',
+  ): void {
+    const rows = db.prepare(`PRAGMA ${check}`).all() as Record<string, unknown>[];
+    const messages = rows.map((row) => String(Object.values(row)[0] ?? ''));
+    const failures = messages.filter((message) => message.toLowerCase() !== 'ok');
+
+    if (rows.length === 0 || failures.length > 0) {
+      const detail = failures.length > 0 ? failures.slice(0, 5).join('\n') : 'no result rows';
+      const suffix = context ? ` ${context}` : '';
+      throw new DatabaseCorruptionError(`SQLite ${check} failed${suffix}: ${detail}`);
+    }
+  }
+
+  private assertForeignKeysOk(db: DatabaseLike): void {
+    const rows = db.prepare('PRAGMA foreign_key_check').all() as Record<string, unknown>[];
+    if (rows.length > 0) {
+      throw new Error(`SQLite foreign_key_check failed after rebuild (${rows.length} violation${rows.length === 1 ? '' : 's'})`);
+    }
+  }
+
+  private recoverDatabaseFile(cause?: unknown): DatabaseRecoveryResult {
+    const backupBase = this.corruptBackupBase();
+    let rebuildError: unknown;
+
+    if (this.databaseFileSetExists()) {
+      try {
+        return this.rebuildDatabaseFromReadableRows(backupBase);
+      } catch (err) {
+        rebuildError = err;
+      }
+    }
+
+    const moved = this.moveDatabaseFilesToBackup(backupBase);
+    return {
+      strategy: 'recreated-empty',
+      backupPaths: moved.map((file) => file.backup),
+      error: DatabaseManager.errorMessage(rebuildError ?? cause ?? 'unknown corruption'),
+    };
+  }
+
+  private rebuildDatabaseFromReadableRows(backupBase: string): DatabaseRecoveryResult {
+    const tempPath = this.rebuildTempPath();
+    this.removeDatabaseFileSet(tempPath);
+
+    let source: DatabaseLike | null = null;
+    let target: DatabaseLike | null = null;
+    let recoveredRows: Record<string, number> | undefined;
+    let rebuildOk = false;
+
+    try {
+      source = new Database(this.dbPath);
+      target = new Database(tempPath);
+      target.exec('PRAGMA journal_mode = DELETE');
+      target.exec('PRAGMA foreign_keys = OFF');
+      target.exec(SCHEMA_SQL);
+
+      recoveredRows = this.copyRecoverableRows(source, target);
+      this.rebuildFtsTables(target);
+      this.assertForeignKeysOk(target);
+      this.assertIntegrityOk(target, 'quick_check', 'after corruption rebuild');
+      rebuildOk = true;
+    } finally {
+      if (source) this.safeClose(source);
+      if (target) this.safeClose(target);
+      if (!rebuildOk) this.removeDatabaseFileSet(tempPath);
+    }
+
+    const moved = this.swapRebuiltDatabase(tempPath, backupBase);
+    this.removeDatabaseFileSet(tempPath);
+
+    return {
+      strategy: 'rebuilt',
+      backupPaths: moved.map((file) => file.backup),
+      recoveredRows,
+    };
+  }
+
+  private copyRecoverableRows(source: DatabaseLike, target: DatabaseLike): Record<string, number> {
+    return {
+      extension_metadata: this.copyExtensionMetadata(source, target),
+      sessions: this.copySessions(source, target),
+      messages: this.copyMessages(source, target),
+      session_files: this.copySessionFiles(source, target),
+      memories: this.copyMemories(source, target),
+    };
+  }
+
+  private copyExtensionMetadata(source: DatabaseLike, target: DatabaseLike): number {
+    const insert = target.prepare('INSERT OR REPLACE INTO extension_metadata (key, value) VALUES (?, ?)');
+    let copied = 0;
+
+    for (const row of this.readTableRows(source, 'extension_metadata', ['key', 'value'])) {
+      if (typeof row.key !== 'string' || typeof row.value !== 'string') continue;
+      insert.run(row.key, row.value);
+      copied++;
+    }
+
+    return copied;
+  }
+
+  private copySessions(source: DatabaseLike, target: DatabaseLike): number {
+    const insert = target.prepare(`
+      INSERT OR IGNORE INTO sessions (id, project, cwd, started_at, ended_at, message_count)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `);
+    let copied = 0;
+
+    for (const row of this.readTableRows(source, 'sessions', ['id', 'project', 'cwd', 'started_at', 'ended_at', 'message_count'])) {
+      if (typeof row.id !== 'string' || typeof row.cwd !== 'string' || typeof row.started_at !== 'string') continue;
+      const project = typeof row.project === 'string' && row.project ? row.project : (path.basename(row.cwd) || 'unknown');
+      insert.run(
+        row.id,
+        project,
+        row.cwd,
+        row.started_at,
+        this.nullableString(row.ended_at),
+        this.integerOr(row.message_count, 0),
+      );
+      copied++;
+    }
+
+    return copied;
+  }
+
+  private copyMessages(source: DatabaseLike, target: DatabaseLike): number {
+    const insert = target.prepare(`
+      INSERT OR IGNORE INTO messages (id, session_id, role, content, timestamp, tool_calls)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `);
+    let copied = 0;
+
+    for (const row of this.readTableRows(source, 'messages', ['id', 'session_id', 'role', 'content', 'timestamp', 'tool_calls'])) {
+      if (
+        typeof row.id !== 'string'
+        || typeof row.session_id !== 'string'
+        || (row.role !== 'user' && row.role !== 'assistant' && row.role !== 'system')
+        || typeof row.content !== 'string'
+        || typeof row.timestamp !== 'string'
+      ) {
+        continue;
+      }
+
+      insert.run(row.id, row.session_id, row.role, row.content, row.timestamp, this.nullableString(row.tool_calls));
+      copied++;
+    }
+
+    return copied;
+  }
+
+  private copySessionFiles(source: DatabaseLike, target: DatabaseLike): number {
+    const insert = target.prepare(`
+      INSERT OR IGNORE INTO session_files (path, session_id, size, mtime_ms, indexed_at)
+      VALUES (?, ?, ?, ?, ?)
+    `);
+    let copied = 0;
+
+    for (const row of this.readTableRows(source, 'session_files', ['path', 'session_id', 'size', 'mtime_ms', 'indexed_at'])) {
+      if (typeof row.path !== 'string' || typeof row.session_id !== 'string') continue;
+      insert.run(
+        row.path,
+        row.session_id,
+        this.integerOr(row.size, 0),
+        this.integerOr(row.mtime_ms, 0),
+        typeof row.indexed_at === 'string' ? row.indexed_at : new Date(0).toISOString(),
+      );
+      copied++;
+    }
+
+    return copied;
+  }
+
+  private copyMemories(source: DatabaseLike, target: DatabaseLike): number {
+    const insert = target.prepare(`
+      INSERT OR IGNORE INTO memories (id, project, target, category, content, failure_reason, tool_state, corrected_to, created, last_referenced)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    let copied = 0;
+
+    for (const row of this.readTableRows(source, 'memories', [
+      'id',
+      'project',
+      'target',
+      'category',
+      'content',
+      'failure_reason',
+      'tool_state',
+      'corrected_to',
+      'created',
+      'last_referenced',
+    ])) {
+      const id = this.integerOr(row.id, NaN);
+      if (!Number.isFinite(id) || typeof row.content !== 'string') continue;
+
+      const targetName = typeof row.target === 'string' && MEMORY_TARGETS.has(row.target) ? row.target : 'memory';
+      const category = typeof row.category === 'string' && MEMORY_CATEGORIES.has(row.category) ? row.category : null;
+      const created = typeof row.created === 'string' ? row.created : new Date(0).toISOString();
+      const lastReferenced = typeof row.last_referenced === 'string' ? row.last_referenced : created;
+
+      insert.run(
+        id,
+        this.nullableString(row.project),
+        targetName,
+        category,
+        row.content,
+        this.nullableString(row.failure_reason),
+        this.nullableString(row.tool_state),
+        this.nullableString(row.corrected_to),
+        created,
+        lastReferenced,
+      );
+      copied++;
+    }
+
+    return copied;
+  }
+
+  private readTableRows(source: DatabaseLike, table: string, desiredColumns: string[]): Iterable<Record<string, unknown>> {
+    const columns = this.getColumnNames(source, table);
+    const selected = desiredColumns.filter((column) => columns.has(column));
+    if (selected.length === 0) return [];
+
+    const sql = `SELECT ${selected.map(quoteIdentifier).join(', ')} FROM ${quoteIdentifier(table)} NOT INDEXED`;
+    const statement = source.prepare(sql);
+    if (statement.iterate) {
+      return statement.iterate() as Iterable<Record<string, unknown>>;
+    }
+    return statement.all() as Record<string, unknown>[];
+  }
+
+  private getColumnNames(db: DatabaseLike, table: string): Set<string> {
+    const rows = db.prepare(`PRAGMA table_info(${quoteIdentifier(table)})`).all() as { name?: unknown }[];
+    return new Set(rows.map((row) => row.name).filter((name): name is string => typeof name === 'string'));
+  }
+
+  private nullableString(value: unknown): string | null {
+    return typeof value === 'string' ? value : null;
+  }
+
+  private integerOr(value: unknown, fallback: number): number {
+    if (typeof value === 'number' && Number.isFinite(value)) return Math.trunc(value);
+    if (typeof value === 'bigint') return Number(value);
+    if (typeof value === 'string' && value.trim()) {
+      const parsed = Number.parseInt(value, 10);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+    return fallback;
+  }
+
+  private rebuildFtsTables(db: DatabaseLike): void {
+    db.exec("INSERT INTO message_fts(message_fts) VALUES('rebuild')");
+    db.exec("INSERT INTO memory_fts(memory_fts) VALUES('rebuild')");
+  }
+
+  private corruptBackupBase(): string {
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const nonce = Math.random().toString(16).slice(2, 8);
+    return `${this.dbPath}.corrupt-${stamp}-${process.pid}-${nonce}`;
+  }
+
+  private rebuildTempPath(): string {
+    const stamp = Date.now();
+    const nonce = Math.random().toString(16).slice(2, 8);
+    return `${this.dbPath}.rebuild-${process.pid}-${stamp}-${nonce}.tmp`;
+  }
+
+  private swapRebuiltDatabase(tempPath: string, backupBase: string): MovedDatabaseFile[] {
+    const moved = this.moveDatabaseFilesToBackup(backupBase);
+    try {
+      fs.renameSync(tempPath, this.dbPath);
+      return moved;
+    } catch (err) {
+      this.restoreMovedDatabaseFiles(moved);
+      this.removeDatabaseFileSet(tempPath);
+      throw err;
+    }
+  }
+
+  private moveDatabaseFilesToBackup(backupBase: string): MovedDatabaseFile[] {
+    const moved: MovedDatabaseFile[] = [];
+    for (const suffix of DATABASE_FILE_SUFFIXES) {
+      const original = `${this.dbPath}${suffix}`;
+      if (!fs.existsSync(original)) continue;
+
+      const backup = `${backupBase}${suffix}`;
+      fs.rmSync(backup, { force: true });
+      fs.renameSync(original, backup);
+      moved.push({ original, backup });
+    }
+    return moved;
+  }
+
+  private restoreMovedDatabaseFiles(moved: MovedDatabaseFile[]): void {
+    for (const file of [...moved].reverse()) {
+      try {
+        if (!fs.existsSync(file.backup)) continue;
+        fs.rmSync(file.original, { force: true });
+        fs.renameSync(file.backup, file.original);
+      } catch {
+        // Best effort. The backup path remains available if restoration fails.
+      }
+    }
+  }
+
+  private removeDatabaseFileSet(basePath: string): void {
+    for (const suffix of DATABASE_FILE_SUFFIXES) {
+      fs.rmSync(`${basePath}${suffix}`, { force: true });
+    }
+  }
+
+  private safeClose(db: DatabaseLike): void {
+    try { db.close(); } catch { /* best effort */ }
   }
 
   private isLegacyMemoriesCategoryError(err: unknown): boolean {
@@ -254,7 +711,7 @@ export class DatabaseManager {
   close(): void {
     if (this.db) {
       try { this.db.exec('PRAGMA wal_checkpoint(TRUNCATE)'); } catch { /* best effort */ }
-      this.db.close();
+      try { this.db.close(); } catch { /* best effort — close may throw on a corrupt handle */ }
       this.db = null;
     }
   }

--- a/src/store/session-indexer.ts
+++ b/src/store/session-indexer.ts
@@ -43,6 +43,10 @@ export interface IncrementalIndexOptions {
  * @returns IndexResult with count of messages indexed
  */
 export function indexSession(dbManager: DatabaseManager, session: ParsedSession): IndexResult {
+  return dbManager.withCorruptionRecovery(() => indexSessionOnce(dbManager, session));
+}
+
+function indexSessionOnce(dbManager: DatabaseManager, session: ParsedSession): IndexResult {
   const db = dbManager.getDb();
 
   const existingSession = db.prepare('SELECT id FROM sessions WHERE id = ?').get(session.id) as { id: string } | undefined;
@@ -210,6 +214,10 @@ export function indexCurrentSession(dbManager: DatabaseManager, sessionManager: 
 }
 
 export function indexLiveSession(dbManager: DatabaseManager, sessionManager: SessionManagerSnapshot): IndexResult | null {
+  return dbManager.withCorruptionRecovery(() => indexLiveSessionOnce(dbManager, sessionManager));
+}
+
+function indexLiveSessionOnce(dbManager: DatabaseManager, sessionManager: SessionManagerSnapshot): IndexResult | null {
   const sessionFile = sessionManager.getSessionFile?.();
   if (sessionFile && fs.existsSync(sessionFile)) {
     const session = parseSessionFile(sessionFile);

--- a/tests/handlers/session-live-index.test.ts
+++ b/tests/handlers/session-live-index.test.ts
@@ -164,6 +164,39 @@ describe('session live indexing handler', () => {
     assert.match(errors[0] instanceof Error ? errors[0].message : String(errors[0]), /boom/);
   });
 
+  it('repairs corruption and retries live indexing once before reporting an error', async () => {
+    dbManager.getDb();
+    const state: SessionLiveIndexState = { inProgress: false, promise: null };
+    const errors: unknown[] = [];
+    let attempts = 0;
+
+    const scheduled = scheduleLiveSessionIndex(dbManager, createSnapshot([]), {
+      state,
+      indexLiveSessionFn: () => {
+        attempts++;
+        if (attempts === 1) {
+          const err = new Error('SQLITE_CORRUPT: database disk image is malformed') as Error & { code: string };
+          err.code = 'SQLITE_CORRUPT';
+          throw err;
+        }
+        return null;
+      },
+      onError: (err) => errors.push(err),
+      delayMs: 0,
+      setTimeoutFn: (callback) => {
+        queueMicrotask(callback);
+        return 0;
+      },
+    });
+
+    assert.equal(scheduled, true);
+    await state.promise;
+
+    assert.equal(attempts, 2);
+    assert.equal(errors.length, 0);
+    assert.equal(dbManager.getLastRecovery()?.strategy, 'rebuilt');
+  });
+
   it('shutdown wait resolves true when live indexing completes before timeout', async () => {
     let resolveIndex!: () => void;
     const state: SessionLiveIndexState = {

--- a/tests/store/db.test.ts
+++ b/tests/store/db.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import Database from 'better-sqlite3';
-import { DatabaseManager } from '../../src/store/db.js';
+import { DatabaseManager, SQLITE_WAL_AUTOCHECKPOINT_PAGES } from '../../src/store/db.js';
 
 describe('DatabaseManager', () => {
   let tmpDir: string;
@@ -19,6 +19,54 @@ describe('DatabaseManager', () => {
     dbManager.close();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
+
+  function assertQuickCheckOk(db: InstanceType<typeof Database>): void {
+    const rows = db.prepare('PRAGMA quick_check').all() as Array<Record<string, unknown>>;
+    assert.deepStrictEqual(rows.map((row) => Object.values(row)[0]), ['ok']);
+  }
+
+  function corruptSqliteError(): Error & { code: string } {
+    const err = new Error('SQLITE_CORRUPT: database disk image is malformed') as Error & { code: string };
+    err.code = 'SQLITE_CORRUPT';
+    return err;
+  }
+
+  function corruptRecoverableIndexPage(dbPath: string, indexName: string): void {
+    const db = new Database(dbPath);
+    const pageSize = db.pragma('page_size', { simple: true }) as number;
+    const row = db.prepare(`
+      SELECT pageno
+      FROM dbstat
+      WHERE name = ? AND pagetype IN ('internal', 'leaf')
+      ORDER BY pageno ASC
+      LIMIT 1
+    `).get(indexName) as { pageno: number } | undefined;
+    db.close();
+
+    assert.ok(row, `dbstat did not find index page for ${indexName}`);
+    assert.ok(row.pageno > 1, 'will not corrupt sqlite database header page');
+
+    const buffer = fs.readFileSync(dbPath);
+    const offset = (row.pageno - 1) * pageSize;
+    for (let i = 0; i < 16 && offset + i < buffer.length; i++) {
+      buffer[offset + i] ^= 0xff;
+    }
+    fs.writeFileSync(dbPath, buffer);
+
+    const checkDb = new Database(dbPath);
+    try {
+      const rows = checkDb.prepare('PRAGMA quick_check').all() as Array<Record<string, unknown>>;
+      const ok = rows.length === 1 && Object.values(rows[0])[0] === 'ok';
+      assert.equal(ok, false, 'test fixture must produce a quick_check failure');
+      assert.doesNotThrow(() => {
+        checkDb.prepare('SELECT COUNT(*) as count FROM sessions NOT INDEXED').get();
+        checkDb.prepare('SELECT COUNT(*) as count FROM messages NOT INDEXED').get();
+        checkDb.prepare('SELECT COUNT(*) as count FROM memories NOT INDEXED').get();
+      }, 'test fixture must leave core table scans readable');
+    } finally {
+      checkDb.close();
+    }
+  }
 
   describe('initialization', () => {
     it('should create database file on first getDb() call', () => {
@@ -171,6 +219,78 @@ describe('DatabaseManager', () => {
     });
   });
 
+  describe('corruption recovery', () => {
+    it('repairs recoverable corruption on open and preserves readable rows', () => {
+      const db = dbManager.getDb();
+      db.prepare(`
+        INSERT INTO sessions (id, project, cwd, started_at)
+        VALUES (?, ?, ?, ?)
+      `).run('recover-session', 'recover-project', '/work/recover', '2026-05-03T00:00:00Z');
+
+      const insertMessage = db.prepare(`
+        INSERT INTO messages (id, session_id, role, content, timestamp)
+        VALUES (?, ?, ?, ?, ?)
+      `);
+      for (let i = 0; i < 50; i++) {
+        insertMessage.run(`recover-msg-${i}`, 'recover-session', i % 2 === 0 ? 'user' : 'assistant', `message ${i}`, `2026-05-03T00:${String(i).padStart(2, '0')}:00Z`);
+      }
+
+      db.prepare(`
+        INSERT INTO memories (project, target, content, created, last_referenced)
+        VALUES (?, ?, ?, ?, ?)
+      `).run(null, 'memory', 'recoverable memory', '2026-05-03', '2026-05-03');
+      dbManager.close();
+
+      corruptRecoverableIndexPage(path.join(tmpDir, 'sessions.db'), 'idx_messages_timestamp');
+
+      dbManager = new DatabaseManager(tmpDir);
+      const repairedDb = dbManager.getDb();
+
+      assert.strictEqual(dbManager.getLastRecovery()?.strategy, 'rebuilt');
+      assert.deepStrictEqual(dbManager.getLastRecovery()?.recoveredRows, {
+        extension_metadata: 0,
+        sessions: 1,
+        messages: 50,
+        session_files: 0,
+        memories: 1,
+      });
+      assert.deepStrictEqual(dbManager.getStats(), { sessions: 1, messages: 50, memories: 1 });
+      const memory = repairedDb.prepare('SELECT content FROM memories WHERE content = ?').get('recoverable memory') as { content: string } | undefined;
+      assert.ok(memory);
+      assertQuickCheckOk(repairedDb as InstanceType<typeof Database>);
+      assert.ok(fs.readdirSync(tmpDir).some((name) => name.startsWith('sessions.db.corrupt-')), 'corrupt DB should be quarantined');
+    });
+
+    it('quarantines unrecoverable files and recreates an empty database', () => {
+      dbManager.close();
+      const dbPath = path.join(tmpDir, 'sessions.db');
+      fs.writeFileSync(dbPath, 'not a sqlite database');
+
+      dbManager = new DatabaseManager(tmpDir);
+      const db = dbManager.getDb();
+
+      assert.strictEqual(dbManager.getLastRecovery()?.strategy, 'recreated-empty');
+      assert.deepStrictEqual(dbManager.getStats(), { sessions: 0, messages: 0, memories: 0 });
+      assertQuickCheckOk(db as InstanceType<typeof Database>);
+      assert.ok(fs.readdirSync(tmpDir).some((name) => name.startsWith('sessions.db.corrupt-')), 'unrecoverable DB should be quarantined');
+    });
+
+    it('retries a corrupt operation once after self-healing', () => {
+      dbManager.getDb();
+      let attempts = 0;
+
+      const result = dbManager.withCorruptionRecovery(() => {
+        attempts++;
+        if (attempts === 1) throw corruptSqliteError();
+        return 'ok';
+      });
+
+      assert.strictEqual(result, 'ok');
+      assert.strictEqual(attempts, 2);
+      assert.strictEqual(dbManager.getLastRecovery()?.strategy, 'rebuilt');
+    });
+  });
+
   describe('close', () => {
     it('should close database connection', () => {
       const db = dbManager.getDb();
@@ -255,6 +375,12 @@ describe('DatabaseManager', () => {
       const db = dbManager.getDb();
       const result = db.pragma('journal_mode', { simple: true }) as string;
       assert.strictEqual(result, 'wal');
+    });
+
+    it('should use SQLite default-size WAL autocheckpoints', () => {
+      const db = dbManager.getDb();
+      const result = db.pragma('wal_autocheckpoint', { simple: true }) as number;
+      assert.strictEqual(result, SQLITE_WAL_AUTOCHECKPOINT_PAGES);
     });
   });
 


### PR DESCRIPTION
Follow-up to #86 (commit 3d82f44).

`package.json` was bumped to `0.7.20` when the DB corruption self-heal fix landed, but `package-lock.json` was left at `0.7.19`. This syncs both root `version` fields in the lockfile so they stay consistent.

No code changes — lockfile-only.