### PR TITLE
fix(db): migrate legacy sessions.db missing project column

### DIFF
--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -245,19 +245,19 @@ export class DatabaseManager {
     try {
       db.exec(SCHEMA_SQL);
     } catch (err) {
-      if (!this.isLegacyMemoriesCategoryError(err)) {
+      if (!this.isLegacySchemaError(err)) {
         throw err;
       }
 
-      // Legacy DB from pre-v0.6 can have memories table without the category
-      // and failure metadata columns. Add missing columns, then retry schema.
-      this.ensureMemoriesColumns(db);
+      // Legacy DBs can be missing v0.6 failure-memory columns and/or the project
+      // column on sessions/memories. Add missing columns, then retry schema.
+      this.ensureLegacySchemaColumns(db);
       db.exec(SCHEMA_SQL);
     }
 
-    // Extra safety: always ensure legacy memories columns exist, then migrate
-    // legacy CHECK(target IN ('memory','user')) constraints to include 'failure'.
-    this.ensureMemoriesColumns(db);
+    // Extra safety: always ensure legacy columns exist, then migrate legacy
+    // CHECK(target IN ('memory','user')) constraints to include 'failure'.
+    this.ensureLegacySchemaColumns(db);
     this.migrateLegacyMemoriesTargetConstraint(db);
     this.rebuildMemoryFts(db);
   }
@@ -590,19 +590,30 @@ export class DatabaseManager {
     try { db.close(); } catch { /* best effort */ }
   }
 
-  private isLegacyMemoriesCategoryError(err: unknown): boolean {
+  private isLegacySchemaError(err: unknown): boolean {
     if (!(err instanceof Error)) return false;
     const msg = err.message.toLowerCase();
-    return msg.includes('no such column: category') || msg.includes('memories(category)');
+    return msg.includes('no such column: category')
+      || msg.includes('memories(category)')
+      || msg.includes('no such column: project')
+      || msg.includes('sessions(project)')
+      || msg.includes('memories(project)');
+  }
+
+  private ensureLegacySchemaColumns(db: DatabaseLike): void {
+    this.ensureMemoriesColumns(db);
+    this.ensureSessionsColumns(db);
   }
 
   private ensureMemoriesColumns(db: DatabaseLike): void {
     const tableExists = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='memories'").get() as { name: string } | undefined;
     if (!tableExists) return;
 
-    const columns = db.prepare('PRAGMA table_info(memories)').all() as { name: string }[];
-    const names = new Set(columns.map((c) => c.name));
+    const names = this.getColumnNames(db, 'memories');
 
+    if (!names.has('project')) {
+      db.exec('ALTER TABLE memories ADD COLUMN project TEXT');
+    }
     if (!names.has('category')) {
       db.exec('ALTER TABLE memories ADD COLUMN category TEXT');
     }
@@ -614,6 +625,40 @@ export class DatabaseManager {
     }
     if (!names.has('corrected_to')) {
       db.exec('ALTER TABLE memories ADD COLUMN corrected_to TEXT');
+    }
+  }
+
+  private ensureSessionsColumns(db: DatabaseLike): void {
+    const tableExists = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='sessions'").get() as { name: string } | undefined;
+    if (!tableExists) return;
+
+    const names = this.getColumnNames(db, 'sessions');
+    if (!names.has('project')) {
+      db.exec('ALTER TABLE sessions ADD COLUMN project TEXT');
+    }
+
+    this.backfillSessionsProject(db);
+  }
+
+  private backfillSessionsProject(db: DatabaseLike): void {
+    const names = this.getColumnNames(db, 'sessions');
+    if (!names.has('project') || !names.has('cwd') || !names.has('id')) return;
+
+    const rows = db.prepare('SELECT id, cwd, project FROM sessions').all() as Array<{
+      id?: unknown;
+      cwd?: unknown;
+      project?: unknown;
+    }>;
+    const update = db.prepare('UPDATE sessions SET project = ? WHERE id = ?');
+
+    for (const row of rows) {
+      if (typeof row.id !== 'string') continue;
+      if (typeof row.project === 'string' && row.project.trim()) continue;
+
+      const project = typeof row.cwd === 'string' && row.cwd.trim()
+        ? (path.basename(row.cwd) || 'unknown')
+        : 'unknown';
+      update.run(project, row.id);
     }
   }
 

--- a/tests/store/db.test.ts
+++ b/tests/store/db.test.ts
@@ -176,6 +176,81 @@ describe('DatabaseManager', () => {
       migratedManager.close();
     });
 
+    it('should migrate legacy sessions table without project column', () => {
+      const dbPath = path.join(tmpDir, 'sessions.db');
+      const legacyDb = new Database(dbPath);
+
+      legacyDb.exec(`
+        CREATE TABLE sessions (
+          id TEXT PRIMARY KEY,
+          cwd TEXT NOT NULL,
+          started_at TEXT NOT NULL,
+          ended_at TEXT,
+          message_count INTEGER DEFAULT 0
+        );
+      `);
+      legacyDb.prepare(`
+        INSERT INTO sessions (id, cwd, started_at)
+        VALUES (?, ?, ?)
+      `).run('legacy-session', '/work/my-app', '2026-05-03T00:00:00Z');
+      legacyDb.close();
+
+      const migratedManager = new DatabaseManager(tmpDir);
+      const migratedDb = migratedManager.getDb();
+      const columns = migratedDb.prepare('PRAGMA table_info(sessions)').all() as { name: string }[];
+      const names = columns.map((c) => c.name);
+
+      assert.ok(names.includes('project'));
+
+      const row = migratedDb.prepare('SELECT project FROM sessions WHERE id = ?').get('legacy-session') as { project: string };
+      assert.strictEqual(row.project, 'my-app');
+
+      assert.doesNotThrow(() => {
+        migratedDb.prepare(`
+          INSERT INTO sessions (id, project, cwd, started_at)
+          VALUES (?, ?, ?, ?)
+        `).run('new-session', 'new-project', '/work/new-project', '2026-05-04T00:00:00Z');
+      });
+
+      migratedManager.close();
+    });
+
+    it('should migrate legacy memories table without project column', () => {
+      const dbPath = path.join(tmpDir, 'sessions.db');
+      const legacyDb = new Database(dbPath);
+
+      legacyDb.exec(`
+        CREATE TABLE memories (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          target TEXT NOT NULL CHECK (target IN ('memory', 'user')),
+          content TEXT NOT NULL,
+          created DATE NOT NULL,
+          last_referenced DATE NOT NULL
+        );
+      `);
+      legacyDb.prepare(`
+        INSERT INTO memories (target, content, created, last_referenced)
+        VALUES (?, ?, ?, ?)
+      `).run('memory', 'legacy memory entry', '2026-05-09', '2026-05-09');
+      legacyDb.close();
+
+      const migratedManager = new DatabaseManager(tmpDir);
+      const migratedDb = migratedManager.getDb();
+      const columns = migratedDb.prepare('PRAGMA table_info(memories)').all() as { name: string }[];
+      const names = columns.map((c) => c.name);
+
+      assert.ok(names.includes('project'));
+
+      const row = migratedDb.prepare('SELECT project, content FROM memories').get() as {
+        project: string | null;
+        content: string;
+      };
+      assert.strictEqual(row.project, null);
+      assert.strictEqual(row.content, 'legacy memory entry');
+
+      migratedManager.close();
+    });
+
     it('should migrate legacy target CHECK constraint to allow failure entries', () => {
       const dbPath = path.join(tmpDir, 'sessions.db');
       const legacyDb = new Database(dbPath);


### PR DESCRIPTION
## Summary

Fixes repeated `no such column: project` errors in `memory_search` and live session indexing when users upgrade with an older `sessions.db` that predates the `project` column on `sessions` / `memories`.

Closes the follow-up from [#86](https://github.com/chandra447/pi-hermes-memory/issues/86#issuecomment-4825799529) (reported by @robchallen).

## Problem

`CREATE TABLE IF NOT EXISTS` does not add new columns to existing tables. If a legacy DB is missing `project`, schema init can appear to succeed while runtime queries fail on every turn — same annoying repeat pattern as #86, but a schema migration gap rather than page corruption.

The v0.7.20 corruption self-heal only retries `SQLITE_CORRUPT` / malformed errors, so `no such column: project` was never recovered automatically.

## Fix

- Detect `no such column: project` during schema init (same pattern as the v0.6 `category` migration)
- Add missing `project` column to `memories` and `sessions` idempotently
- Backfill `sessions.project` from `cwd` basename (matches corruption-rebuild logic)
- Retry `SCHEMA_SQL` after migration so indexes like `idx_sessions_project` are created

## Tests

- Legacy `sessions` table without `project` → column added, existing row backfilled (`/work/my-app` → `my-app`)
- Legacy `memories` table without `project` → column added, existing rows preserved

All 35 test files pass.

## User workaround (pre-fix)

Delete `~/.pi/agent/pi-hermes-memory/sessions.db*` and run `/memory-sync-markdown`. After this PR, affected users should self-heal on next startup without manual intervention.