### PR TITLE
fix: detect external file writes before memory mutations (consolidation race)

### DIFF
--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -32,6 +32,8 @@ export class MemoryStore {
   private userEntries: string[] = [];
   private failureEntries: string[] = [];
   private snapshot: MemorySnapshot = { memory: "", user: "" };
+  /** Per-file fingerprint (mtimeMs:size) captured at last load/save — detects external writes. */
+  private fileFingerprints: Record<string, string> = {};
   private consolidator: ((target: "memory" | "user" | "failure", signal?: AbortSignal) => Promise<ConsolidationResult>) | null = null;
 
   constructor(private config: MemoryConfig) {}
@@ -90,6 +92,11 @@ export class MemoryStore {
     this.userEntries = await this.readFile(this.pathFor("user"));
     this.failureEntries = await this.readFile(this.pathFor("failure"));
 
+    for (const target of ["memory", "user", "failure"] as const) {
+      const filePath = this.pathFor(target);
+      this.fileFingerprints[filePath] = await this.fingerprintOf(filePath);
+    }
+
     // Deduplicate preserving order
     this.memoryEntries = [...new Set(this.memoryEntries)];
     this.userEntries = [...new Set(this.userEntries)];
@@ -147,6 +154,12 @@ export class MemoryStore {
 
     const scanError = scanContent(content);
     if (scanError) return { success: false, error: scanError };
+
+    // Guard against external file writes (e.g. a consolidation child process):
+    // re-sync this target from disk before mutating, or the save below would
+    // clobber the newer on-disk state (and our new entry could later be lost
+    // to a loadFromDisk that discards unsaved in-memory changes).
+    await this.syncTargetFromDiskIfChanged(target);
 
     const entries = this.entriesFor(target);
     const limit = this.charLimit(target);
@@ -244,6 +257,9 @@ export class MemoryStore {
     const scanError = scanContent(newContent);
     if (scanError) return { success: false, error: scanError };
 
+    // Re-sync from disk if the file changed externally (see _add).
+    await this.syncTargetFromDiskIfChanged(target);
+
     const entries = this.entriesFor(target);
     // Match against stripped text (entries may have metadata comments)
     const matches = entries.filter((e) => this.stripMetadata(e).includes(oldText));
@@ -284,6 +300,9 @@ export class MemoryStore {
   async remove(target: "memory" | "user" | "failure", oldText: string): Promise<MemoryResult> {
     oldText = normalizeMemoryLookupText(oldText);
     if (!oldText) return { success: false, error: "old_text cannot be empty." };
+
+    // Re-sync from disk if the file changed externally (see _add).
+    await this.syncTargetFromDiskIfChanged(target);
 
     const entries = this.entriesFor(target);
     const matches = entries.filter((e) => this.stripMetadata(e).includes(oldText));
@@ -470,6 +489,32 @@ export class MemoryStore {
     return `${header}\n${bulletList}`;
   }
 
+  /** Fingerprint of a file's current on-disk state; "missing" when unreadable. */
+  private async fingerprintOf(filePath: string): Promise<string> {
+    try {
+      const st = await fs.stat(filePath);
+      return `${st.mtimeMs}:${st.size}`;
+    } catch {
+      return "missing";
+    }
+  }
+
+  /**
+   * If the target's file changed on disk since our last load/save (external
+   * writer: consolidation child process, another pi session, manual edit),
+   * re-read just that target so mutations apply on top of the fresh state
+   * instead of clobbering it with stale in-memory arrays.
+   * Does NOT rebuild the frozen system-prompt snapshot (prompt-cache safety).
+   */
+  private async syncTargetFromDiskIfChanged(target: "memory" | "user" | "failure"): Promise<void> {
+    const filePath = this.pathFor(target);
+    const fp = await this.fingerprintOf(filePath);
+    if (this.fileFingerprints[filePath] === fp) return;
+    const entries = await this.readFile(filePath);
+    this.setEntries(target, [...new Set(entries)]);
+    this.fileFingerprints[filePath] = fp;
+  }
+
   private async readFile(filePath: string): Promise<string[]> {
     try {
       const raw = await fs.readFile(filePath, "utf-8");
@@ -498,6 +543,7 @@ export class MemoryStore {
     try {
       await fs.writeFile(tmpPath, content, "utf-8");
       await fs.rename(tmpPath, filePath);
+      this.fileFingerprints[filePath] = await this.fingerprintOf(filePath);
     } catch (err) {
       try { await fs.unlink(tmpPath); } catch { /* ignore */ }
       throw err;

--- a/tests/store/memory-store.test.ts
+++ b/tests/store/memory-store.test.ts
@@ -775,4 +775,94 @@ describe("MemoryStore", { concurrency: 1 }, () => {
       assert.ok(!memRaw.includes(`${TEST_MARKER} user fact`));
     });
   });
+
+  // ─── External write detection (consolidation race) ───
+
+  describe("external file changes (consolidation race)", () => {
+    /** Ensure the next external write gets a distinct mtime on coarse-grained filesystems. */
+    async function tick(): Promise<void> {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+
+    it("add() after an external rewrite preserves the on-disk state instead of clobbering it", async () => {
+      const store = new MemoryStore(makeConfig());
+      await store.loadFromDisk();
+
+      await store.add("memory", `${TEST_MARKER} stale entry A`);
+      await settle();
+
+      // Simulate a consolidation child process rewriting the file on disk
+      await tick();
+      const consolidated = `${TEST_MARKER} CONSOLIDATED entry <!-- created=2026-01-01, last=2026-01-01 -->`;
+      await writeRaw(memoryPath, consolidated);
+
+      const result = await store.add("memory", `${TEST_MARKER} entry B after consolidation`);
+      await settle();
+
+      assert.ok(result.success);
+      const raw = await readRaw(memoryPath);
+      assert.ok(raw.includes("CONSOLIDATED entry"), "externally-written consolidated content must survive");
+      assert.ok(raw.includes(`${TEST_MARKER} entry B after consolidation`), "new entry must be appended");
+      assert.ok(!raw.includes(`${TEST_MARKER} stale entry A`), "stale pre-consolidation entry must not be resurrected");
+    });
+
+    it("remove() matches entries written externally after the last load", async () => {
+      const store = new MemoryStore(makeConfig());
+      await store.loadFromDisk();
+
+      await store.add("memory", `${TEST_MARKER} original entry`);
+      await settle();
+
+      await tick();
+      const external = `${TEST_MARKER} externally added entry <!-- created=2026-01-01, last=2026-01-01 -->`;
+      const current = await readRaw(memoryPath);
+      await writeRaw(memoryPath, current + ENTRY_DELIMITER + external);
+
+      const result = await store.remove("memory", `${TEST_MARKER} externally added entry`);
+      await settle();
+
+      assert.ok(result.success, "remove should see the externally-added entry");
+      const raw = await readRaw(memoryPath);
+      assert.ok(!raw.includes("externally added entry"));
+      assert.ok(raw.includes(`${TEST_MARKER} original entry`));
+    });
+
+    it("replace() matches entries written externally after the last load", async () => {
+      const store = new MemoryStore(makeConfig());
+      await store.loadFromDisk();
+
+      await tick();
+      const external = `${TEST_MARKER} external entry to replace <!-- created=2026-01-01, last=2026-01-01 -->`;
+      await writeRaw(memoryPath, external);
+
+      const result = await store.replace(
+        "memory",
+        `${TEST_MARKER} external entry to replace`,
+        `${TEST_MARKER} replaced content`,
+      );
+      await settle();
+
+      assert.ok(result.success, "replace should see the externally-written entry");
+      const raw = await readRaw(memoryPath);
+      assert.ok(raw.includes(`${TEST_MARKER} replaced content`));
+      assert.ok(!raw.includes("external entry to replace"));
+      // Original created date must be preserved from the external entry
+      assert.ok(raw.includes("created=2026-01-01"));
+    });
+
+    it("does not reload when the file is unchanged (steady state)", async () => {
+      const store = new MemoryStore(makeConfig());
+      await store.loadFromDisk();
+
+      await store.add("memory", `${TEST_MARKER} first`);
+      await store.add("memory", `${TEST_MARKER} second`);
+      await settle();
+
+      const raw = await readRaw(memoryPath);
+      assert.ok(raw.includes(`${TEST_MARKER} first`));
+      assert.ok(raw.includes(`${TEST_MARKER} second`));
+      const count = raw.split(ENTRY_DELIMITER).filter(Boolean).length;
+      assert.equal(count, 2);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`MemoryStore.add/replace/remove` mutate stale in-memory arrays and save them to disk without checking whether the markdown file was changed by an external writer — a consolidation child process, another pi session, or a manual edit. 

**Real-world impact (reproduced on v0.7.23):** while `/memory-consolidate` is still consolidating one target (child pi processes run up to 180s each), a `memory add` in the live session reports success but the entry is **silently lost** when the file is rewritten from a stale snapshot; conversely, a stale in-session save can clobber freshly consolidated content.

## Fix

- Track a per-file fingerprint (`mtimeMs:size`) at every `loadFromDisk`/`saveToDisk`
- New `syncTargetFromDiskIfChanged()` runs before every mutation (`_add`/`replace`/`remove`): if the fingerprint no longer matches, re-read just that target from disk so the mutation applies on top of the current on-disk state
- The frozen system-prompt snapshot is intentionally **not** rebuilt on re-sync (prompt-cache safety)
- Consolidation children run the same store code, so the race is closed on both sides

Complementary to #97 — that PR prevents duplicate consolidation subprocesses per target; this one protects live-session mutations against any external file writer.

## Verification

- `npm run check` — clean
- `npm test` — all 36 test files pass
- 4 new regression tests in `tests/store/memory-store.test.ts` (`external file changes (consolidation race)`): on unpatched `memory-store.ts` the 3 race tests fail, with the patch all pass

## Repro (before the fix)

1. Fill memory near the limit, run `/memory-consolidate`
2. While a slower target (e.g. `failure`) is still consolidating, call `memory add` — returns `success`
3. Entry is gone from MEMORY.md after the consolidation child's write / next `loadFromDisk`