### PR TITLE
fix: bound session search output

### DIFF
--- a/src/tools/session-search-tool.ts
+++ b/src/tools/session-search-tool.ts
@@ -14,6 +14,10 @@ interface SearchResult {
   count?: number;
   message?: string;
   output?: string;
+  outputChars?: number;
+  outputTruncated?: boolean;
+  snippetChars?: number;
+  truncatedCount?: number;
   ranges?: SessionAnchorRange[];
 }
 
@@ -22,6 +26,26 @@ interface SessionSearchToolOptions {
 }
 
 const DEFAULT_SESSIONS_DIR = path.join(AGENT_ROOT, 'sessions');
+const DEFAULT_LEGACY_SNIPPET_CHARS = 1_200;
+const MAX_LEGACY_SNIPPET_CHARS = 4_000;
+const MAX_LEGACY_OUTPUT_CHARS = 50 * 1024;
+
+function truncateLegacySnippet(text: string, maxChars: number): { text: string; truncated: boolean } {
+  if (text.length <= maxChars) return { text, truncated: false };
+  return {
+    text: `${text.slice(0, maxChars)}\n... (truncated, ${text.length} chars total — refine the query or increase snippetChars)`,
+    truncated: true,
+  };
+}
+
+function capLegacyOutput(text: string): { text: string; truncated: boolean } {
+  if (text.length <= MAX_LEGACY_OUTPUT_CHARS) return { text, truncated: false };
+  const suffix = `\n... (output truncated, ${text.length} chars total — refine the query or lower the result limit)`;
+  return {
+    text: `${text.slice(0, MAX_LEGACY_OUTPUT_CHARS - suffix.length)}${suffix}`,
+    truncated: true,
+  };
+}
 
 export function registerSessionSearchTool(
   pi: ExtensionAPI,
@@ -127,7 +151,7 @@ Examples:
 - "Find the PR where we fixed the test hang"
 - "What approach did we take for the database migration?"
 
-Returns conversation snippets with session dates and project context.`,
+Returns bounded conversation snippets with session dates and project context. Large messages are truncated with their original character count.`,
     promptSnippet: 'Search past conversations for relevant context',
     promptGuidelines: [
       'Use session_search when the user asks about previous discussions or past work.',
@@ -138,12 +162,21 @@ Returns conversation snippets with session dates and project context.`,
       project: Type.Optional(Type.String({ description: 'Filter by project name (optional).' })),
       role: Type.Optional(StringEnum(['user', 'assistant'] as const, { description: 'Filter by message role (optional).' })),
       limit: Type.Optional(Type.Number({ description: 'Maximum results to return (default: 10, max: 20).' })),
+      snippetChars: Type.Optional(Type.Number({
+        description: `Maximum characters per result snippet (default: ${DEFAULT_LEGACY_SNIPPET_CHARS}, max: ${MAX_LEGACY_SNIPPET_CHARS}).`,
+        minimum: 100,
+        maximum: MAX_LEGACY_SNIPPET_CHARS,
+      })),
     }),
-    execute: async (_id: string, args: { query: string; project?: string; role?: string; limit?: number }) => {
+    execute: async (_id: string, args: { query: string; project?: string; role?: string; limit?: number; snippetChars?: number }) => {
       const query = args.query;
       const project = args.project;
       const role = args.role;
       const limit = Math.min(args.limit || 10, 20);
+      const snippetChars = Math.min(
+        Math.max(Math.floor(args.snippetChars ?? DEFAULT_LEGACY_SNIPPET_CHARS), 100),
+        MAX_LEGACY_SNIPPET_CHARS,
+      );
 
       if (!query || query.trim().length === 0) {
         const result: SearchResult = { success: false, message: 'query is required' };
@@ -163,7 +196,8 @@ Returns conversation snippets with session dates and project context.`,
         return { content: [{ type: 'text' as const, text: result.message! }], details: result };
       }
 
-      let output = `Found ${results.length} results for "${query}":\n\n`;
+      const blocks: string[] = [`Found ${results.length} results for "${query}":`];
+      let truncatedCount = 0;
 
       for (const r of results) {
         const date = new Date(r.timestamp).toLocaleDateString('en-US', {
@@ -172,13 +206,25 @@ Returns conversation snippets with session dates and project context.`,
           day: 'numeric',
         });
 
-        output += `---\n`;
-        output += `📅 ${date} | 📁 ${r.project} | ${r.role === 'user' ? '👤 User' : '🤖 Assistant'}\n`;
-        output += `${r.snippet}\n\n`;
+        const snippet = truncateLegacySnippet(r.snippet, snippetChars);
+        if (snippet.truncated) truncatedCount += 1;
+        blocks.push([
+          '---',
+          `📅 ${date} | 📁 ${r.project} | ${r.role === 'user' ? '👤 User' : '🤖 Assistant'}`,
+          snippet.text,
+        ].join('\n'));
       }
 
-      const finalResult: SearchResult = { success: true, count: results.length, output: output.trim() };
-      return { content: [{ type: 'text' as const, text: output.trim() }], details: finalResult };
+      const output = capLegacyOutput(blocks.join('\n\n').trim());
+      const finalResult: SearchResult = {
+        success: true,
+        count: results.length,
+        truncatedCount,
+        snippetChars,
+        outputChars: output.text.length,
+        outputTruncated: output.truncated,
+      };
+      return { content: [{ type: 'text' as const, text: output.text }], details: finalResult };
     },
   });
 }

--- a/src/tools/session-search-tool.ts
+++ b/src/tools/session-search-tool.ts
@@ -161,7 +161,11 @@ Returns bounded conversation snippets with session dates and project context. La
       query: Type.String({ description: 'Search query. Use natural language or specific terms.' }),
       project: Type.Optional(Type.String({ description: 'Filter by project name (optional).' })),
       role: Type.Optional(StringEnum(['user', 'assistant'] as const, { description: 'Filter by message role (optional).' })),
-      limit: Type.Optional(Type.Number({ description: 'Maximum results to return (default: 10, max: 20).' })),
+      limit: Type.Optional(Type.Number({
+        description: 'Maximum results to return (default: 10, min: 1, max: 20).',
+        minimum: 1,
+        maximum: 20,
+      })),
       snippetChars: Type.Optional(Type.Number({
         description: `Maximum characters per result snippet (default: ${DEFAULT_LEGACY_SNIPPET_CHARS}, max: ${MAX_LEGACY_SNIPPET_CHARS}).`,
         minimum: 100,
@@ -172,7 +176,8 @@ Returns bounded conversation snippets with session dates and project context. La
       const query = args.query;
       const project = args.project;
       const role = args.role;
-      const limit = Math.min(args.limit || 10, 20);
+      const requestedLimit = Number.isFinite(args.limit) ? Math.floor(args.limit!) : 10;
+      const limit = Math.min(Math.max(requestedLimit, 1), 20);
       const snippetChars = Math.min(
         Math.max(Math.floor(args.snippetChars ?? DEFAULT_LEGACY_SNIPPET_CHARS), 100),
         MAX_LEGACY_SNIPPET_CHARS,
@@ -192,8 +197,15 @@ Returns bounded conversation snippets with session dates and project context. La
       const results = searchSessions(dbManager, query, { project, role, limit });
 
       if (results.length === 0) {
-        const result: SearchResult = { success: true, count: 0, message: `No results found for "${query}". Try a different search term or broader query.` };
-        return { content: [{ type: 'text' as const, text: result.message! }], details: result };
+        const output = capLegacyOutput('No results found. Try a different search term or broader query.');
+        const result: SearchResult = {
+          success: true,
+          count: 0,
+          message: output.text,
+          outputChars: output.text.length,
+          outputTruncated: output.truncated,
+        };
+        return { content: [{ type: 'text' as const, text: output.text }], details: result };
       }
 
       const blocks: string[] = [`Found ${results.length} results for "${query}":`];

--- a/tests/tools/session-search-tool.test.ts
+++ b/tests/tools/session-search-tool.test.ts
@@ -4,6 +4,8 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { registerSessionSearchTool } from "../../src/tools/session-search-tool.js";
+import { DatabaseManager } from "../../src/store/db.js";
+import { indexSession } from "../../src/store/session-indexer.js";
 
 let ROOT_DIR = "";
 
@@ -30,6 +32,125 @@ describe("registerSessionSearchTool", () => {
     assert.strictEqual(captured.name, "session_search");
     assert.match(schema, /query/);
     assert.doesNotMatch(schema, /markdown/);
+  });
+
+  it("bounds oversized legacy results and reports truncation without duplicating output in details", async () => {
+    let captured: any;
+    const mockPi = {
+      registerTool: (def: any) => { captured = def; },
+    } as any;
+    const memoryDir = makeSessionsDir();
+    const dbManager = new DatabaseManager(memoryDir);
+    const oversizedContent = `needle ${"x".repeat(6_000_000)}`;
+
+    try {
+      indexSession(dbManager, {
+        id: "oversized-session",
+        project: "oversized-project",
+        cwd: "/work/oversized",
+        startedAt: "2026-07-11T00:00:00.000Z",
+        endedAt: null,
+        messages: [{
+          id: "oversized-message",
+          role: "assistant",
+          content: oversizedContent,
+          timestamp: "2026-07-11T00:01:00.000Z",
+        }],
+      });
+      registerSessionSearchTool(mockPi, dbManager);
+
+      const result = await captured.execute("tc-oversized", { query: "needle" });
+      const output = result.content[0].text as string;
+
+      assert.ok(output.length <= 50 * 1024, `expected <= 50 KiB, got ${output.length}`);
+      assert.match(output, /truncated/);
+      assert.match(output, /6000007 chars total/);
+      assert.strictEqual(result.details.truncatedCount, 1);
+      assert.strictEqual(result.details.outputChars, output.length);
+      assert.strictEqual(result.details.output, undefined);
+      assert.ok(JSON.stringify(result.details).length < 1_000);
+    } finally {
+      dbManager.close();
+    }
+  });
+
+  it("offers a bounded snippetChars override for legacy searches", async () => {
+    let captured: any;
+    const mockPi = {
+      registerTool: (def: any) => { captured = def; },
+    } as any;
+    const memoryDir = makeSessionsDir();
+    const dbManager = new DatabaseManager(memoryDir);
+
+    try {
+      indexSession(dbManager, {
+        id: "bounded-override-session",
+        project: "bounded-project",
+        cwd: "/work/bounded",
+        startedAt: "2026-07-11T00:00:00.000Z",
+        endedAt: null,
+        messages: [{
+          id: "bounded-override-message",
+          role: "assistant",
+          content: `needle ${"y".repeat(10_000)}`,
+          timestamp: "2026-07-11T00:01:00.000Z",
+        }],
+      });
+      registerSessionSearchTool(mockPi, dbManager);
+
+      assert.match(JSON.stringify(captured.parameters), /snippetChars/);
+      const result = await captured.execute("tc-bounded-override", {
+        query: "needle",
+        snippetChars: 2_000,
+      });
+
+      assert.strictEqual(result.details.snippetChars, 2_000);
+      assert.strictEqual(result.details.truncatedCount, 1);
+      assert.match(result.content[0].text, /10007 chars total/);
+      assert.ok(result.content[0].text.length < 3_000);
+    } finally {
+      dbManager.close();
+    }
+  });
+
+  it("enforces a hard 50 KiB ceiling across many large legacy results", async () => {
+    let captured: any;
+    const mockPi = {
+      registerTool: (def: any) => { captured = def; },
+    } as any;
+    const memoryDir = makeSessionsDir();
+    const dbManager = new DatabaseManager(memoryDir);
+
+    try {
+      indexSession(dbManager, {
+        id: "aggregate-ceiling-session",
+        project: "aggregate-project",
+        cwd: "/work/aggregate",
+        startedAt: "2026-07-11T00:00:00.000Z",
+        endedAt: null,
+        messages: Array.from({ length: 20 }, (_, index) => ({
+          id: `aggregate-message-${index}`,
+          role: "assistant",
+          content: `needle-${index} ${"z".repeat(10_000)}`,
+          timestamp: `2026-07-11T00:${String(index).padStart(2, "0")}:00.000Z`,
+        })),
+      });
+      registerSessionSearchTool(mockPi, dbManager);
+
+      const result = await captured.execute("tc-aggregate-ceiling", {
+        query: "needle",
+        limit: 20,
+        snippetChars: 4_000,
+      });
+      const output = result.content[0].text as string;
+
+      assert.ok(output.length <= 50 * 1024, `expected <= 50 KiB, got ${output.length}`);
+      assert.strictEqual(result.details.outputTruncated, true);
+      assert.match(output, /output truncated/);
+      assert.match(output, /refine the query or lower the result limit/);
+    } finally {
+      dbManager.close();
+    }
   });
 
   it("registers and executes the anchor markdown-only schema when configured", async () => {

--- a/tests/tools/session-search-tool.test.ts
+++ b/tests/tools/session-search-tool.test.ts
@@ -32,6 +32,50 @@ describe("registerSessionSearchTool", () => {
     assert.strictEqual(captured.name, "session_search");
     assert.match(schema, /query/);
     assert.doesNotMatch(schema, /markdown/);
+    assert.match(schema, /"minimum":1/);
+    assert.match(schema, /"maximum":20/);
+  });
+
+  it("clamps negative and fractional legacy limits before querying", async () => {
+    let captured: any;
+    const mockPi = {
+      registerTool: (def: any) => { captured = def; },
+    } as any;
+    const memoryDir = makeSessionsDir();
+    const dbManager = new DatabaseManager(memoryDir);
+
+    try {
+      indexSession(dbManager, {
+        id: "bounded-limit-session",
+        project: "bounded-project",
+        cwd: "/work/bounded",
+        startedAt: "2026-07-11T00:00:00.000Z",
+        endedAt: null,
+        messages: Array.from({ length: 25 }, (_, index) => ({
+          id: `bounded-limit-message-${index}`,
+          role: "assistant",
+          content: `bounded-limit-needle ${index}`,
+          timestamp: `2026-07-11T00:${String(index).padStart(2, "0")}:00.000Z`,
+        })),
+      });
+      registerSessionSearchTool(mockPi, dbManager);
+
+      const negative = await captured.execute("tc-negative-limit", {
+        query: "bounded-limit-needle",
+        limit: -1,
+      });
+      const fractional = await captured.execute("tc-fractional-limit", {
+        query: "bounded-limit-needle",
+        limit: 2.9,
+      });
+
+      assert.strictEqual(negative.details.count, 1);
+      assert.strictEqual(fractional.details.count, 2);
+      assert.ok(negative.content[0].text.length < 2_000);
+      assert.ok(fractional.content[0].text.length < 4_000);
+    } finally {
+      dbManager.close();
+    }
   });
 
   it("bounds oversized legacy results and reports truncation without duplicating output in details", async () => {
@@ -148,6 +192,43 @@ describe("registerSessionSearchTool", () => {
       assert.strictEqual(result.details.outputTruncated, true);
       assert.match(output, /output truncated/);
       assert.match(output, /refine the query or lower the result limit/);
+    } finally {
+      dbManager.close();
+    }
+  });
+
+  it("bounds the zero-result response without echoing an oversized query", async () => {
+    let captured: any;
+    const mockPi = {
+      registerTool: (def: any) => { captured = def; },
+    } as any;
+    const memoryDir = makeSessionsDir();
+    const dbManager = new DatabaseManager(memoryDir);
+
+    try {
+      indexSession(dbManager, {
+        id: "zero-result-session",
+        project: "zero-result-project",
+        cwd: "/work/zero-result",
+        startedAt: "2026-07-11T00:00:00.000Z",
+        endedAt: null,
+        messages: [{
+          id: "zero-result-message",
+          role: "assistant",
+          content: "indexed haystack",
+          timestamp: "2026-07-11T00:01:00.000Z",
+        }],
+      });
+      registerSessionSearchTool(mockPi, dbManager);
+      const query = `${" ".repeat(60_000)}missing`;
+
+      const result = await captured.execute("tc-zero-result", { query });
+      const output = result.content[0].text as string;
+
+      assert.strictEqual(result.details.count, 0);
+      assert.ok(output.length <= 50 * 1024, `expected <= 50 KiB, got ${output.length}`);
+      assert.strictEqual(output.includes(query), false);
+      assert.ok(JSON.stringify(result.details).length < 1_000);
     } finally {
       dbManager.close();
     }


### PR DESCRIPTION
## Summary

- bound each legacy `session_search` snippet to 1,200 characters by default
- expose a bounded `snippetChars` override (100–4,000 characters)
- clamp legacy limits to integer values from 1–20
- enforce a non-bypassable 50 KiB aggregate output ceiling, including zero-result responses
- report truncation and output-size metadata without duplicating the complete output in `details`

## Root cause

A production Pi session received a 5,787,158-character `session_search` tool result from one indexed message. The result exceeded the model context window even after compaction, while duplicated `details.output` inflated the persisted session. Pi then repeatedly failed overflow recovery and consumed a full CPU core processing the oversized context.

This applies AXI's token-budget principles at the tool boundary: compact defaults, explicit size hints, bounded opt-in detail, and a hard aggregate ceiling on every response path.

## Verification

- regression reproduces a 6,000,096-character response before the fix
- aggregate regression proves 20 large results cannot exceed 50 KiB
- zero-result regression proves an oversized query cannot bypass the ceiling
- focused suite: 7/7 passed
- `npm run check`
- combined hardening branch: all 38 test files passed on Node 24.16 and Node 26
