### PR TITLE
feat: respect PI_CODING_AGENT_SESSION_DIR for session indexing

### DIFF
--- a/src/handlers/index-sessions.ts
+++ b/src/handlers/index-sessions.ts
@@ -9,7 +9,7 @@ import { DatabaseManager } from '../store/db.js';
 import { indexAllSessions, getSessionStats } from '../store/session-indexer.js';
 import { AGENT_ROOT } from '../paths.js';
 
-const SESSIONS_DIR = path.join(AGENT_ROOT, 'sessions');
+const SESSIONS_DIR = process.env.PI_CODING_AGENT_SESSION_DIR || path.join(AGENT_ROOT, 'sessions');
 
 export function registerIndexSessionsCommand(pi: ExtensionAPI): void {
   pi.registerCommand("memory-index-sessions", {


### PR DESCRIPTION
## Problem

The session indexer hardcodes AGENT_ROOT/sessions as the session directory. Users who set PI_CODING_AGENT_SESSION_DIR (e.g. to ~/.cache/pi/sessions) need a symlink for /memory-index-sessions to work.

## Solution

Check PI_CODING_AGENT_SESSION_DIR first, fall back to AGENT_ROOT/sessions.