### PR TITLE
feat: in-process direct LLM for background review (fixes #89)

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,19 @@ Background review triggers based on **activity level**, not just turn count:
 
 Both counters reset after each review.
 
+### Background Review Transport
+
+By default, background review uses an in-process `completeSimple()` side-channel: a small JSON-only prompt, no child `pi` process, and memory writes applied directly by the extension. This keeps the main session's system prompt, tools, and LLM prefix cache intact.
+
+If direct review fails (no model, no auth, provider error, unparseable response), it automatically falls back to the legacy `pi -p --no-session` subprocess path.
+
+Set `reviewTransport` in config only when you need to override this:
+
+| Value | Behavior |
+|---|---|
+| `direct` (default) | Try in-process `completeSimple()` first; fall back to subprocess on failure |
+| `subprocess` | Always use `pi -p` subprocess (pre-PR #92 behavior) |
+
 ### Skill Auto-Extraction
 
 After a complex task (8+ tool calls using 2+ different tools in a single turn), the extension automatically asks the agent:
@@ -430,6 +443,7 @@ Create `~/.pi/agent/hermes-memory-config.json`:
   "nudgeToolCalls": 15,
   "reviewRecentMessages": 0,
   "reviewEnabled": true,
+  "reviewTransport": "direct",
   "memoryOverflowStrategy": "auto-consolidate",
   "autoConsolidate": true,
   "correctionDetection": true,
@@ -455,12 +469,13 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 | `memoryDir` | `~/.pi/agent/pi-hermes-memory` | Custom directory for extension storage files |
 | `projectsMemoryDir` | `projects-memory` | Subdirectory under `~/.pi/agent/` for project-scoped memory |
 | `sessionSearch` | `{ "variant": "legacy" }` | Session search implementation: `legacy` keeps the existing SQLite/FTS snippet search; `anchors` uses the opt-in Markdown request surface and returns compact JSONL line-range anchors from `~/.pi/agent/sessions/` |
-| `llmModelOverride` | unset | Optional model override for child `pi -p` subprocess calls used by background review, correction save, session flush, and consolidation |
-| `llmThinkingOverride` | unset | Optional thinking override for those child subprocess calls; valid values are `off`, `minimal`, `low`, `medium`, `high`, and `xhigh`. If `llmModelOverride` is set and this is omitted, child calls default to `off` |
+| `llmModelOverride` | unset | Optional model override for background review (direct and subprocess), correction save, session flush, and consolidation |
+| `llmThinkingOverride` | unset | Optional thinking override for those LLM calls; valid values are `off`, `minimal`, `low`, `medium`, `high`, and `xhigh`. If `llmModelOverride` is set and this is omitted, review/child calls default to `off` |
 | `nudgeInterval` | `10` | Turns between auto-reviews |
 | `nudgeToolCalls` | `15` | Tool calls between auto-reviews (OR with turns) |
 | `reviewRecentMessages` | `0` | Recent messages included in background review (`0` = all) |
 | `reviewEnabled` | `true` | Enable/disable background learning loop |
+| `reviewTransport` | `direct` | Background review LLM transport: `direct` uses in-process `completeSimple()` with subprocess fallback; `subprocess` forces legacy `pi -p` only |
 | `memoryOverflowStrategy` | `auto-consolidate` | Behavior when MEMORY.md, USER.md, failures.md, or project-scoped memory reaches its character limit: `auto-consolidate` runs the existing consolidation flow; `reject` returns an error; `fifo-evict` rotates older entries in file order until the new entry fits |
 | `autoConsolidate` | `true` | Legacy alias for `memoryOverflowStrategy` when `memoryOverflowStrategy` is not set (`true` = `auto-consolidate`, `false` = `reject`) |
 | `consolidationTimeoutMs` | `60000` | Maximum time in milliseconds for auto-consolidation to complete |

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "typescript": "^6.0.3"
       },
       "peerDependencies": {
-        "@earendil-works/pi-coding-agent": ">=0.74.0"
+        "@earendil-works/pi-coding-agent": ">=0.74.0",
+        "@earendil-works/pi-ai": "*"
       }
     },
     "node_modules/@aws-crypto/crc32": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,8 @@
         "typescript": "^6.0.3"
       },
       "peerDependencies": {
-        "@earendil-works/pi-coding-agent": ">=0.74.0",
-        "@earendil-works/pi-ai": "*"
+        "@earendil-works/pi-ai": "*",
+        "@earendil-works/pi-coding-agent": ">=0.74.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "url": "https://github.com/chandra447/pi-hermes-memory"
   },
   "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
     "@earendil-works/pi-coding-agent": ">=0.74.0"
   },
   "devDependencies": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { MemoryConfig, MemoryOverflowStrategy, SessionSearchVariant, ThinkingLevel } from "./types.js";
+import type { MemoryConfig, MemoryOverflowStrategy, ReviewTransport, SessionSearchVariant, ThinkingLevel } from "./types.js";
 import {
   DEFAULT_MEMORY_CHAR_LIMIT,
   DEFAULT_USER_CHAR_LIMIT,
@@ -19,7 +19,12 @@ import { AGENT_ROOT, normalizeConfiguredMemoryDir, normalizeProjectsMemoryDir } 
 
 const MEMORY_OVERFLOW_STRATEGIES: readonly MemoryOverflowStrategy[] = ["auto-consolidate", "reject", "fifo-evict"];
 const SESSION_SEARCH_VARIANTS: readonly SessionSearchVariant[] = ["legacy", "anchors"];
+const REVIEW_TRANSPORTS: readonly ReviewTransport[] = ["direct", "subprocess"];
 const THINKING_LEVELS: readonly ThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh"];
+
+function isReviewTransport(value: unknown): value is ReviewTransport {
+  return typeof value === "string" && REVIEW_TRANSPORTS.includes(value as ReviewTransport);
+}
 
 function isMemoryOverflowStrategy(value: unknown): value is MemoryOverflowStrategy {
   return typeof value === "string" && MEMORY_OVERFLOW_STRATEGIES.includes(value as MemoryOverflowStrategy);
@@ -42,6 +47,7 @@ const DEFAULT_CONFIG: MemoryConfig = {
   nudgeInterval: DEFAULT_NUDGE_INTERVAL,
   reviewRecentMessages: DEFAULT_REVIEW_RECENT_MESSAGES,
   reviewEnabled: true,
+  reviewTransport: "direct",
   flushOnCompact: true,
   flushOnShutdown: true,
   flushMinTurns: DEFAULT_FLUSH_MIN_TURNS,
@@ -91,6 +97,7 @@ export function loadConfig(configPath = DEFAULT_CONFIG_PATH): MemoryConfig {
       if (typeof parsed.nudgeInterval === "number") config.nudgeInterval = parsed.nudgeInterval;
       if (isNonNegativeNumber(parsed.reviewRecentMessages)) config.reviewRecentMessages = parsed.reviewRecentMessages;
       if (typeof parsed.reviewEnabled === "boolean") config.reviewEnabled = parsed.reviewEnabled;
+      if (isReviewTransport(parsed.reviewTransport)) config.reviewTransport = parsed.reviewTransport;
       if (typeof parsed.flushOnCompact === "boolean") config.flushOnCompact = parsed.flushOnCompact;
       if (typeof parsed.flushOnShutdown === "boolean") config.flushOnShutdown = parsed.flushOnShutdown;
       if (typeof parsed.flushMinTurns === "number") config.flushMinTurns = parsed.flushMinTurns;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -145,6 +145,36 @@ For failures, include: what was tried, why it failed, what error occurred, and w
 
 Only act if there's something genuinely worth saving. If nothing stands out, just say 'Nothing to save.' and stop.`;
 
+// ─── Direct (in-process) background review prompts ───
+export const DIRECT_REVIEW_SYSTEM_PROMPT = `You review coding conversations and extract durable memories worth saving across sessions.
+
+Review these aspects:
+- **Memory**: User persona, preferences, expectations about how the agent should behave, work style.
+- **Failures & Corrections**: What failed, user corrections, insights, conventions, tool quirks.
+
+Do NOT create or modify skills. Only save genuinely durable facts — not task progress, session outcomes, or temporary state.
+
+Respond with JSON only (no markdown fences):
+{
+  "operations": [
+    {
+      "action": "add",
+      "target": "memory",
+      "content": "entry text"
+    }
+  ]
+}
+
+Operation fields:
+- action: "add" | "replace" | "remove"
+- target: "memory" | "user" | "project" | "failure"
+- content: required for add/replace
+- old_text: required for replace/remove (substring match)
+- category: for failure target — failure | correction | insight | convention | tool-quirk | preference
+- failure_reason: optional context for failure entries
+
+If nothing is worth saving, return {"operations":[]}.`;
+
 // ─── Flush prompt (ported from flush_memories() in run_agent.py ~L7379) ───
 export const FLUSH_PROMPT = `[System: The session is being compressed. Save anything worth remembering — prioritize user preferences, corrections, and recurring patterns over task-specific details.]`;
 

--- a/src/handlers/background-review.ts
+++ b/src/handlers/background-review.ts
@@ -3,23 +3,128 @@
  * Ported from hermes-agent/run_agent.py (_spawn_background_review, _memory_nudge_interval).
  * See PLAN.md → "Hermes Source File Reference Map" for source lines.
  *
- * Uses pi.exec("pi", ["-p", ...]) for isolated one-shot review,
- * keeping us within Pi's intended extension API.
+ * Default transport: in-process complete() side-channel (preserves parent LLM cache).
+ * Fallback: pi.exec("pi", ["-p", ...]) subprocess when direct path is unavailable.
  */
 
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { MemoryStore } from "../store/memory-store.js";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { COMBINED_REVIEW_PROMPT } from "../constants.js";
+import { MemoryStore } from "../store/memory-store.js";
+import { DatabaseManager } from "../store/db.js";
 import type { MemoryConfig } from "../types.js";
 import { applyRecentMessageLimit, collectMessageParts } from "./message-parts.js";
 import { execChildPrompt } from "./pi-child-process.js";
+import { runDirectBackgroundReview, type DirectReviewResult } from "./review-memory-ops.js";
+
+export interface BackgroundReviewOptions {
+  dbManager?: DatabaseManager | null;
+  projectName?: string | null;
+  deps?: BackgroundReviewDeps;
+}
+
+export interface BackgroundReviewDeps {
+  runDirectReview?: typeof runDirectBackgroundReview;
+  execChildPrompt?: typeof execChildPrompt;
+}
+
+export interface ReviewPromptInput {
+  parts: string[];
+  currentMemory: string;
+  currentUser: string;
+  currentProject: string | null;
+}
+
+export function buildSubprocessReviewPrompt(input: ReviewPromptInput): string {
+  const reviewPrompt = [
+    COMBINED_REVIEW_PROMPT,
+    "",
+    "--- Current Memory ---",
+    input.currentMemory || "(empty)",
+    "",
+    "--- Current User Profile ---",
+    input.currentUser || "(empty)",
+  ];
+
+  if (input.currentProject !== null) {
+    reviewPrompt.push(
+      "",
+      "--- Current Project Memory ---",
+      input.currentProject || "(empty)",
+    );
+  }
+
+  reviewPrompt.push(
+    "",
+    "--- Conversation to Review ---",
+    input.parts.join("\n\n"),
+  );
+
+  return reviewPrompt.join("\n");
+}
+
+export function buildDirectReviewUserPrompt(input: ReviewPromptInput): string {
+  const sections = [
+    "--- Current Memory ---",
+    input.currentMemory || "(empty)",
+    "",
+    "--- Current User Profile ---",
+    input.currentUser || "(empty)",
+  ];
+
+  if (input.currentProject !== null) {
+    sections.push(
+      "",
+      "--- Current Project Memory ---",
+      input.currentProject || "(empty)",
+    );
+  }
+
+  sections.push(
+    "",
+    "--- Conversation to Review ---",
+    input.parts.join("\n\n"),
+  );
+
+  return sections.join("\n");
+}
+
+function shouldNotifyDirect(result: DirectReviewResult): boolean {
+  return result.ok && result.appliedCount > 0;
+}
+
+function shouldNotifySubprocess(stdout: string | undefined): boolean {
+  const output = stdout?.trim();
+  return !!output && !output.toLowerCase().includes("nothing to save");
+}
+
+function usesDirectTransport(config: MemoryConfig): boolean {
+  return (config.reviewTransport ?? "direct") === "direct";
+}
+
+async function runSubprocessReview(
+  pi: ExtensionAPI,
+  prompt: string,
+  config: MemoryConfig,
+  execChild: typeof execChildPrompt,
+): Promise<{ code: number; stdout?: string }> {
+  return execChild(pi, prompt, config, {
+    signal: undefined,
+    timeoutMs: 120000,
+  });
+}
 
 export function setupBackgroundReview(
   pi: ExtensionAPI,
   store: MemoryStore,
   projectStore: MemoryStore | null,
   config: MemoryConfig,
+  options: BackgroundReviewOptions = {},
 ): void {
+  const dbManager = options.dbManager ?? null;
+  const projectName = options.projectName ?? null;
+  const runDirectReview = options.deps?.runDirectReview ?? runDirectBackgroundReview;
+  const execChild = options.deps?.execChildPrompt ?? execChildPrompt;
+
   let turnsSinceReview = 0;
   let toolCallsSinceReview = 0;
   let userTurnCount = 0;
@@ -37,9 +142,6 @@ export function setupBackgroundReview(
     if (!config.reviewEnabled) return;
     if (reviewInProgress) return;
 
-    // Count tool calls from this turn's message only (not cumulative branch scan —
-    // otherwise the counter resets to 0 at review, then immediately re-counts all
-    // historical tool calls and re-triggers on every subsequent turn).
     try {
       const msg = event.message;
       if (msg?.role === "assistant") {
@@ -56,7 +158,6 @@ export function setupBackgroundReview(
       // If we can't count tool calls, fall back to turn-based only
     }
 
-    // Trigger on EITHER turn count OR tool call count
     const turnThresholdMet = turnsSinceReview >= config.nudgeInterval;
     const toolCallThresholdMet = toolCallsSinceReview >= config.nudgeToolCalls;
 
@@ -67,78 +168,71 @@ export function setupBackgroundReview(
     toolCallsSinceReview = 0;
     reviewInProgress = true;
 
-    // Build conversation snapshot from session entries (crash-safe)
     let allParts: string[] = [];
     try {
       const entries = ctx.sessionManager.getBranch();
       allParts = collectMessageParts(entries);
     } catch {
       reviewInProgress = false;
-      return; // Session expired or empty — nothing to review
+      return;
     }
     if (allParts.length < 4) {
       reviewInProgress = false;
-      return; // Not enough conversation to review
+      return;
     }
+
     const parts = applyRecentMessageLimit(allParts, config.reviewRecentMessages);
+    const promptInput: ReviewPromptInput = {
+      parts,
+      currentMemory: store.getMemoryEntries().join("\n§\n"),
+      currentUser: store.getUserEntries().join("\n§\n"),
+      currentProject: projectStore ? projectStore.getMemoryEntries().join("\n§\n") : null,
+    };
 
-    const currentMemory = store.getMemoryEntries().join("\n§\n");
-    const currentUser = store.getUserEntries().join("\n§\n");
-    const currentProject = projectStore ? projectStore.getMemoryEntries().join("\n§\n") : null;
+    const subprocessPrompt = buildSubprocessReviewPrompt(promptInput);
+    const directPrompt = buildDirectReviewUserPrompt(promptInput);
 
-    const reviewPrompt = [
-      COMBINED_REVIEW_PROMPT,
-      "",
-      "--- Current Memory ---",
-      currentMemory || "(empty)",
-      "",
-      "--- Current User Profile ---",
-      currentUser || "(empty)",
-    ];
+    const finishReview = () => {
+      reviewInProgress = false;
+    };
 
-    if (currentProject !== null) {
-      reviewPrompt.push(
-        "",
-        "--- Current Project Memory ---",
-        currentProject || "(empty)",
-      );
-    }
+    const notifyIfSaved = (saved: boolean) => {
+      if (saved) {
+        ctx.ui.notify("💾 Memory auto-reviewed and updated", "info");
+      }
+    };
 
-    reviewPrompt.push(
-      "",
-      "--- Conversation to Review ---",
-      parts.join("\n\n"),
-    );
+    const runReview = async (): Promise<void> => {
+      if (usesDirectTransport(config)) {
+        const directResult = await runDirectReview(
+          ctx as Pick<ExtensionContext, "model" | "modelRegistry">,
+          store,
+          projectStore,
+          { userPrompt: directPrompt, config, timeoutMs: 120000 },
+          dbManager,
+          projectName,
+        );
 
-    // Fire-and-forget: do NOT await. The review runs in a subprocess;
-    // blocking turn_end would freeze the interactive chat.
-    // Notifications are delivered via .then() once the subprocess completes.
-    //
-    // We intentionally omit ctx.signal — the signal is tied to the turn
-    // lifetime and would abort the subprocess before it finishes now that
-    // we're not awaiting. The timeout (120s) provides its own safety net.
-    const reviewPromise = execChildPrompt(pi, reviewPrompt.join("\n"), config, {
-      signal: undefined,
-      timeoutMs: 120000,
-    });
-
-    reviewPromise
-      .then((result) => {
-        reviewInProgress = false;
-        if (result.code === 0 && result.stdout) {
-          const output = result.stdout.trim();
-          if (output && !output.toLowerCase().includes("nothing to save")) {
-            ctx.ui.notify("💾 Memory auto-reviewed and updated", "info");
-          }
+        if (directResult.ok) {
+          notifyIfSaved(shouldNotifyDirect(directResult));
+          return;
         }
-        // Auto-review is best-effort. Non-zero exits are silently skipped —
-        // common on Windows where pi CLI may resolve differently. The next
-        // review cycle will retry.
-      })
+
+        if (directResult.fallbackReason === "empty") {
+          return;
+        }
+      }
+
+      const subprocessResult = await runSubprocessReview(pi, subprocessPrompt, config, execChild);
+      if (subprocessResult.code === 0) {
+        notifyIfSaved(shouldNotifySubprocess(subprocessResult.stdout));
+      }
+    };
+
+    runReview()
       .catch(() => {
-        // Best-effort: subprocess failures (timeout, signal, spawn errors)
-        // are silently ignored. The next review cycle will retry.
-        reviewInProgress = false;
-      });
+        // Best-effort only
+      })
+      .finally(finishReview);
   });
 }

--- a/src/handlers/review-memory-ops.ts
+++ b/src/handlers/review-memory-ops.ts
@@ -1,0 +1,463 @@
+/**
+ * Parse and apply structured memory operations from direct background review.
+ */
+
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { complete, type Message } from "@earendil-works/pi-ai/compat";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { DIRECT_REVIEW_SYSTEM_PROMPT } from "../constants.js";
+import { MemoryStore } from "../store/memory-store.js";
+import { DatabaseManager } from "../store/db.js";
+import {
+  formatFailureMemoryContent,
+  removeExactSyncedMemories,
+  removeSyncedMemories,
+  replaceSyncedMemories,
+  syncMemoryEntry,
+} from "../store/sqlite-memory-store.js";
+import type { MemoryCategory, MemoryConfig, MemoryResult, ThinkingLevel } from "../types.js";
+
+export interface ReviewMemoryOperation {
+  action: "add" | "replace" | "remove";
+  target: "memory" | "user" | "project" | "failure";
+  content?: string;
+  old_text?: string;
+  category?: MemoryCategory;
+  failure_reason?: string;
+}
+
+export interface ApplyReviewOperationsResult {
+  appliedCount: number;
+  skippedCount: number;
+}
+
+export interface DirectReviewResult {
+  ok: boolean;
+  appliedCount: number;
+  fallbackReason?: "no_model" | "no_auth" | "aborted" | "parse_error" | "provider_error" | "empty";
+  error?: string;
+}
+
+export interface RunDirectBackgroundReviewOptions {
+  userPrompt: string;
+  config: Pick<MemoryConfig, "llmModelOverride" | "llmThinkingOverride">;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+type ReviewLlmConfig = Pick<MemoryConfig, "llmModelOverride" | "llmThinkingOverride">;
+
+function findExactModelReferenceMatch(modelReference: string, availableModels: Model<Api>[]): Model<Api> | undefined {
+  const trimmedReference = modelReference.trim();
+  if (!trimmedReference) return undefined;
+
+  const normalizedReference = trimmedReference.toLowerCase();
+  const canonicalMatches = availableModels.filter(
+    (model) => `${model.provider}/${model.id}`.toLowerCase() === normalizedReference,
+  );
+  if (canonicalMatches.length === 1) return canonicalMatches[0];
+  if (canonicalMatches.length > 1) return undefined;
+
+  const slashIndex = trimmedReference.indexOf("/");
+  if (slashIndex !== -1) {
+    const provider = trimmedReference.substring(0, slashIndex).trim();
+    const modelId = trimmedReference.substring(slashIndex + 1).trim();
+    if (provider && modelId) {
+      const providerMatches = availableModels.filter(
+        (model) => model.provider.toLowerCase() === provider.toLowerCase()
+          && model.id.toLowerCase() === modelId.toLowerCase(),
+      );
+      if (providerMatches.length === 1) return providerMatches[0];
+    }
+  }
+
+  const idMatches = availableModels.filter((model) => model.id.toLowerCase() === normalizedReference);
+  return idMatches.length === 1 ? idMatches[0] : undefined;
+}
+
+function normalizedModelOverride(config: ReviewLlmConfig): string | undefined {
+  const trimmed = config.llmModelOverride?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function effectiveThinkingOverride(config: ReviewLlmConfig): ThinkingLevel | undefined {
+  return config.llmThinkingOverride ?? (normalizedModelOverride(config) ? "off" : undefined);
+}
+
+function thinkingEnabledForLevel(level: ThinkingLevel | undefined): boolean {
+  return !!level && level !== "off";
+}
+
+type ReviewModelRegistry = ExtensionContext["modelRegistry"];
+
+export function resolveReviewModel(
+  ctxModel: Model<Api> | undefined,
+  modelRegistry: ReviewModelRegistry,
+  config: ReviewLlmConfig,
+): Model<Api> | undefined {
+  const override = normalizedModelOverride(config);
+  if (override) {
+    const matched = findExactModelReferenceMatch(override, modelRegistry.getAll());
+    if (matched) return matched;
+  }
+  return ctxModel;
+}
+
+function extractJsonPayload(text: string): unknown {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    // continue
+  }
+
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fenced?.[1]) {
+    try {
+      return JSON.parse(fenced[1].trim());
+    } catch {
+      // continue
+    }
+  }
+
+  const start = trimmed.indexOf("{");
+  const end = trimmed.lastIndexOf("}");
+  if (start >= 0 && end > start) {
+    try {
+      return JSON.parse(trimmed.slice(start, end + 1));
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function isMemoryCategory(value: unknown): value is MemoryCategory {
+  return value === "failure"
+    || value === "correction"
+    || value === "insight"
+    || value === "preference"
+    || value === "convention"
+    || value === "tool-quirk";
+}
+
+function isReviewTarget(value: unknown): value is ReviewMemoryOperation["target"] {
+  return value === "memory" || value === "user" || value === "project" || value === "failure";
+}
+
+function isReviewAction(value: unknown): value is ReviewMemoryOperation["action"] {
+  return value === "add" || value === "replace" || value === "remove";
+}
+
+export function parseReviewOperations(text: string): ReviewMemoryOperation[] | null {
+  if (/nothing to save/i.test(text) && !text.includes("{")) {
+    return [];
+  }
+
+  const payload = extractJsonPayload(text);
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+
+  const operations = (payload as { operations?: unknown }).operations;
+  if (!Array.isArray(operations)) return null;
+
+  const parsed: ReviewMemoryOperation[] = [];
+  for (const item of operations) {
+    if (!item || typeof item !== "object") continue;
+    const op = item as Record<string, unknown>;
+    if (!isReviewAction(op.action) || !isReviewTarget(op.target)) continue;
+
+    const operation: ReviewMemoryOperation = {
+      action: op.action,
+      target: op.target,
+    };
+    if (typeof op.content === "string") operation.content = op.content;
+    if (typeof op.old_text === "string") operation.old_text = op.old_text;
+    if (isMemoryCategory(op.category)) operation.category = op.category;
+    if (typeof op.failure_reason === "string") operation.failure_reason = op.failure_reason;
+    parsed.push(operation);
+  }
+
+  return parsed;
+}
+
+function sqliteProjectFor(
+  rawTarget: ReviewMemoryOperation["target"],
+  projectName?: string | null,
+): string | null | undefined {
+  if (rawTarget === "project") return projectName?.trim() || null;
+  if (rawTarget === "memory" || rawTarget === "user" || rawTarget === "failure") return null;
+  return undefined;
+}
+
+function sqliteTargetFor(rawTarget: ReviewMemoryOperation["target"]): "memory" | "user" | "failure" {
+  return rawTarget === "user" ? "user" : rawTarget === "failure" ? "failure" : "memory";
+}
+
+async function syncAdd(
+  rawTarget: ReviewMemoryOperation["target"],
+  content: string,
+  category: MemoryCategory | undefined,
+  failureReason: string | undefined,
+  dbManager: DatabaseManager | null,
+  projectName?: string | null,
+): Promise<void> {
+  if (!dbManager) return;
+
+  const sqliteTarget = sqliteTargetFor(rawTarget);
+  const sqliteProject = sqliteProjectFor(rawTarget, projectName);
+
+  if (rawTarget === "failure") {
+    const failureCategory = category ?? "failure";
+    syncMemoryEntry(dbManager, {
+      content: formatFailureMemoryContent(content, {
+        category: failureCategory,
+        failureReason,
+      }),
+      target: "failure",
+      project: sqliteProject ?? null,
+      category: failureCategory,
+      failureReason,
+    });
+    return;
+  }
+
+  syncMemoryEntry(dbManager, {
+    content,
+    target: sqliteTarget,
+    project: sqliteProject ?? null,
+  });
+}
+
+async function syncReplace(
+  rawTarget: ReviewMemoryOperation["target"],
+  oldText: string,
+  newContent: string,
+  dbManager: DatabaseManager | null,
+  projectName?: string | null,
+): Promise<void> {
+  if (!dbManager) return;
+  replaceSyncedMemories(dbManager, oldText, {
+    content: newContent,
+    target: sqliteTargetFor(rawTarget),
+    project: sqliteProjectFor(rawTarget, projectName),
+  });
+}
+
+async function syncRemove(
+  rawTarget: ReviewMemoryOperation["target"],
+  oldText: string,
+  dbManager: DatabaseManager | null,
+  projectName?: string | null,
+): Promise<void> {
+  if (!dbManager) return;
+  removeSyncedMemories(dbManager, oldText, {
+    target: sqliteTargetFor(rawTarget),
+    project: sqliteProjectFor(rawTarget, projectName),
+  });
+}
+
+async function syncEvictions(
+  rawTarget: ReviewMemoryOperation["target"],
+  evictedEntries: string[] | undefined,
+  dbManager: DatabaseManager | null,
+  projectName?: string | null,
+): Promise<void> {
+  if (!dbManager || !evictedEntries?.length) return;
+  for (const entry of evictedEntries) {
+    try {
+      removeExactSyncedMemories(dbManager, entry, {
+        target: sqliteTargetFor(rawTarget),
+        project: sqliteProjectFor(rawTarget, projectName),
+      });
+    } catch {
+      // best effort
+    }
+  }
+}
+
+export async function applyReviewOperations(
+  store: MemoryStore,
+  projectStore: MemoryStore | null,
+  operations: ReviewMemoryOperation[],
+  dbManager: DatabaseManager | null = null,
+  projectName?: string | null,
+): Promise<ApplyReviewOperationsResult> {
+  let appliedCount = 0;
+  let skippedCount = 0;
+
+  for (const op of operations) {
+    if (op.target === "project" && !projectStore) {
+      skippedCount++;
+      continue;
+    }
+
+    const rawTarget = op.target;
+    const memoryTarget = rawTarget === "project" ? "memory" : rawTarget === "failure" ? "failure" : rawTarget;
+    const activeStore = rawTarget === "project" ? projectStore! : store;
+
+    let result: MemoryResult;
+    switch (op.action) {
+      case "add": {
+        if (!op.content?.trim()) {
+          skippedCount++;
+          continue;
+        }
+        if (rawTarget === "failure") {
+          const category = op.category ?? "failure";
+          result = await activeStore.addFailure(op.content, {
+            category,
+            failureReason: op.failure_reason,
+          });
+          if (result.success) {
+            await syncAdd(rawTarget, op.content, category, op.failure_reason, dbManager, projectName);
+            appliedCount++;
+          } else {
+            skippedCount++;
+          }
+        } else {
+          result = await activeStore.add(memoryTarget, op.content);
+          if (result.success) {
+            await syncEvictions(rawTarget, result.evicted_entries, dbManager, projectName);
+            await syncAdd(rawTarget, op.content, undefined, undefined, dbManager, projectName);
+            appliedCount++;
+          } else {
+            skippedCount++;
+          }
+        }
+        break;
+      }
+      case "replace": {
+        if (!op.old_text || !op.content?.trim()) {
+          skippedCount++;
+          continue;
+        }
+        result = await activeStore.replace(memoryTarget, op.old_text, op.content);
+        if (result.success) {
+          await syncReplace(rawTarget, op.old_text, op.content, dbManager, projectName);
+          appliedCount++;
+        } else {
+          skippedCount++;
+        }
+        break;
+      }
+      case "remove": {
+        if (!op.old_text) {
+          skippedCount++;
+          continue;
+        }
+        result = await activeStore.remove(memoryTarget, op.old_text);
+        if (result.success) {
+          await syncRemove(rawTarget, op.old_text, dbManager, projectName);
+          appliedCount++;
+        } else {
+          skippedCount++;
+        }
+        break;
+      }
+      default:
+        skippedCount++;
+    }
+  }
+
+  return { appliedCount, skippedCount };
+}
+
+function responseText(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((block): block is { type: "text"; text: string } => (
+      !!block && typeof block === "object" && (block as { type?: string }).type === "text"
+    ))
+    .map((block) => block.text)
+    .join("\n");
+}
+
+export async function runDirectBackgroundReview(
+  ctx: Pick<ExtensionContext, "model" | "modelRegistry">,
+  store: MemoryStore,
+  projectStore: MemoryStore | null,
+  options: RunDirectBackgroundReviewOptions,
+  dbManager: DatabaseManager | null = null,
+  projectName?: string | null,
+): Promise<DirectReviewResult> {
+  const model = resolveReviewModel(ctx.model, ctx.modelRegistry, options.config);
+  if (!model) {
+    return { ok: false, appliedCount: 0, fallbackReason: "no_model" };
+  }
+
+  const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+  if (!auth.ok || !auth.apiKey) {
+    return {
+      ok: false,
+      appliedCount: 0,
+      fallbackReason: "no_auth",
+      error: auth.ok ? `No API key for ${model.provider}` : auth.error,
+    };
+  }
+
+  const controller = new AbortController();
+  const timeoutMs = options.timeoutMs ?? 120000;
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  if (options.signal) {
+    options.signal.addEventListener("abort", () => controller.abort(), { once: true });
+  }
+
+  const thinking = effectiveThinkingOverride(options.config);
+  const userMessage: Message = {
+    role: "user",
+    content: [{ type: "text", text: options.userPrompt }],
+    timestamp: Date.now(),
+  };
+
+  try {
+    const response = await complete(
+      model,
+      { systemPrompt: DIRECT_REVIEW_SYSTEM_PROMPT, messages: [userMessage] },
+      {
+        apiKey: auth.apiKey,
+        headers: auth.headers,
+        signal: controller.signal,
+        thinkingEnabled: thinkingEnabledForLevel(thinking),
+      },
+    );
+
+    if (response.stopReason === "aborted") {
+      return { ok: false, appliedCount: 0, fallbackReason: "aborted" };
+    }
+
+    const text = responseText(response.content);
+    const operations = parseReviewOperations(text);
+    if (operations === null) {
+      return { ok: false, appliedCount: 0, fallbackReason: "parse_error" };
+    }
+    if (operations.length === 0) {
+      return { ok: true, appliedCount: 0, fallbackReason: "empty" };
+    }
+
+    const { appliedCount } = await applyReviewOperations(
+      store,
+      projectStore,
+      operations,
+      dbManager,
+      projectName,
+    );
+    return { ok: true, appliedCount };
+  } catch (err) {
+    if (controller.signal.aborted) {
+      return { ok: false, appliedCount: 0, fallbackReason: "aborted" };
+    }
+    return {
+      ok: false,
+      appliedCount: 0,
+      fallbackReason: "provider_error",
+      error: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/handlers/review-memory-ops.ts
+++ b/src/handlers/review-memory-ops.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Api, Model } from "@earendil-works/pi-ai";
-import { complete, type Message } from "@earendil-works/pi-ai/compat";
+import { completeSimple, type Message, type SimpleStreamOptions } from "@earendil-works/pi-ai/compat";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { DIRECT_REVIEW_SYSTEM_PROMPT } from "../constants.js";
 import { MemoryStore } from "../store/memory-store.js";
@@ -84,11 +84,29 @@ function effectiveThinkingOverride(config: ReviewLlmConfig): ThinkingLevel | und
   return config.llmThinkingOverride ?? (normalizedModelOverride(config) ? "off" : undefined);
 }
 
-function thinkingEnabledForLevel(level: ThinkingLevel | undefined): boolean {
-  return !!level && level !== "off";
-}
-
 type ReviewModelRegistry = ExtensionContext["modelRegistry"];
+
+export function buildDirectReviewCompletionOptions(
+  model: Model<Api>,
+  auth: {
+    apiKey: string;
+    headers?: Record<string, string>;
+    env?: Record<string, string>;
+  },
+  thinking: ThinkingLevel | undefined,
+  signal: AbortSignal,
+): SimpleStreamOptions {
+  const options: SimpleStreamOptions = {
+    apiKey: auth.apiKey,
+    headers: auth.headers,
+    env: auth.env,
+    signal,
+  };
+  if (model.reasoning && thinking && thinking !== "off") {
+    options.reasoning = thinking;
+  }
+  return options;
+}
 
 export function resolveReviewModel(
   ctxModel: Model<Api> | undefined,
@@ -415,15 +433,15 @@ export async function runDirectBackgroundReview(
   };
 
   try {
-    const response = await complete(
+    const response = await completeSimple(
       model,
       { systemPrompt: DIRECT_REVIEW_SYSTEM_PROMPT, messages: [userMessage] },
-      {
-        apiKey: auth.apiKey,
-        headers: auth.headers,
-        signal: controller.signal,
-        thinkingEnabled: thinkingEnabledForLevel(thinking),
-      },
+      buildDirectReviewCompletionOptions(
+        model,
+        { apiKey: auth.apiKey, headers: auth.headers, env: auth.env },
+        thinking,
+        controller.signal,
+      ),
     );
 
     if (response.stopReason === "aborted") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,7 +188,10 @@ export default function (pi: ExtensionAPI) {
   registerSkillTool(pi, skillStore);
 
   // ── 5. Setup background learning loop (with tool-call-aware nudge) ──
-  setupBackgroundReview(pi, store, projectStore, config);
+  setupBackgroundReview(pi, store, projectStore, config, {
+    dbManager,
+    projectName: projectName || null,
+  });
 
   // ── 6. Setup session-end flush ──
   setupSessionFlush(pi, store, projectStore, config);

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,8 @@ export type SessionSearchVariant = "legacy" | "anchors";
 
 export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
 
+export type ReviewTransport = "direct" | "subprocess";
+
 export interface SessionSearchConfig {
   /** Session search implementation variant. Default: legacy */
   variant: SessionSearchVariant;
@@ -34,6 +36,8 @@ export interface MemoryConfig {
   reviewRecentMessages?: number;
   /** Enable background learning loop. Default: true */
   reviewEnabled: boolean;
+  /** How background review invokes the LLM. Default: direct */
+  reviewTransport?: ReviewTransport;
   /** Flush memories before compaction. Default: true */
   flushOnCompact: boolean;
   /** Flush memories on session shutdown. Default: true */

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -23,6 +23,7 @@ describe("loadConfig", () => {
     assert.strictEqual(config.nudgeInterval, 10);
     assert.strictEqual(config.reviewRecentMessages, 0);
     assert.strictEqual(config.reviewEnabled, true);
+    assert.strictEqual(config.reviewTransport, "direct");
     assert.strictEqual(config.flushOnCompact, true);
     assert.strictEqual(config.flushOnShutdown, true);
     assert.strictEqual(config.flushMinTurns, 6);
@@ -265,6 +266,20 @@ describe("loadConfig", () => {
       const config = loadConfig(TEST_CONFIG_PATH);
       assert.deepStrictEqual(config.sessionSearch, { variant });
     }
+  });
+
+  it("accepts valid reviewTransport values and ignores invalid ones", () => {
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+
+    for (const transport of ["direct", "subprocess"] as const) {
+      fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({ reviewTransport: transport }));
+      const config = loadConfig(TEST_CONFIG_PATH);
+      assert.strictEqual(config.reviewTransport, transport);
+    }
+
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({ reviewTransport: "branch" }));
+    const invalid = loadConfig(TEST_CONFIG_PATH);
+    assert.strictEqual(invalid.reviewTransport, "direct");
   });
 
   it("accepts valid llmThinkingOverride values and ignores invalid ones", () => {

--- a/tests/handlers/background-review.test.ts
+++ b/tests/handlers/background-review.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert";
-import { setupBackgroundReview } from "../../src/handlers/background-review.js";
+import {
+  buildDirectReviewUserPrompt,
+  buildSubprocessReviewPrompt,
+  setupBackgroundReview,
+} from "../../src/handlers/background-review.js";
 import { resolveChildPiInvocation } from "../../src/handlers/pi-child-process.js";
+import type { DirectReviewResult } from "../../src/handlers/review-memory-ops.js";
 
 // ─── Mock infrastructure ───
 
@@ -12,6 +17,7 @@ interface CallLog {
 
 let handlers: Record<string, Function[]>;
 let execCalls: any[];
+let directCalls: any[];
 let notifyCalls: any[];
 
 function createMockPi(execReturn?: { code: number; stdout: string; stderr: string }) {
@@ -58,6 +64,7 @@ function makeCtx(branch: any[] = [], overrides: Record<string, any> = {}) {
 
 const defaultConfig = {
   reviewEnabled: true,
+  reviewTransport: "subprocess" as const,
   nudgeInterval: 10,
   reviewRecentMessages: 0,
   flushMinTurns: 6,
@@ -133,8 +140,24 @@ describe("setupBackgroundReview", () => {
   beforeEach(() => {
     handlers = {};
     execCalls = [];
+    directCalls = [];
     notifyCalls = [];
   });
+
+  function setupWithDirectDeps(
+    pi: ReturnType<typeof createMockPi>,
+    directResult: DirectReviewResult,
+    config = { ...defaultConfig, reviewTransport: "direct" as const },
+  ) {
+    setupBackgroundReview(pi, mockStore, null, config, {
+      deps: {
+        runDirectReview: async (...args: any[]) => {
+          directCalls.push(args);
+          return directResult;
+        },
+      },
+    });
+  }
 
   it("increments user turn count on message_end for user messages", () => {
     const pi = createMockPi();
@@ -659,6 +682,87 @@ describe("setupBackgroundReview", () => {
     await settle();
 
     assert.strictEqual(execCalls.length, 0, "exec should NOT be called — no toolCall blocks, turn threshold not met");
+  });
+
+  it("uses direct review by default and does not call subprocess", async () => {
+    const pi = createMockPi();
+    setupWithDirectDeps(pi, { ok: true, appliedCount: 1 }, {
+      ...defaultConfig,
+      reviewTransport: "direct",
+    });
+
+    fireMessageEnd("user");
+    fireMessageEnd("user");
+    fireMessageEnd("user");
+
+    for (let i = 0; i < 10; i++) {
+      fireTurnEnd();
+    }
+    await settle();
+
+    assert.strictEqual(directCalls.length, 1, "direct review should run once");
+    assert.strictEqual(execCalls.length, 0, "subprocess should not run on successful direct review");
+    const reviewNotify = notifyCalls.find((n) => n.msg.includes("Memory auto-reviewed"));
+    assert.ok(reviewNotify, "should notify when direct review applies memory");
+  });
+
+  it("falls back to subprocess when direct review cannot run", async () => {
+    const pi = createMockPi();
+    setupWithDirectDeps(pi, { ok: false, appliedCount: 0, fallbackReason: "no_model" }, {
+      ...defaultConfig,
+      reviewTransport: "direct",
+    });
+
+    fireMessageEnd("user");
+    fireMessageEnd("user");
+    fireMessageEnd("user");
+
+    for (let i = 0; i < 10; i++) {
+      fireTurnEnd();
+    }
+    await settle();
+
+    assert.strictEqual(directCalls.length, 1, "direct review should be attempted first");
+    assert.strictEqual(execCalls.length, 1, "subprocess should run as fallback");
+  });
+
+  it("does not notify when direct review returns no operations", async () => {
+    const pi = createMockPi();
+    setupWithDirectDeps(pi, { ok: true, appliedCount: 0, fallbackReason: "empty" }, {
+      ...defaultConfig,
+      reviewTransport: "direct",
+    });
+
+    fireMessageEnd("user");
+    fireMessageEnd("user");
+    fireMessageEnd("user");
+
+    for (let i = 0; i < 10; i++) {
+      fireTurnEnd();
+    }
+    await settle();
+
+    const reviewNotify = notifyCalls.find((n) => n.msg.includes("Memory auto-reviewed"));
+    assert.strictEqual(reviewNotify, undefined, "empty direct review should not notify");
+    assert.strictEqual(execCalls.length, 0, "empty direct review should not fall back");
+  });
+
+  it("builds separate prompts for direct and subprocess transports", () => {
+    const input = {
+      parts: ["[USER] hello", "[ASSISTANT] hi"],
+      currentMemory: "uses pnpm",
+      currentUser: "likes TypeScript",
+      currentProject: "monorepo layout",
+    };
+
+    const subprocessPrompt = buildSubprocessReviewPrompt(input);
+    const directPrompt = buildDirectReviewUserPrompt(input);
+
+    assert.match(subprocessPrompt, /save using the memory tool/i);
+    assert.match(directPrompt, /Conversation to Review/);
+    assert.doesNotMatch(directPrompt, /save using the memory tool/i);
+    assert.ok(subprocessPrompt.includes("uses pnpm"));
+    assert.ok(directPrompt.includes("monorepo layout"));
   });
 
   it("falls back gracefully if getBranch throws", async () => {

--- a/tests/handlers/review-memory-ops.test.ts
+++ b/tests/handlers/review-memory-ops.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { MemoryStore } from "../../src/store/memory-store.js";
+import {
+  applyReviewOperations,
+  parseReviewOperations,
+} from "../../src/handlers/review-memory-ops.js";
+
+describe("parseReviewOperations", () => {
+  it("parses valid JSON operations", () => {
+    const parsed = parseReviewOperations(JSON.stringify({
+      operations: [
+        { action: "add", target: "memory", content: "uses pnpm" },
+      ],
+    }));
+
+    assert.deepStrictEqual(parsed, [
+      { action: "add", target: "memory", content: "uses pnpm" },
+    ]);
+  });
+
+  it("returns empty array for nothing-to-save text", () => {
+    assert.deepStrictEqual(parseReviewOperations("Nothing to save."), []);
+  });
+
+  it("returns null for invalid JSON", () => {
+    assert.strictEqual(parseReviewOperations("not json at all"), null);
+  });
+
+  it("extracts JSON from fenced blocks", () => {
+    const parsed = parseReviewOperations("```json\n{\"operations\":[{\"action\":\"add\",\"target\":\"user\",\"content\":\"prefers dark mode\"}]}\n```");
+    assert.deepStrictEqual(parsed, [
+      { action: "add", target: "user", content: "prefers dark mode" },
+    ]);
+  });
+});
+
+describe("applyReviewOperations", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "review-ops-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("applies add operations to memory store", async () => {
+    const store = new MemoryStore({
+      memoryDir: tmpDir,
+      memoryCharLimit: 5000,
+      userCharLimit: 5000,
+      autoConsolidate: true,
+    });
+    await store.loadFromDisk();
+
+    const result = await applyReviewOperations(store, null, [
+      { action: "add", target: "memory", content: "prefers biome over eslint" },
+    ]);
+
+    assert.strictEqual(result.appliedCount, 1);
+    assert.strictEqual(result.skippedCount, 0);
+    assert.ok(store.getMemoryEntries().some((entry) => entry.includes("prefers biome over eslint")));
+  });
+
+  it("skips project operations when project store is unavailable", async () => {
+    const store = new MemoryStore({
+      memoryDir: tmpDir,
+      memoryCharLimit: 5000,
+      userCharLimit: 5000,
+      autoConsolidate: true,
+    });
+    await store.loadFromDisk();
+
+    const result = await applyReviewOperations(store, null, [
+      { action: "add", target: "project", content: "api uses /v2" },
+    ]);
+
+    assert.strictEqual(result.appliedCount, 0);
+    assert.strictEqual(result.skippedCount, 1);
+  });
+});

--- a/tests/handlers/review-memory-ops.test.ts
+++ b/tests/handlers/review-memory-ops.test.ts
@@ -4,10 +4,62 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { MemoryStore } from "../../src/store/memory-store.js";
+import type { Api, Model } from "@earendil-works/pi-ai";
 import {
   applyReviewOperations,
+  buildDirectReviewCompletionOptions,
   parseReviewOperations,
 } from "../../src/handlers/review-memory-ops.js";
+
+function mockModel(reasoning: boolean): Model<Api> {
+  return {
+    id: "test-model",
+    provider: "test",
+    api: "openai-completions",
+    reasoning,
+  } as Model<Api>;
+}
+
+describe("buildDirectReviewCompletionOptions", () => {
+  it("forwards auth env and preserves reasoning level", () => {
+    const signal = new AbortController().signal;
+    const options = buildDirectReviewCompletionOptions(
+      mockModel(true),
+      {
+        apiKey: "sk-test",
+        headers: { "X-Test": "1" },
+        env: { CUSTOM_BASE_URL: "https://proxy.example" },
+      },
+      "minimal",
+      signal,
+    );
+
+    assert.strictEqual(options.apiKey, "sk-test");
+    assert.deepStrictEqual(options.headers, { "X-Test": "1" });
+    assert.deepStrictEqual(options.env, { CUSTOM_BASE_URL: "https://proxy.example" });
+    assert.strictEqual(options.reasoning, "minimal");
+    assert.strictEqual(options.signal, signal);
+  });
+
+  it("omits reasoning when thinking is off or model does not support it", () => {
+    const signal = new AbortController().signal;
+    const off = buildDirectReviewCompletionOptions(
+      mockModel(true),
+      { apiKey: "sk-test" },
+      "off",
+      signal,
+    );
+    const nonReasoning = buildDirectReviewCompletionOptions(
+      mockModel(false),
+      { apiKey: "sk-test" },
+      "high",
+      signal,
+    );
+
+    assert.strictEqual(off.reasoning, undefined);
+    assert.strictEqual(nonReasoning.reasoning, undefined);
+  });
+});
 
 describe("parseReviewOperations", () => {
   it("parses valid JSON operations", () => {


### PR DESCRIPTION
## Summary

Implements [issue #89](https://github.com/chandra447/pi-hermes-memory/issues/89): background memory review no longer spawns a cold `pi -p` subprocess by default. Instead it uses an in-process side-channel `complete()` call (the same pattern as Pi's `handoff` extension), applies structured memory operations directly, and preserves the parent session's LLM prefix cache.

Closes #89

---

## Problem

Background review previously ran via `pi.exec("pi", ["-p", "--no-session", "--no-extensions", "-e", own, ...])` on every nudge. Each review:

- Started a **new Pi process** with a fresh system prompt and tool surface
- Could not reuse the parent session's **LLM prefix cache** (cold start every nudge)
- Added process spawn overhead on top of the LLM call itself

The parent session was already partially protected (frozen memory snapshot at `session_start`), but the review subprocess itself paid full cold-cache cost on every cycle.

---

## Solution

Add a **`direct` transport** that runs review outside the main agent loop:

1. Build a tight review payload from the current branch (unchanged)
2. Call `modelRegistry.getApiKeyAndHeaders()` + `complete()` with a small review-only system prompt
3. Parse structured JSON memory operations from the response
4. Apply writes via `MemoryStore` + SQLite sync (same end result as the memory tool)
5. Fall back to the existing subprocess when direct path cannot run

New config: `reviewTransport: "direct" | "subprocess"` (default: **`direct`**).

---

## Architecture

### Before (subprocess only)

```mermaid
sequenceDiagram
    participant User as Parent Pi session
    participant Ext as pi-hermes-memory
    participant Child as Child pi -p process
    participant LLM as LLM provider

    User->>Ext: turn_end (nudge threshold met)
    Ext->>Ext: Build conversation snapshot
    Ext-->>Child: pi.exec(-p --no-session --no-extensions)
    Note over Child: Cold system prompt + tools
    Child->>LLM: Full agent turn + memory tool
    LLM-->>Child: Tool calls / response
    Child->>Child: Write MEMORY.md via memory tool
    Child-->>Ext: exit code + stdout
    Ext->>User: ui.notify (best effort)

    Note over User: Frozen snapshot unchanged
    Note over Child: No prefix cache reuse
```

### After (direct default + subprocess fallback)

```mermaid
sequenceDiagram
    participant User as Parent Pi session
    participant Ext as pi-hermes-memory
    participant LLM as LLM provider
    participant Child as Child pi -p (fallback)

    User->>Ext: turn_end (nudge threshold met)
    Ext->>Ext: Build review payload

    alt reviewTransport = direct (default)
        Ext->>LLM: complete(reviewSystemPrompt, userPayload)
        Note over User: Agent loop untouched
        Note over User: Tools + system prompt unchanged
        LLM-->>Ext: JSON memory operations
        Ext->>Ext: applyReviewOperations → MemoryStore + SQLite
        Ext->>User: ui.notify if ops applied
    else direct unavailable (no model / no auth / parse error)
        Ext-->>Child: pi.exec (existing subprocess path)
        Child->>LLM: Full agent turn
        Child-->>Ext: exit code + stdout
    end
```

### Transport decision flow

```mermaid
flowchart TD
    A[turn_end: nudge threshold met] --> B{reviewTransport?}
    B -->|direct default| C[runDirectBackgroundReview]
    B -->|subprocess| G[pi.exec subprocess]

    C --> D{Result}
    D -->|ok + ops applied| E[Notify user]
    D -->|ok + empty ops| F[Silent — nothing to save]
    D -->|fail: no model / no auth / parse / provider| G

    G --> H{exit code 0?}
    H -->|yes + saved| E
    H -->|otherwise| I[Silent — retry next cycle]

    subgraph preserved [Unchanged during direct review]
        P1[Frozen memory snapshot]
        P2[Active tool set]
        P3[Main branch history]
    end
```

---

## What this enhances

| Area | Before | After |
|------|--------|-------|
| Parent LLM prefix cache | Already preserved via frozen snapshot | Still preserved; direct path also avoids touching agent loop |
| Review LLM call cost | Cold subprocess every nudge | Single `complete()` with minimal context |
| Process overhead | Spawn `pi -p` per review | No subprocess on happy path |
| Main conversation branch | Isolated (subprocess) | Still isolated — review ops never appended to user branch |
| Tool surface during review | Child loads `--no-extensions -e own` | Direct path: no tool loop; extension applies ops in code |
| Backward compatibility | — | `reviewTransport: "subprocess"` restores old behavior; auto-fallback if direct fails |

---

## Pi design alignment

This follows Pi's extension principles discussed in [#89](https://github.com/chandra447/pi-hermes-memory/issues/89#issuecomment-4825878332):

- **Context discipline** — side work uses an explicit, minimal context payload, not the main agent turn
- **Stable main loop** — no `setActiveTools()` or `before_agent_start` mutation mid-session for review
- **No branch pollution** — review turns are not queued on the user's conversation path
- **Subprocess as fallback** — Pi allows spawning separate Pi instances for isolation; we keep that path when direct review cannot run

---

## Implementation details

### New files

- `src/handlers/review-memory-ops.ts` — model resolution, `complete()` call, JSON parsing, `applyReviewOperations()`
- `tests/handlers/review-memory-ops.test.ts` — parser + store apply tests

### Modified files

- `src/handlers/background-review.ts` — transport selection, separate prompts for direct vs subprocess, injectable deps for testing
- `src/constants.ts` — `DIRECT_REVIEW_SYSTEM_PROMPT` (structured JSON output schema)
- `src/types.ts` / `src/config.ts` — `ReviewTransport` type + `reviewTransport` config (default `direct`)
- `src/index.ts` — pass `dbManager` + `projectName` into background review for SQLite sync on direct path

### Structured review response

The direct path asks the LLM for JSON instead of calling the memory tool:

```json
{
  "operations": [
    {
      "action": "add",
      "target": "memory",
      "content": "User prefers pnpm over npm"
    }
  ]
}
```

Supported: `add` / `replace` / `remove` on `memory` | `user` | `project` | `failure` targets (mirrors memory tool semantics).

### Config

```json
{
  "reviewTransport": "direct"
}
```

Set `"subprocess"` to force the legacy `pi.exec` path only.

---

## Testing

- All **36 test files** pass
- New tests: direct transport, subprocess fallback, empty-ops silence, prompt builders, JSON parser, store apply
- Existing subprocess tests unchanged (`reviewTransport: "subprocess"` in test fixtures)

---

## Out of scope (future)

- Rolling direct transport to correction save, consolidation, and session flush (same helper can be reused)
- Programmatic session-tree branching for review (blocked on Pi extension API today)

---

## Checklist

- [x] Default transport is `direct`
- [x] Subprocess fallback on direct failure
- [x] Frozen parent snapshot not reloaded mid-session after review writes
- [x] SQLite sync on direct path (via `dbManager` passed from `index.ts`)
- [x] Tests for both transports