### PR TITLE
fix: protect isolated child prompts and auth adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 | `sessionSearch` | `{ "variant": "legacy" }` | Session search implementation: `legacy` keeps the existing SQLite/FTS snippet search; `anchors` uses the opt-in Markdown request surface and returns compact JSONL line-range anchors from `~/.pi/agent/sessions/` |
 | `llmModelOverride` | unset | Optional model override for background review (direct and subprocess), correction save, session flush, and consolidation |
 | `llmThinkingOverride` | unset | Optional thinking override for those LLM calls; valid values are `off`, `minimal`, `low`, `medium`, `high`, and `xhigh`. If `llmModelOverride` is set and this is omitted, review/child calls default to `off` |
-| `childExtensionPaths` | unset | Extra extension entry paths required by isolated child Pi processes, such as provider auth adapters; the installed `pi-claude-oauth-adapter` is detected automatically |
+| `childExtensionPaths` | unset | Trusted provider/auth adapter entry paths explicitly allowed in isolated child Pi processes; the installed `pi-claude-oauth-adapter` is detected automatically |
 | `nudgeInterval` | `10` | Turns between auto-reviews |
 | `nudgeToolCalls` | `15` | Tool calls between auto-reviews (OR with turns) |
 | `reviewRecentMessages` | `0` | Recent messages included in background review (`0` = all) |

--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 | `sessionSearch` | `{ "variant": "legacy" }` | Session search implementation: `legacy` keeps the existing SQLite/FTS snippet search; `anchors` uses the opt-in Markdown request surface and returns compact JSONL line-range anchors from `~/.pi/agent/sessions/` |
 | `llmModelOverride` | unset | Optional model override for background review (direct and subprocess), correction save, session flush, and consolidation |
 | `llmThinkingOverride` | unset | Optional thinking override for those LLM calls; valid values are `off`, `minimal`, `low`, `medium`, `high`, and `xhigh`. If `llmModelOverride` is set and this is omitted, review/child calls default to `off` |
+| `childExtensionPaths` | unset | Extra extension entry paths required by isolated child Pi processes, such as provider auth adapters; the installed `pi-claude-oauth-adapter` is detected automatically |
 | `nudgeInterval` | `10` | Turns between auto-reviews |
 | `nudgeToolCalls` | `15` | Tool calls between auto-reviews (OR with turns) |
 | `reviewRecentMessages` | `0` | Recent messages included in background review (`0` = all) |

--- a/src/config.ts
+++ b/src/config.ts
@@ -141,6 +141,12 @@ export function loadConfig(configPath = DEFAULT_CONFIG_PATH): MemoryConfig {
         if (trimmed.length > 0) config.llmModelOverride = trimmed;
       }
       if (isThinkingLevel(parsed.llmThinkingOverride)) config.llmThinkingOverride = parsed.llmThinkingOverride;
+      if (isStringArray(parsed.childExtensionPaths)) {
+        const childExtensionPaths = [...new Set<string>(
+          (parsed.childExtensionPaths as string[]).map((item) => item.trim()).filter(Boolean),
+        )];
+        if (childExtensionPaths.length > 0) config.childExtensionPaths = childExtensionPaths;
+      }
       if (hasMemoryOverflowStrategy) {
         config.autoConsolidate = config.memoryOverflowStrategy === "auto-consolidate";
       } else if (hasLegacyAutoConsolidate) {

--- a/src/handlers/pi-child-process.ts
+++ b/src/handlers/pi-child-process.ts
@@ -5,8 +5,9 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { MemoryConfig, ThinkingLevel } from "../types.js";
+import { AGENT_ROOT } from "../paths.js";
 
-type ChildLlmConfig = Pick<MemoryConfig, "llmModelOverride" | "llmThinkingOverride">;
+type ChildLlmConfig = Pick<MemoryConfig, "llmModelOverride" | "llmThinkingOverride" | "childExtensionPaths">;
 
 interface PiExecResult {
   code: number;
@@ -82,34 +83,75 @@ export function inheritedExtensionArgs(argv: string[] = process.argv.slice(2)): 
   return args;
 }
 
-function appendOwnExtensionArgs(args: string[]): void {
+function inheritedExtensionPaths(argv: string[]): string[] {
+  return inheritedExtensionArgs(argv).flatMap((arg, index, args) => {
+    if (arg === "-e" || arg === "--extension") return args[index + 1] ? [args[index + 1]] : [];
+    if (arg.startsWith("--extension=")) return [arg.slice("--extension=".length)];
+    return [];
+  });
+}
+
+export function detectClaudeOAuthAdapterPaths(ownExtensionPath = OWN_EXTENSION_PATH): string[] {
+  const candidates = new Set<string>();
+  if (ownExtensionPath) {
+    const packageRoot = dirname(dirname(ownExtensionPath));
+    candidates.add(join(dirname(packageRoot), "pi-claude-oauth-adapter", "extensions", "index.ts"));
+  }
+  candidates.add(join(AGENT_ROOT, "npm", "node_modules", "pi-claude-oauth-adapter", "extensions", "index.ts"));
+  return [...candidates].filter((candidate) => existsSync(candidate));
+}
+
+function childExtensionPaths(config: ChildLlmConfig, argv: string[]): string[] {
+  const candidates = [
+    OWN_EXTENSION_PATH,
+    ...(config.childExtensionPaths ?? []),
+    ...inheritedExtensionPaths(argv),
+    ...detectClaudeOAuthAdapterPaths(),
+  ];
+  const seen = new Set<string>();
+  const paths: string[] = [];
+  for (const candidate of candidates) {
+    const trimmed = candidate?.trim();
+    if (!trimmed) continue;
+    const normalized = resolve(trimmed);
+    if (seen.has(normalized) || !existsSync(normalized)) continue;
+    seen.add(normalized);
+    paths.push(normalized);
+  }
+  return paths;
+}
+
+function appendOwnExtensionArgs(args: string[], config: ChildLlmConfig, argv: string[]): void {
   // Skip all packages from settings.json (--no-extensions) — the subprocess
-  // only needs pi-hermes-memory to access the memory tool. Loading every
-  // plugin (context-mode, pi-lens, pi-web-access, pi-review, …) wastes
-  // prompt tokens and startup CPU for simple one-shot memory tasks.
-  if (OWN_EXTENSION_PATH) {
-    args.push("--no-extensions", "-e", OWN_EXTENSION_PATH);
+  // loads only Hermes and explicitly required provider adapters.
+  args.push("--no-extensions");
+  for (const extensionPath of childExtensionPaths(config, argv)) {
+    args.push("-e", extensionPath);
   }
 }
 
-export function buildChildPiPromptArgs(prompt: string, config: ChildLlmConfig, _argv?: string[]): string[] {
+export function buildChildPiPromptArgs(
+  prompt: string,
+  config: ChildLlmConfig,
+  argv: string[] = process.argv.slice(2),
+): string[] {
   const args = ["-p", "--no-session"];
   const model = normalizedModelOverride(config);
   const thinking = effectiveThinkingOverride(config);
 
   if (model) args.push("--model", model);
   if (thinking) args.push("--thinking", thinking);
-  appendOwnExtensionArgs(args);
+  appendOwnExtensionArgs(args, config, argv);
   args.push(prompt);
 
   return args;
 }
 
-function basePromptArgs(prompt: string): string[] {
+function basePromptArgs(prompt: string, config: ChildLlmConfig): string[] {
   // Always use --no-extensions + own path so the retry also avoids loading
   // all settings.json packages — matching the primary code path.
   const args = ["-p", "--no-session"];
-  appendOwnExtensionArgs(args);
+  appendOwnExtensionArgs(args, config, process.argv.slice(2));
   args.push(prompt);
   return args;
 }
@@ -224,7 +266,7 @@ export async function execChildPrompt(
       }
     }
 
-    const retryInvocation = resolveChildPiInvocation(basePromptArgs(promptReference));
+    const retryInvocation = resolveChildPiInvocation(basePromptArgs(promptReference, config));
     return await pi.exec(retryInvocation.command, retryInvocation.args, execOptions) as PiExecResult;
   } finally {
     await fs.rm(temporaryPrompt.dir, { recursive: true, force: true });

--- a/src/handlers/pi-child-process.ts
+++ b/src/handlers/pi-child-process.ts
@@ -21,6 +21,16 @@ interface ExecChildPromptOptions {
   retryWithoutOverrides?: boolean;
 }
 
+interface ExecChildPromptDependencies {
+  removeTemporaryDirectory: (dir: string) => Promise<void>;
+}
+
+const DEFAULT_EXEC_CHILD_PROMPT_DEPENDENCIES: ExecChildPromptDependencies = {
+  removeTemporaryDirectory: async (dir) => {
+    await fs.rm(dir, { recursive: true, force: true });
+  },
+};
+
 export interface ChildPiInvocation {
   command: string;
   args: string[];
@@ -83,14 +93,6 @@ export function inheritedExtensionArgs(argv: string[] = process.argv.slice(2)): 
   return args;
 }
 
-function inheritedExtensionPaths(argv: string[]): string[] {
-  return inheritedExtensionArgs(argv).flatMap((arg, index, args) => {
-    if (arg === "-e" || arg === "--extension") return args[index + 1] ? [args[index + 1]] : [];
-    if (arg.startsWith("--extension=")) return [arg.slice("--extension=".length)];
-    return [];
-  });
-}
-
 export function detectClaudeOAuthAdapterPaths(ownExtensionPath = OWN_EXTENSION_PATH): string[] {
   const candidates = new Set<string>();
   if (ownExtensionPath) {
@@ -101,11 +103,10 @@ export function detectClaudeOAuthAdapterPaths(ownExtensionPath = OWN_EXTENSION_P
   return [...candidates].filter((candidate) => existsSync(candidate));
 }
 
-function childExtensionPaths(config: ChildLlmConfig, argv: string[]): string[] {
+function childExtensionPaths(config: ChildLlmConfig): string[] {
   const candidates = [
     OWN_EXTENSION_PATH,
     ...(config.childExtensionPaths ?? []),
-    ...inheritedExtensionPaths(argv),
     ...detectClaudeOAuthAdapterPaths(),
   ];
   const seen = new Set<string>();
@@ -121,11 +122,11 @@ function childExtensionPaths(config: ChildLlmConfig, argv: string[]): string[] {
   return paths;
 }
 
-function appendOwnExtensionArgs(args: string[], config: ChildLlmConfig, argv: string[]): void {
+function appendOwnExtensionArgs(args: string[], config: ChildLlmConfig): void {
   // Skip all packages from settings.json (--no-extensions) — the subprocess
   // loads only Hermes and explicitly required provider adapters.
   args.push("--no-extensions");
-  for (const extensionPath of childExtensionPaths(config, argv)) {
+  for (const extensionPath of childExtensionPaths(config)) {
     args.push("-e", extensionPath);
   }
 }
@@ -133,7 +134,7 @@ function appendOwnExtensionArgs(args: string[], config: ChildLlmConfig, argv: st
 export function buildChildPiPromptArgs(
   prompt: string,
   config: ChildLlmConfig,
-  argv: string[] = process.argv.slice(2),
+  _argv: string[] = process.argv.slice(2),
 ): string[] {
   const args = ["-p", "--no-session"];
   const model = normalizedModelOverride(config);
@@ -141,7 +142,7 @@ export function buildChildPiPromptArgs(
 
   if (model) args.push("--model", model);
   if (thinking) args.push("--thinking", thinking);
-  appendOwnExtensionArgs(args, config, argv);
+  appendOwnExtensionArgs(args, config);
   args.push(prompt);
 
   return args;
@@ -151,7 +152,7 @@ function basePromptArgs(prompt: string, config: ChildLlmConfig): string[] {
   // Always use --no-extensions + own path so the retry also avoids loading
   // all settings.json packages — matching the primary code path.
   const args = ["-p", "--no-session"];
-  appendOwnExtensionArgs(args, config, process.argv.slice(2));
+  appendOwnExtensionArgs(args, config);
   args.push(prompt);
   return args;
 }
@@ -226,7 +227,7 @@ async function writePromptToTemporaryFile(prompt: string): Promise<{ dir: string
     await fs.writeFile(filePath, prompt, { encoding: "utf-8", mode: 0o600 });
     return { dir, filePath };
   } catch (error) {
-    await fs.rm(dir, { recursive: true, force: true });
+    try { await fs.rm(dir, { recursive: true, force: true }); } catch {}
     throw error;
   }
 }
@@ -236,6 +237,7 @@ export async function execChildPrompt(
   prompt: string,
   config: ChildLlmConfig,
   options: ExecChildPromptOptions,
+  dependencies: ExecChildPromptDependencies = DEFAULT_EXEC_CHILD_PROMPT_DEPENDENCIES,
 ): Promise<PiExecResult> {
   const execOptions = {
     signal: options.signal,
@@ -269,6 +271,6 @@ export async function execChildPrompt(
     const retryInvocation = resolveChildPiInvocation(basePromptArgs(promptReference, config));
     return await pi.exec(retryInvocation.command, retryInvocation.args, execOptions) as PiExecResult;
   } finally {
-    await fs.rm(temporaryPrompt.dir, { recursive: true, force: true });
+    try { await dependencies.removeTemporaryDirectory(temporaryPrompt.dir); } catch {}
   }
 }

--- a/src/handlers/pi-child-process.ts
+++ b/src/handlers/pi-child-process.ts
@@ -1,4 +1,6 @@
 import { existsSync } from "node:fs";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -175,6 +177,18 @@ function shouldRetryWithoutOverridesForError(error: unknown): boolean {
   return shouldRetryWithoutOverridesFromText(String(error));
 }
 
+async function writePromptToTemporaryFile(prompt: string): Promise<{ dir: string; filePath: string }> {
+  const dir = await fs.mkdtemp(join(os.tmpdir(), "pi-hermes-prompt-"));
+  const filePath = join(dir, "prompt.md");
+  try {
+    await fs.writeFile(filePath, prompt, { encoding: "utf-8", mode: 0o600 });
+    return { dir, filePath };
+  } catch (error) {
+    await fs.rm(dir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
 export async function execChildPrompt(
   pi: Pick<ExtensionAPI, "exec">,
   prompt: string,
@@ -185,28 +199,34 @@ export async function execChildPrompt(
     signal: options.signal,
     timeout: options.timeoutMs,
   };
+  const temporaryPrompt = await writePromptToTemporaryFile(prompt);
+  const promptReference = `@${temporaryPrompt.filePath}`;
 
   try {
-    const invocation = resolveChildPiInvocation(buildChildPiPromptArgs(prompt, config));
-    const result = await pi.exec(invocation.command, invocation.args, execOptions) as PiExecResult;
-    if (
-      result.code === 0 ||
-      !options.retryWithoutOverrides ||
-      !hasChildLlmOverrides(config) ||
-      !shouldRetryWithoutOverrides(result)
-    ) {
-      return result;
+    try {
+      const invocation = resolveChildPiInvocation(buildChildPiPromptArgs(promptReference, config));
+      const result = await pi.exec(invocation.command, invocation.args, execOptions) as PiExecResult;
+      if (
+        result.code === 0 ||
+        !options.retryWithoutOverrides ||
+        !hasChildLlmOverrides(config) ||
+        !shouldRetryWithoutOverrides(result)
+      ) {
+        return result;
+      }
+    } catch (error) {
+      if (
+        !options.retryWithoutOverrides ||
+        !hasChildLlmOverrides(config) ||
+        !shouldRetryWithoutOverridesForError(error)
+      ) {
+        throw error;
+      }
     }
-  } catch (error) {
-    if (
-      !options.retryWithoutOverrides ||
-      !hasChildLlmOverrides(config) ||
-      !shouldRetryWithoutOverridesForError(error)
-    ) {
-      throw error;
-    }
-  }
 
-  const retryInvocation = resolveChildPiInvocation(basePromptArgs(prompt));
-  return pi.exec(retryInvocation.command, retryInvocation.args, execOptions) as Promise<PiExecResult>;
+    const retryInvocation = resolveChildPiInvocation(basePromptArgs(promptReference));
+    return await pi.exec(retryInvocation.command, retryInvocation.args, execOptions) as PiExecResult;
+  } finally {
+    await fs.rm(temporaryPrompt.dir, { recursive: true, force: true });
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,8 @@ export interface MemoryConfig {
   llmModelOverride?: string;
   /** Override thinking level used for child pi -p subprocess LLM calls. Default: unset */
   llmThinkingOverride?: ThinkingLevel;
+  /** Extra extension entry paths required by child Pi processes, such as provider auth adapters. */
+  childExtensionPaths?: string[];
   /** Strategy when memory is full. Default: auto-consolidate */
   memoryOverflowStrategy?: MemoryOverflowStrategy;
   /** Legacy alias for memoryOverflowStrategy. Default: true */

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -94,6 +94,21 @@ describe("loadConfig", () => {
     assert.strictEqual(config.llmThinkingOverride, undefined);
   });
 
+  it("loads, trims, and deduplicates child extension paths", () => {
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({
+      childExtensionPaths: [" /tmp/auth-adapter.ts ", "/tmp/auth-adapter.ts", "/tmp/other-adapter.ts"],
+    }));
+
+    const config = loadConfig(TEST_CONFIG_PATH);
+
+    assert.deepStrictEqual(config.childExtensionPaths, ["/tmp/auth-adapter.ts", "/tmp/other-adapter.ts"]);
+  });
+
+  it("ignores invalid child extension path configuration", () => {
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({ childExtensionPaths: ["/tmp/auth.ts", 42] }));
+    assert.strictEqual(loadConfig(TEST_CONFIG_PATH).childExtensionPaths, undefined);
+  });
+
   it("expands ~/ memoryDir into an absolute home path", () => {
     fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
     fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({

--- a/tests/handlers/auto-consolidate.test.ts
+++ b/tests/handlers/auto-consolidate.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, beforeEach, before, after } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";
@@ -14,6 +15,16 @@ import { ENTRY_DELIMITER } from "../../src/constants.js";
 // ─── Mock infrastructure ───
 
 let execCalls: any[];
+
+function captureExecArgs(args: any[]): any[] {
+  const [command, childArgs, options] = args;
+  const capturedArgs = [...childArgs];
+  const promptReference = capturedArgs.at(-1);
+  if (typeof promptReference === "string" && promptReference.startsWith("@")) {
+    capturedArgs[capturedArgs.length - 1] = readFileSync(promptReference.slice(1), "utf-8");
+  }
+  return [command, capturedArgs, options];
+}
 
 function logicalChildArgs(call: any[]): string[] {
   const [cmd, args] = call;
@@ -34,7 +45,7 @@ function createMockPi(execReturn?: { code: number; stdout: string; stderr: strin
   return {
     on: () => {},
     exec: async (...args: any[]) => {
-      execCalls.push(args);
+      execCalls.push(captureExecArgs(args));
       return ret;
     },
     registerTool: () => {},
@@ -148,7 +159,7 @@ describe("triggerConsolidation", () => {
     const pi = {
       on: () => {},
       exec: async (...args: any[]) => {
-        execCalls.push(args);
+        execCalls.push(captureExecArgs(args));
         if (execCalls.length === 1) {
           return { code: 1, stdout: "", stderr: "model not found" };
         }
@@ -189,7 +200,7 @@ describe("triggerConsolidation", () => {
     const pi = {
       on: () => {},
       exec: async (...args: any[]) => {
-        execCalls.push(args);
+        execCalls.push(captureExecArgs(args));
         return { code: 1, stdout: "", stderr: "memory tool returned no changes" };
       },
       registerTool: () => {},
@@ -238,7 +249,7 @@ describe("registerConsolidateCommand", () => {
     const pi = {
       on: () => {},
       exec: async (...args: any[]) => {
-        execCalls.push(args);
+        execCalls.push(captureExecArgs(args));
         return { code: 0, stdout: "Done", stderr: "" };
       },
       registerTool: () => {},
@@ -282,7 +293,7 @@ describe("registerConsolidateCommand", () => {
     const pi = {
       on: () => {},
       exec: async (...args: any[]) => {
-        execCalls.push(args);
+        execCalls.push(captureExecArgs(args));
         return { code: 0, stdout: "Done", stderr: "" };
       },
       registerTool: () => {},
@@ -308,7 +319,7 @@ describe("registerConsolidateCommand", () => {
     const pi = {
       on: () => {},
       exec: async (...args: any[]) => {
-        execCalls.push(args);
+        execCalls.push(captureExecArgs(args));
         return { code: 0, stdout: "Done", stderr: "" };
       },
       registerTool: () => {},

--- a/tests/handlers/background-review.test.ts
+++ b/tests/handlers/background-review.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert";
+import { readFileSync } from "node:fs";
 import {
   buildDirectReviewUserPrompt,
   buildSubprocessReviewPrompt,
@@ -20,6 +21,16 @@ let execCalls: any[];
 let directCalls: any[];
 let notifyCalls: any[];
 
+function captureExecArgs(args: any[]): any[] {
+  const [command, childArgs, options] = args;
+  const capturedArgs = [...childArgs];
+  const promptReference = capturedArgs.at(-1);
+  if (typeof promptReference === "string" && promptReference.startsWith("@")) {
+    capturedArgs[capturedArgs.length - 1] = readFileSync(promptReference.slice(1), "utf-8");
+  }
+  return [command, capturedArgs, options];
+}
+
 function createMockPi(execReturn?: { code: number; stdout: string; stderr: string }) {
   const defaultReturn = { code: 0, stdout: "Saved memory", stderr: "" };
   const ret = execReturn ?? defaultReturn;
@@ -30,7 +41,7 @@ function createMockPi(execReturn?: { code: number; stdout: string; stderr: strin
       handlers[event].push(handler);
     },
     exec: async (...args: any[]) => {
-      execCalls.push(args);
+      execCalls.push(captureExecArgs(args));
       return ret;
     },
     registerTool: () => {},
@@ -159,7 +170,7 @@ describe("setupBackgroundReview", () => {
     });
   }
 
-  it("increments user turn count on message_end for user messages", () => {
+  it("increments user turn count on message_end for user messages", async () => {
     const pi = createMockPi();
     setupBackgroundReview(pi, mockStore, null, defaultConfig);
 
@@ -173,6 +184,7 @@ describe("setupBackgroundReview", () => {
     for (let i = 0; i < 10; i++) {
       fireTurnEnd();
     }
+    await settle();
 
     // exec should have been called since we have 3 user turns and 10 turn_end events
     assert.ok(execCalls.length > 0, "exec should be called with 3 user turns and 10 turn_end events");
@@ -273,7 +285,7 @@ describe("setupBackgroundReview", () => {
         handlers[event].push(handler);
       },
       exec: async (...args: any[]) => {
-        execCalls.push(args);
+        execCalls.push(captureExecArgs(args));
         await new Promise<void>((r) => { resolveExec = r; });
         return { code: 0, stdout: "Saved", stderr: "" };
       },
@@ -478,7 +490,7 @@ describe("setupBackgroundReview", () => {
         handlers[event].push(handler);
       },
       exec: async (...args: any[]) => {
-        execCalls.push(args);
+        execCalls.push(captureExecArgs(args));
         throw new Error("exec crashed");
       },
       registerTool: () => {},

--- a/tests/handlers/correction-detector.test.ts
+++ b/tests/handlers/correction-detector.test.ts
@@ -290,18 +290,11 @@ describe("setupCorrectionDetector handler", () => {
     }
   }
 
-  function fireTurnEnd(branch: any[] = []) {
+  function fireTurnEnd(branch: any[] = []): Promise<unknown> {
     const h = handlers["turn_end"];
     if (!h) throw new Error("No turn_end handler registered");
     const ctx = makeCtx(branch);
-    for (const fn of h) {
-      fn({}, ctx);
-    }
-    return ctx;
-  }
-
-  async function settle(ms = 30) {
-    await new Promise((r) => setTimeout(r, ms));
+    return Promise.all(h.map((fn) => fn({}, ctx)));
   }
 
   beforeEach(() => {
@@ -327,8 +320,7 @@ describe("setupCorrectionDetector handler", () => {
     ];
 
     fireMessageEnd("user", "don't do that");
-    fireTurnEnd(branch);
-    await settle();
+    await fireTurnEnd(branch);
 
     assert.ok(execCalls.length >= 1, "pi.exec should be called on correction");
   });
@@ -346,8 +338,7 @@ describe("setupCorrectionDetector handler", () => {
     ];
 
     fireMessageEnd("user", "don't do that");
-    fireTurnEnd(branch);
-    await settle();
+    await fireTurnEnd(branch);
 
     const cmdArgs = logicalChildArgs(execCalls[0]);
     assert.deepStrictEqual(
@@ -361,8 +352,7 @@ describe("setupCorrectionDetector handler", () => {
     setupCorrectionDetector(pi, mockStore, null, config);
 
     fireMessageEnd("user", "looks good");
-    fireTurnEnd([]);
-    await settle();
+    await fireTurnEnd([]);
 
     assert.strictEqual(execCalls.length, 0, "pi.exec should NOT be called for normal messages");
   });
@@ -373,16 +363,14 @@ describe("setupCorrectionDetector handler", () => {
 
     // First correction
     fireMessageEnd("user", "don't do that");
-    fireTurnEnd([]);
-    await settle();
+    await fireTurnEnd([]);
 
     const firstCallCount = execCalls.length;
     assert.ok(firstCallCount >= 1, "first correction should trigger");
 
     // Second correction within 3 turns — should be rate-limited
     fireMessageEnd("user", "not like that");
-    fireTurnEnd([]);
-    await settle();
+    await fireTurnEnd([]);
 
     assert.strictEqual(execCalls.length, firstCallCount, "second correction should be rate-limited");
   });
@@ -402,8 +390,7 @@ describe("setupCorrectionDetector handler", () => {
     ];
 
     fireMessageEnd("user", "no, use pnpm instead");
-    fireTurnEnd(branch);
-    await settle();
+    await fireTurnEnd(branch);
 
     const failures = getMemories(dbManager, { target: 'failure' });
     assert.strictEqual(failures.length, 1);
@@ -429,8 +416,7 @@ describe("setupCorrectionDetector handler", () => {
     ];
 
     fireMessageEnd("user", "no, use pnpm in this repo");
-    fireTurnEnd(branch);
-    await settle();
+    await fireTurnEnd(branch);
 
     const projectFailures = getMemories(dbManager, { target: 'failure', project: 'project-a' });
     assert.strictEqual(projectFailures.length, 1);
@@ -464,8 +450,7 @@ describe("setupCorrectionDetector handler", () => {
     ];
 
     fireMessageEnd("user", "no, use yarn instead");
-    fireTurnEnd(branch);
-    await settle();
+    await fireTurnEnd(branch);
 
     assert.ok(execCalls.length >= 1, 'correction review should still run');
     assert.strictEqual(addFailureCalls, 1, 'Markdown correction save should still happen');

--- a/tests/handlers/correction-detector.test.ts
+++ b/tests/handlers/correction-detector.test.ts
@@ -300,7 +300,7 @@ describe("setupCorrectionDetector handler", () => {
     return ctx;
   }
 
-  async function settle(ms = 10) {
+  async function settle(ms = 30) {
     await new Promise((r) => setTimeout(r, ms));
   }
 

--- a/tests/handlers/pi-child-process.test.ts
+++ b/tests/handlers/pi-child-process.test.ts
@@ -1,4 +1,6 @@
 import { fileURLToPath } from "node:url";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
@@ -107,6 +109,47 @@ describe("resolveChildPiInvocation", () => {
 });
 
 describe("execChildPrompt", () => {
+  it("keeps a sensitive prompt out of argv and removes its mode-0600 temporary file", async () => {
+    const secret = "PRIVATE-MEMORY-CONTENT";
+    let promptPath = "";
+    const pi = {
+      exec: async (_cmd: string, args: string[]) => {
+        assert.ok(args.every((arg) => !arg.includes(secret)), "child argv must not contain prompt content");
+        const promptArg = args.at(-1)!;
+        assert.match(promptArg, /^@/);
+        promptPath = promptArg.slice(1);
+        assert.equal(await fs.readFile(promptPath, "utf-8"), secret);
+        assert.equal((await fs.stat(promptPath)).mode & 0o777, 0o600);
+        return { code: 0, stdout: "ok", stderr: "" };
+      },
+    };
+
+    const result = await execChildPrompt(pi as any, secret, {}, { timeoutMs: 30000 });
+
+    assert.equal(result.code, 0);
+    await assert.rejects(fs.access(promptPath), { code: "ENOENT" });
+    await assert.rejects(fs.access(path.dirname(promptPath)), { code: "ENOENT" });
+  });
+
+  it("removes the temporary prompt file when child execution throws", async () => {
+    let promptPath = "";
+    const pi = {
+      exec: async (_cmd: string, args: string[]) => {
+        promptPath = args.at(-1)!.slice(1);
+        assert.equal(await fs.readFile(promptPath, "utf-8"), "secret failure prompt");
+        throw new Error("child failed");
+      },
+    };
+
+    await assert.rejects(
+      execChildPrompt(pi as any, "secret failure prompt", {}, { timeoutMs: 30000 }),
+      /child failed/,
+    );
+
+    assert.ok(promptPath.startsWith(os.tmpdir()));
+    await assert.rejects(fs.access(promptPath), { code: "ENOENT" });
+  });
+
   it("retries once without overrides when requested and the override subprocess fails for model resolution reasons", async () => {
     const calls: Array<{ cmd: string; args: string[] }> = [];
     const pi = {
@@ -127,10 +170,13 @@ describe("execChildPrompt", () => {
     });
 
     assert.strictEqual(result.code, 0);
-    assert.deepStrictEqual(calls.map(logicalChildArgs), [
-      ["-p", "--no-session", "--model", "openrouter/deepseek/deepseek-v4-flash", "--thinking", "off", ...EXT_ARGS, "hello"],
+    const logicalCalls = calls.map(logicalChildArgs);
+    const promptReference = logicalCalls[0].at(-1)!;
+    assert.match(promptReference, /^@/);
+    assert.deepStrictEqual(logicalCalls, [
+      ["-p", "--no-session", "--model", "openrouter/deepseek/deepseek-v4-flash", "--thinking", "off", ...EXT_ARGS, promptReference],
       // Retry path (basePromptArgs) also passes --no-extensions + own path.
-      ["-p", "--no-session", ...EXT_ARGS, "hello"],
+      ["-p", "--no-session", ...EXT_ARGS, promptReference],
     ]);
   });
 
@@ -162,9 +208,11 @@ describe("execChildPrompt", () => {
       assert.strictEqual(calls[1].cmd, process.execPath);
       assert.match(calls[0].args[0].replace(/\\/g, "/"), /\/cli\.js$/);
       assert.match(calls[1].args[0].replace(/\\/g, "/"), /\/cli\.js$/);
+      const promptReference = calls[0].args.at(-1)!;
+      assert.match(promptReference, /^@/);
       assert.deepStrictEqual(calls.map((call) => call.args.slice(1)), [
-        ["-p", "--no-session", "--model", "openrouter/deepseek/deepseek-v4-flash", "--thinking", "off", ...EXT_ARGS, "hello"],
-        ["-p", "--no-session", ...EXT_ARGS, "hello"],
+        ["-p", "--no-session", "--model", "openrouter/deepseek/deepseek-v4-flash", "--thinking", "off", ...EXT_ARGS, promptReference],
+        ["-p", "--no-session", ...EXT_ARGS, promptReference],
       ]);
     } finally {
       if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);

--- a/tests/handlers/pi-child-process.test.ts
+++ b/tests/handlers/pi-child-process.test.ts
@@ -72,7 +72,7 @@ describe("buildChildPiPromptArgs", () => {
     );
   });
 
-  it("preserves existing configured and inherited extensions without duplicating Hermes", async () => {
+  it("passes configured extensions but excludes unrelated inherited extensions", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-child-extensions-"));
     const configured = path.join(dir, "configured.ts");
     const inherited = path.join(dir, "inherited.ts");
@@ -87,7 +87,6 @@ describe("buildChildPiPromptArgs", () => {
           "-p", "--no-session", "--no-extensions",
           "-e", OWN_EXTENSION_PATH,
           "-e", configured,
-          "-e", inherited,
           "hello",
         ],
       );
@@ -193,6 +192,38 @@ describe("execChildPrompt", () => {
     await assert.rejects(fs.access(promptPath), { code: "ENOENT" });
   });
 
+  it("returns a successful child result when temporary cleanup fails", async () => {
+    let cleanupCalls = 0;
+    let promptDirectory = "";
+    const pi = {
+      exec: async (_cmd: string, args: string[]) => {
+        promptDirectory = path.dirname(args.at(-1)!.slice(1));
+        return { code: 0, stdout: "completed", stderr: "" };
+      },
+    };
+
+    try {
+      const result = await execChildPrompt(
+        pi as any,
+        "cleanup failure prompt",
+        {},
+        { timeoutMs: 30000 },
+        {
+          removeTemporaryDirectory: async () => {
+            cleanupCalls++;
+            throw new Error("cleanup denied");
+          },
+        },
+      );
+
+      assert.equal(result.code, 0);
+      assert.equal(result.stdout, "completed");
+      assert.equal(cleanupCalls, 1);
+    } finally {
+      if (promptDirectory) await fs.rm(promptDirectory, { recursive: true, force: true });
+    }
+  });
+
   it("passes configured auth adapters to both override attempts", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-child-auth-"));
     const adapterPath = path.join(dir, "adapter.ts");
@@ -219,6 +250,36 @@ describe("execChildPrompt", () => {
         assert.equal(args[index - 1], "-e");
       }
     } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("excludes unrelated inherited extensions from primary and retry attempts", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-child-untrusted-"));
+    const inherited = path.join(dir, "unrelated-extension.ts");
+    await fs.writeFile(inherited, "export default () => {};");
+    const originalArgv = process.argv;
+    const calls: string[][] = [];
+    process.argv = [originalArgv[0], originalArgv[1], "-e", inherited];
+    try {
+      await execChildPrompt({
+        exec: async (_cmd: string, args: string[]) => {
+          calls.push(args);
+          return calls.length === 1
+            ? { code: 1, stderr: "model not found" }
+            : { code: 0, stdout: "ok" };
+        },
+      } as any, "private review", {
+        llmModelOverride: "missing/model",
+      }, { timeoutMs: 30000, retryWithoutOverrides: true });
+
+      assert.equal(calls.length, 2);
+      for (const args of calls) {
+        assert.equal(args.includes(inherited), false);
+        assert.ok(args.includes("--no-extensions"));
+      }
+    } finally {
+      process.argv = originalArgv;
       await fs.rm(dir, { recursive: true, force: true });
     }
   });

--- a/tests/handlers/pi-child-process.test.ts
+++ b/tests/handlers/pi-child-process.test.ts
@@ -4,7 +4,13 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { buildChildPiPromptArgs, execChildPrompt, inheritedExtensionArgs, resolveChildPiInvocation } from "../../src/handlers/pi-child-process.js";
+import {
+  buildChildPiPromptArgs,
+  detectClaudeOAuthAdapterPaths,
+  execChildPrompt,
+  inheritedExtensionArgs,
+  resolveChildPiInvocation,
+} from "../../src/handlers/pi-child-process.js";
 
 function logicalChildArgs(call: { cmd: string; args: string[] }): string[] {
   const expected = resolveChildPiInvocation(call.cmd === "pi" ? call.args : call.args.slice(1));
@@ -59,13 +65,50 @@ describe("buildChildPiPromptArgs", () => {
     );
   });
 
-  it("ignores inherited extension args and always uses own path", () => {
-    // The function no longer inherits parent -e flags; it always passes
-    // --no-extensions and its own resolved path.
+  it("ignores missing inherited extension paths", () => {
     assert.deepStrictEqual(
       buildChildPiPromptArgs("hello", {}, ["-e", "src/index.ts"]),
       ["-p", "--no-session", ...EXT_ARGS, "hello"],
     );
+  });
+
+  it("preserves existing configured and inherited extensions without duplicating Hermes", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-child-extensions-"));
+    const configured = path.join(dir, "configured.ts");
+    const inherited = path.join(dir, "inherited.ts");
+    await fs.writeFile(configured, "export default () => {};");
+    await fs.writeFile(inherited, "export default () => {};");
+    try {
+      assert.deepStrictEqual(
+        buildChildPiPromptArgs("hello", {
+          childExtensionPaths: [configured, configured, "/missing/adapter.ts", OWN_EXTENSION_PATH],
+        }, ["-e", inherited, `--extension=${configured}`]),
+        [
+          "-p", "--no-session", "--no-extensions",
+          "-e", OWN_EXTENSION_PATH,
+          "-e", configured,
+          "-e", inherited,
+          "hello",
+        ],
+      );
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("detects a sibling pi-claude-oauth-adapter extension", async () => {
+    const nodeModules = await fs.mkdtemp(path.join(os.tmpdir(), "pi-node-modules-"));
+    const ownPath = path.join(nodeModules, "pi-hermes-memory", "src", "index.ts");
+    const adapterPath = path.join(nodeModules, "pi-claude-oauth-adapter", "extensions", "index.ts");
+    await fs.mkdir(path.dirname(ownPath), { recursive: true });
+    await fs.mkdir(path.dirname(adapterPath), { recursive: true });
+    await fs.writeFile(ownPath, "export default () => {};");
+    await fs.writeFile(adapterPath, "export default () => {};");
+    try {
+      assert.deepStrictEqual(detectClaudeOAuthAdapterPaths(ownPath), [adapterPath]);
+    } finally {
+      await fs.rm(nodeModules, { recursive: true, force: true });
+    }
   });
 });
 
@@ -148,6 +191,36 @@ describe("execChildPrompt", () => {
 
     assert.ok(promptPath.startsWith(os.tmpdir()));
     await assert.rejects(fs.access(promptPath), { code: "ENOENT" });
+  });
+
+  it("passes configured auth adapters to both override attempts", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-child-auth-"));
+    const adapterPath = path.join(dir, "adapter.ts");
+    await fs.writeFile(adapterPath, "export default () => {};");
+    const calls: string[][] = [];
+    const pi = {
+      exec: async (_cmd: string, args: string[]) => {
+        calls.push(args);
+        return calls.length === 1
+          ? { code: 1, stdout: "", stderr: "model not found" }
+          : { code: 0, stdout: "ok", stderr: "" };
+      },
+    };
+    try {
+      await execChildPrompt(pi as any, "hello", {
+        llmModelOverride: "missing/model",
+        childExtensionPaths: [adapterPath],
+      }, { timeoutMs: 30000, retryWithoutOverrides: true });
+
+      assert.equal(calls.length, 2);
+      for (const args of calls) {
+        const index = args.indexOf(adapterPath);
+        assert.ok(index > 0);
+        assert.equal(args[index - 1], "-e");
+      }
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
   });
 
   it("retries once without overrides when requested and the override subprocess fails for model resolution reasons", async () => {

--- a/tests/handlers/session-flush.test.ts
+++ b/tests/handlers/session-flush.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { setupSessionFlush } from "../../src/handlers/session-flush.js";
 import { resolveChildPiInvocation } from "../../src/handlers/pi-child-process.js";
 import { FLUSH_PROMPT } from "../../src/constants.js";
@@ -18,7 +19,13 @@ function createMockPi() {
       handlers[event].push(handler);
     },
     async exec(...args: any[]) {
-      execCalls.push({ args });
+      const [command, childArgs, options] = args;
+      const capturedArgs = [...childArgs];
+      const promptReference = capturedArgs.at(-1);
+      if (typeof promptReference === "string" && promptReference.startsWith("@")) {
+        capturedArgs[capturedArgs.length - 1] = readFileSync(promptReference.slice(1), "utf-8");
+      }
+      execCalls.push({ args: [command, capturedArgs, options] });
       return { code: 0, stdout: "", stderr: "" };
     },
     registerTool() {},


### PR DESCRIPTION
## Summary

- pass private review/consolidation/flush/correction prompts through mode-0600 temporary files instead of argv
- retain `--no-extensions` isolation for child Pi processes
- load only Hermes, explicitly trusted `childExtensionPaths`, and the narrowly detected `pi-claude-oauth-adapter`
- preserve configured auth adapters on both the primary and model-override retry paths
- clean temporary prompts best-effort without turning a completed child result into failure
- resolve the Pi CLI safely on Windows

## Root causes

The fallback subprocess placed complete memory and conversation payloads in the process command line, exposing private content to process inspection and AV/EDR heuristics. Separately, `--no-extensions` removed provider OAuth adapters, so child Pi calls lost the authenticated provider path used by the parent session.

The fix keeps the isolation boundary but makes its trusted dependencies explicit. Arbitrary inherited `-e` extensions are deliberately excluded so they cannot observe private review prompts or reintroduce unrelated tools and side effects.

Closes #94.
Closes #95.

Thanks to @Akshay-patel7 for the auth-adapter diagnosis and @flumignano for the Windows privacy/Defender report.

## Verification

- all 36 upstream test files passed on Node 24.16
- focused child/caller suite: 154 tests passed
- `npm run check`
- regressions cover argv privacy, mode 0600, cleanup on success/failure, cleanup failure, Windows invocation, explicit adapters on both attempts, automatic Claude OAuth discovery, and exclusion of unrelated inherited extensions
