### PR TITLE
fix: make SQLite recovery and reconciliation authoritative

### DIFF
--- a/src/extension-root-migration.ts
+++ b/src/extension-root-migration.ts
@@ -1,12 +1,41 @@
 import fs from "node:fs/promises";
 import { existsSync } from "node:fs";
+import { randomUUID } from "node:crypto";
 import path from "node:path";
+import Database from "better-sqlite3";
+import { AtomicLockCoordinator, type AtomicLockLease } from "./store/atomic-lock-coordinator.js";
+import { canonicalStoragePathSync } from "./store/canonical-storage-path.js";
+
+const DATABASE_FILES = ["sessions.db", "sessions.db-wal", "sessions.db-shm"] as const;
+const DATABASE_MIGRATION_PENDING_FILE = ".sessions-db-migration-pending";
 
 export interface ExtensionRootMigrationResult {
   moved: number;
   merged: number;
   skipped: number;
   warnings: string[];
+  criticalFailures: Array<{
+    name: string;
+    source: string;
+    target: string;
+    message: string;
+  }>;
+}
+
+export interface ExtensionRootMigrationOptions {
+  moveFile?: (source: string, target: string) => Promise<void>;
+  publishDatabaseFile?: (source: string, target: string) => Promise<void>;
+  retireDatabaseFile?: (source: string, target: string) => Promise<void>;
+  backupDatabase?: (source: string, staged: string, onProgress?: () => void) => Promise<void>;
+  onDatabaseBackupProgress?: () => void;
+}
+
+const MIGRATION_LOCK_WAIT_MS = 5000;
+const MIGRATION_LOCK_POLL_MS = 50;
+
+export function isDatabaseMigrationPending(legacyRoot: string, targetRoot: string): boolean {
+  return existsSync(path.join(targetRoot, DATABASE_MIGRATION_PENDING_FILE))
+    || (existsSync(path.join(legacyRoot, "sessions.db")) && !existsSync(path.join(targetRoot, "sessions.db")));
 }
 
 async function pathExists(filePath: string): Promise<boolean> {
@@ -16,6 +45,24 @@ async function pathExists(filePath: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+async function pathEntryExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.lstat(filePath);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function databaseFilesAt(root: string): Promise<string[]> {
+  const names: string[] = [];
+  for (const name of DATABASE_FILES) {
+    if (await pathEntryExists(path.join(root, name))) names.push(name);
+  }
+  return names;
 }
 
 async function moveFileSafe(source: string, target: string): Promise<void> {
@@ -33,26 +80,176 @@ async function moveFileSafe(source: string, target: string): Promise<void> {
   await fs.unlink(source);
 }
 
-async function moveDirContents(sourceDir: string, targetDir: string, result: ExtensionRootMigrationResult): Promise<void> {
+async function stageDatabaseSnapshot(
+  source: string,
+  staged: string,
+  onProgress?: () => void,
+): Promise<void> {
+  const sourceDb = new Database(source, { readonly: true, fileMustExist: true });
+  try {
+    await sourceDb.backup(staged, {
+      progress: () => {
+        onProgress?.();
+        return 64;
+      },
+    });
+  } finally {
+    sourceDb.close();
+  }
+
+  const stagedDb = new Database(staged, { readonly: true, fileMustExist: true });
+  try {
+    const check = stagedDb.pragma("integrity_check", { simple: true });
+    if (check !== "ok") throw new Error(`staged SQLite snapshot failed integrity_check: ${String(check)}`);
+  } finally {
+    stagedDb.close();
+  }
+}
+
+function isDatabaseCorruption(error: unknown): boolean {
+  const code = typeof error === "object" && error && "code" in error
+    ? String((error as { code?: unknown }).code)
+    : "";
+  if (code === "SQLITE_CORRUPT" || code === "SQLITE_NOTADB") return true;
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  return message.includes("database disk image is malformed")
+    || message.includes("file is not a database")
+    || message.includes("database schema is corrupt")
+    || message.includes("malformed database schema")
+    || message.includes("failed integrity_check");
+}
+
+async function acquireMigrationLease(legacyRoot: string, targetRoot: string): Promise<AtomicLockLease> {
+  const coordinator = new AtomicLockCoordinator(path.join(targetRoot, ".pi-hermes-locks.sqlite"));
+  const sourceIdentity = canonicalStoragePathSync(path.join(legacyRoot, "sessions.db"));
+  const targetIdentity = canonicalStoragePathSync(path.join(targetRoot, "sessions.db"));
+  const key = `extension-root-migration:${sourceIdentity}:${targetIdentity}`;
+  const deadline = Date.now() + MIGRATION_LOCK_WAIT_MS;
+
+  while (true) {
+    const lease = coordinator.tryAcquire(key, { staleMs: 300_000 });
+    if (lease) return lease;
+    if (Date.now() >= deadline) {
+      throw new Error(`SQLite extension-root migration already in progress for ${targetIdentity}`);
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, MIGRATION_LOCK_POLL_MS));
+  }
+}
+
+class DatabaseGenerationMoveError extends Error {
+  constructor(message: string, readonly moved: string[], options: { cause: unknown }) {
+    super(message, options);
+  }
+}
+
+async function moveDatabaseGeneration(
+  names: string[],
+  sourceRoot: string,
+  holdingRoot: string,
+  move: (source: string, target: string) => Promise<void>,
+): Promise<string[]> {
+  const moved: string[] = [];
+  await fs.mkdir(holdingRoot, { mode: 0o700 });
+  const orderedNames = [...names].sort((left, right) => Number(left === "sessions.db") - Number(right === "sessions.db"));
+  try {
+    for (const name of orderedNames) {
+      const source = path.join(sourceRoot, name);
+      const target = path.join(holdingRoot, name);
+      try {
+        await move(source, target);
+        moved.push(name);
+      } catch (error) {
+        if (await pathEntryExists(target)) moved.push(name);
+        throw error;
+      }
+    }
+    return moved;
+  } catch (error) {
+    throw new DatabaseGenerationMoveError(
+      error instanceof Error ? error.message : String(error),
+      moved,
+      { cause: error },
+    );
+  }
+}
+
+async function restoreDatabaseGeneration(names: string[], holdingRoot: string, sourceRoot: string): Promise<string[]> {
+  const failures: string[] = [];
+  for (const name of [...names].reverse()) {
+    const held = path.join(holdingRoot, name);
+    if (!await pathEntryExists(held)) continue;
+    try {
+      await fs.link(held, path.join(sourceRoot, name));
+      await fs.unlink(held);
+    } catch (error) {
+      failures.push(`${name}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  return failures;
+}
+
+interface FileIdentity {
+  dev: number;
+  ino: number;
+}
+
+async function fileIdentity(filePath: string): Promise<FileIdentity> {
+  const stat = await fs.lstat(filePath);
+  return { dev: stat.dev, ino: stat.ino };
+}
+
+async function unlinkIfOwned(filePath: string, identity: FileIdentity): Promise<void> {
+  try {
+    const current = await fileIdentity(filePath);
+    if (current.dev === identity.dev && current.ino === identity.ino) await fs.unlink(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+}
+
+async function stageDatabaseSymlink(source: string, staged: string): Promise<void> {
+  const before = await fs.readlink(source);
+  await fs.symlink(path.resolve(path.dirname(source), before), staged);
+  const after = await fs.readlink(source);
+  if (before !== after) throw new Error("sessions.db symlink changed while staging");
+}
+
+async function moveDirContents(
+  sourceDir: string,
+  targetDir: string,
+  result: ExtensionRootMigrationResult,
+  moveFile: (source: string, target: string) => Promise<void>,
+  relativeDir = "",
+): Promise<void> {
   await fs.mkdir(targetDir, { recursive: true });
 
   const entries = await fs.readdir(sourceDir, { withFileTypes: true });
   for (const entry of entries) {
+    if (!relativeDir && DATABASE_FILES.includes(entry.name as typeof DATABASE_FILES[number])) {
+      continue;
+    }
     const sourcePath = path.join(sourceDir, entry.name);
     const targetPath = path.join(targetDir, entry.name);
 
     if (!await pathExists(targetPath)) {
       try {
-        await moveFileSafe(sourcePath, targetPath);
+        await moveFile(sourcePath, targetPath);
         result.moved++;
       } catch (error) {
-        result.warnings.push(`${sourcePath}: ${error instanceof Error ? error.message : String(error)}`);
+        const message = error instanceof Error ? error.message : String(error);
+        result.warnings.push(`${sourcePath}: ${message}`);
       }
       continue;
     }
 
     if (entry.isDirectory()) {
-      await moveDirContents(sourcePath, targetPath, result);
+      await moveDirContents(
+        sourcePath,
+        targetPath,
+        result,
+        moveFile,
+        path.join(relativeDir, entry.name),
+      );
       result.merged++;
       try {
         const remaining = await fs.readdir(sourcePath);
@@ -67,6 +264,221 @@ async function moveDirContents(sourceDir: string, targetDir: string, result: Ext
   }
 }
 
+async function publishDatabaseFile(source: string, target: string): Promise<void> {
+  if ((await fs.lstat(source)).isSymbolicLink()) {
+    await fs.symlink(await fs.readlink(source), target);
+    return;
+  }
+  await fs.link(source, target);
+}
+
+async function migrateDatabaseGeneration(
+  legacyRoot: string,
+  targetRoot: string,
+  result: ExtensionRootMigrationResult,
+  publish: (source: string, target: string) => Promise<void>,
+  retire: (source: string, target: string) => Promise<void>,
+  backup: (source: string, staged: string, onProgress?: () => void) => Promise<void>,
+  onBackupProgress?: () => void,
+): Promise<void> {
+  let lease: AtomicLockLease | null = null;
+  try {
+    lease = await acquireMigrationLease(legacyRoot, targetRoot);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    result.warnings.push(`${path.join(legacyRoot, "sessions.db")}: ${message}`);
+    result.criticalFailures.push({
+      name: "sessions.db",
+      source: path.join(legacyRoot, "sessions.db"),
+      target: path.join(targetRoot, "sessions.db"),
+      message,
+    });
+    return;
+  }
+
+  try {
+  const pendingMarker = path.join(targetRoot, DATABASE_MIGRATION_PENDING_FILE);
+  const hadPendingMarker = await pathEntryExists(pendingMarker);
+  const sourceNames = await databaseFilesAt(legacyRoot);
+  const targetNames = await databaseFilesAt(targetRoot);
+  if (sourceNames.length === 0) {
+    if (!hadPendingMarker) return;
+    if (targetNames.includes("sessions.db")) {
+      await fs.unlink(pendingMarker);
+      return;
+    }
+    const retirementDirs = (await fs.readdir(legacyRoot))
+      .filter((name) => name.startsWith(".sessions-db-retirement-"));
+    const message = retirementDirs.length > 0
+      ? `an interrupted migration preserved recovery artifacts at ${retirementDirs.map((name) => path.join(legacyRoot, name)).join(", ")}`
+      : "an interrupted migration has no complete source or destination SQLite generation";
+    result.warnings.push(`${path.join(legacyRoot, "sessions.db")}: ${message}`);
+    result.criticalFailures.push({
+      name: "sessions.db",
+      source: path.join(legacyRoot, "sessions.db"),
+      target: path.join(targetRoot, "sessions.db"),
+      message,
+    });
+    return;
+  }
+
+  if (targetNames.includes("sessions.db")) {
+    if (hadPendingMarker) {
+      const message = "an incomplete migration left both legacy and destination SQLite generations; manual recovery is required";
+      result.warnings.push(`${path.join(legacyRoot, "sessions.db")}: ${message}`);
+      result.criticalFailures.push({
+        name: "sessions.db",
+        source: path.join(legacyRoot, "sessions.db"),
+        target: path.join(targetRoot, "sessions.db"),
+        message,
+      });
+      return;
+    }
+    result.skipped += sourceNames.length;
+    return;
+  }
+
+  if (!sourceNames.includes("sessions.db") || targetNames.length > 0) {
+    const message = targetNames.length > 0
+      ? `destination contains a partial SQLite generation: ${targetNames.join(", ")}`
+      : "legacy SQLite sidecars exist without sessions.db";
+    result.warnings.push(`${path.join(legacyRoot, "sessions.db")}: ${message}`);
+    result.criticalFailures.push({
+      name: "sessions.db",
+      source: path.join(legacyRoot, "sessions.db"),
+      target: path.join(targetRoot, "sessions.db"),
+      message,
+    });
+    return;
+  }
+
+  await fs.mkdir(targetRoot, { recursive: true });
+  const stagingDir = path.join(targetRoot, `.sessions-db-migration-${randomUUID()}`);
+  const retirementDir = path.join(legacyRoot, `.sessions-db-retirement-${randomUUID()}`);
+  const published = new Map<string, FileIdentity>();
+  let retired: string[] = [];
+  let preserveRetirement = false;
+  let keepPendingMarker = false;
+  let writeLock: {
+    pragma: (query: string) => unknown;
+    exec: (sql: string) => void;
+    close: () => void;
+  } | null = null;
+  let corruptGeneration = false;
+  let generationNames = sourceNames;
+  try {
+    await fs.writeFile(pendingMarker, `${process.pid}:${randomUUID()}\n`, { mode: 0o600 });
+    await fs.mkdir(stagingDir, { mode: 0o700 });
+    const source = path.join(legacyRoot, "sessions.db");
+    const staged = path.join(stagingDir, "sessions.db");
+    const sourceState = await fs.lstat(source);
+    try {
+      writeLock = new Database(source, { fileMustExist: true, timeout: 0 });
+      writeLock.pragma("busy_timeout = 0");
+      writeLock.exec("BEGIN IMMEDIATE");
+    } catch (error) {
+      if (!isDatabaseCorruption(error)) throw error;
+      if (writeLock) {
+        try { writeLock.close(); } catch {}
+        writeLock = null;
+      }
+      corruptGeneration = true;
+    }
+    generationNames = await databaseFilesAt(legacyRoot);
+
+    if (sourceState.isSymbolicLink()) {
+      if (sourceNames.length !== 1) {
+        throw new Error("symlinked sessions.db cannot be combined with legacy SQLite sidecars");
+      }
+      await stageDatabaseSymlink(source, staged);
+      corruptGeneration = false;
+    } else if (sourceState.isFile()) {
+      if (!corruptGeneration) {
+        try {
+          await backup(source, staged, onBackupProgress);
+        } catch (error) {
+          if (!isDatabaseCorruption(error)) throw error;
+          corruptGeneration = true;
+          try { await fs.unlink(staged); } catch {}
+        }
+      }
+      if (corruptGeneration) {
+        try {
+          retired = await moveDatabaseGeneration(generationNames, legacyRoot, retirementDir, retire);
+        } catch (error) {
+          if (error instanceof DatabaseGenerationMoveError) retired = error.moved;
+          throw error;
+        }
+        for (const name of retired) {
+          const target = path.join(targetRoot, name);
+          await publish(path.join(retirementDir, name), target);
+          published.set(target, await fileIdentity(target));
+        }
+      }
+    } else {
+      throw new Error("sessions.db is not a regular file or symlink");
+    }
+
+    if (!corruptGeneration) {
+      try {
+        retired = await moveDatabaseGeneration(generationNames, legacyRoot, retirementDir, retire);
+      } catch (error) {
+        if (error instanceof DatabaseGenerationMoveError) retired = error.moved;
+        throw error;
+      }
+      const target = path.join(targetRoot, "sessions.db");
+      await publish(staged, target);
+      published.set(target, await fileIdentity(target));
+    }
+
+    if (writeLock) writeLock.exec("COMMIT");
+    result.moved += generationNames.length;
+  } catch (error) {
+    for (const [target, identity] of [...published.entries()].reverse()) {
+      try { await unlinkIfOwned(target, identity); } catch {}
+    }
+    let restoreFailures: string[] = [];
+    if (retired.length > 0) {
+      restoreFailures = await restoreDatabaseGeneration(retired, retirementDir, legacyRoot);
+      preserveRetirement = restoreFailures.length > 0;
+      keepPendingMarker = preserveRetirement;
+    }
+    const destinationPreserved = await pathEntryExists(path.join(targetRoot, "sessions.db"));
+    if (destinationPreserved) keepPendingMarker = true;
+    if (writeLock) {
+      try { writeLock.exec("ROLLBACK"); } catch {}
+    }
+    const baseMessage = error instanceof Error ? error.message : String(error);
+    let message = restoreFailures.length > 0
+      ? `${baseMessage}; recovery artifacts preserved at ${retirementDir} (${restoreFailures.join("; ")})`
+      : baseMessage;
+    if (destinationPreserved) {
+      message += `; an unowned destination generation was preserved at ${path.join(targetRoot, "sessions.db")}`;
+    }
+    result.warnings.push(`${path.join(legacyRoot, "sessions.db")}: ${message}`);
+    result.criticalFailures.push({
+      name: "sessions.db",
+      source: path.join(legacyRoot, "sessions.db"),
+      target: path.join(targetRoot, "sessions.db"),
+      message,
+    });
+  } finally {
+    if (writeLock) {
+      try { writeLock.close(); } catch {}
+    }
+    try { await fs.rm(stagingDir, { recursive: true, force: true }); } catch {}
+    if (!preserveRetirement) {
+      try { await fs.rm(retirementDir, { recursive: true, force: true }); } catch {}
+    }
+    if (!keepPendingMarker) {
+      try { await fs.unlink(pendingMarker); } catch {}
+    }
+  }
+  } finally {
+    lease.release();
+  }
+}
+
 /**
  * Move legacy extension assets from ~/.pi/agent/memory into
  * ~/.pi/agent/pi-hermes-memory. Existing destination files win.
@@ -74,19 +486,31 @@ async function moveDirContents(sourceDir: string, targetDir: string, result: Ext
 export async function migrateExtensionRoot(
   legacyRoot: string,
   targetRoot: string,
+  options: ExtensionRootMigrationOptions = {},
 ): Promise<ExtensionRootMigrationResult> {
   const result: ExtensionRootMigrationResult = {
     moved: 0,
     merged: 0,
     skipped: 0,
     warnings: [],
+    criticalFailures: [],
   };
 
   if (path.resolve(legacyRoot) === path.resolve(targetRoot)) return result;
   if (!existsSync(legacyRoot)) return result;
 
   await fs.mkdir(targetRoot, { recursive: true });
-  await moveDirContents(legacyRoot, targetRoot, result);
+  await migrateDatabaseGeneration(
+    legacyRoot,
+    targetRoot,
+    result,
+    options.publishDatabaseFile ?? options.moveFile ?? publishDatabaseFile,
+    options.retireDatabaseFile ?? moveFileSafe,
+    options.backupDatabase ?? stageDatabaseSnapshot,
+    options.onDatabaseBackupProgress,
+  );
+  if (result.criticalFailures.some((failure) => failure.name === "sessions.db")) return result;
+  await moveDirContents(legacyRoot, targetRoot, result, options.moveFile ?? moveFileSafe);
 
   try {
     const remaining = await fs.readdir(legacyRoot);

--- a/src/handlers/correction-detector.ts
+++ b/src/handlers/correction-detector.ts
@@ -12,10 +12,6 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { MemoryStore } from "../store/memory-store.js";
 import { DatabaseManager } from "../store/db.js";
 import {
-  formatFailureMemoryContent,
-  syncMemoryEntry,
-} from "../store/sqlite-memory-store.js";
-import {
   CORRECTION_SAVE_PROMPT,
   CORRECTION_STRONG_PATTERNS,
   CORRECTION_WEAK_PATTERNS,
@@ -127,7 +123,7 @@ export function setupCorrectionDetector(
   store: MemoryStore,
   projectStore: MemoryStore | null,
   config: MemoryConfig,
-  dbManager: DatabaseManager | null = null,
+  _dbManager: DatabaseManager | null = null,
   projectName?: string | null,
 ): void {
   if (!config.correctionDetection) return;
@@ -226,29 +222,11 @@ export function setupCorrectionDetector(
           const directive = extractCorrectionDirective(correctionText);
           const failureReason = "User corrected the agent";
           const scopedProjectName = projectStore ? projectName?.trim() || null : null;
-          const addResult = await store.addFailure(directive, {
+          await store.addFailure(directive, {
             category: "correction",
             failureReason,
             project: scopedProjectName ?? undefined,
           });
-
-          if (addResult.success && dbManager) {
-            try {
-              syncMemoryEntry(dbManager, {
-                content: formatFailureMemoryContent(directive, {
-                  category: "correction",
-                  failureReason,
-                  project: scopedProjectName,
-                }),
-                target: "failure",
-                project: scopedProjectName,
-                category: "correction",
-                failureReason,
-              });
-            } catch {
-              // Best-effort — searchable sync should not block correction capture
-            }
-          }
         }
       } catch {
         // Best-effort — don't block the session

--- a/src/handlers/review-memory-ops.ts
+++ b/src/handlers/review-memory-ops.ts
@@ -7,14 +7,7 @@ import { completeSimple, type Message, type SimpleStreamOptions } from "@earendi
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { DIRECT_REVIEW_SYSTEM_PROMPT } from "../constants.js";
 import { MemoryStore } from "../store/memory-store.js";
-import { DatabaseManager } from "../store/db.js";
-import {
-  formatFailureMemoryContent,
-  removeExactSyncedMemories,
-  removeSyncedMemories,
-  replaceSyncedMemories,
-  syncMemoryEntry,
-} from "../store/sqlite-memory-store.js";
+import type { DatabaseManager } from "../store/db.js";
 import type { MemoryCategory, MemoryConfig, MemoryResult, ThinkingLevel } from "../types.js";
 
 export interface ReviewMemoryOperation {
@@ -203,107 +196,12 @@ export function parseReviewOperations(text: string): ReviewMemoryOperation[] | n
   return parsed;
 }
 
-function sqliteProjectFor(
-  rawTarget: ReviewMemoryOperation["target"],
-  projectName?: string | null,
-): string | null | undefined {
-  if (rawTarget === "project") return projectName?.trim() || null;
-  if (rawTarget === "memory" || rawTarget === "user" || rawTarget === "failure") return null;
-  return undefined;
-}
-
-function sqliteTargetFor(rawTarget: ReviewMemoryOperation["target"]): "memory" | "user" | "failure" {
-  return rawTarget === "user" ? "user" : rawTarget === "failure" ? "failure" : "memory";
-}
-
-async function syncAdd(
-  rawTarget: ReviewMemoryOperation["target"],
-  content: string,
-  category: MemoryCategory | undefined,
-  failureReason: string | undefined,
-  dbManager: DatabaseManager | null,
-  projectName?: string | null,
-): Promise<void> {
-  if (!dbManager) return;
-
-  const sqliteTarget = sqliteTargetFor(rawTarget);
-  const sqliteProject = sqliteProjectFor(rawTarget, projectName);
-
-  if (rawTarget === "failure") {
-    const failureCategory = category ?? "failure";
-    syncMemoryEntry(dbManager, {
-      content: formatFailureMemoryContent(content, {
-        category: failureCategory,
-        failureReason,
-      }),
-      target: "failure",
-      project: sqliteProject ?? null,
-      category: failureCategory,
-      failureReason,
-    });
-    return;
-  }
-
-  syncMemoryEntry(dbManager, {
-    content,
-    target: sqliteTarget,
-    project: sqliteProject ?? null,
-  });
-}
-
-async function syncReplace(
-  rawTarget: ReviewMemoryOperation["target"],
-  oldText: string,
-  newContent: string,
-  dbManager: DatabaseManager | null,
-  projectName?: string | null,
-): Promise<void> {
-  if (!dbManager) return;
-  replaceSyncedMemories(dbManager, oldText, {
-    content: newContent,
-    target: sqliteTargetFor(rawTarget),
-    project: sqliteProjectFor(rawTarget, projectName),
-  });
-}
-
-async function syncRemove(
-  rawTarget: ReviewMemoryOperation["target"],
-  oldText: string,
-  dbManager: DatabaseManager | null,
-  projectName?: string | null,
-): Promise<void> {
-  if (!dbManager) return;
-  removeSyncedMemories(dbManager, oldText, {
-    target: sqliteTargetFor(rawTarget),
-    project: sqliteProjectFor(rawTarget, projectName),
-  });
-}
-
-async function syncEvictions(
-  rawTarget: ReviewMemoryOperation["target"],
-  evictedEntries: string[] | undefined,
-  dbManager: DatabaseManager | null,
-  projectName?: string | null,
-): Promise<void> {
-  if (!dbManager || !evictedEntries?.length) return;
-  for (const entry of evictedEntries) {
-    try {
-      removeExactSyncedMemories(dbManager, entry, {
-        target: sqliteTargetFor(rawTarget),
-        project: sqliteProjectFor(rawTarget, projectName),
-      });
-    } catch {
-      // best effort
-    }
-  }
-}
-
 export async function applyReviewOperations(
   store: MemoryStore,
   projectStore: MemoryStore | null,
   operations: ReviewMemoryOperation[],
-  dbManager: DatabaseManager | null = null,
-  projectName?: string | null,
+  _dbManager: DatabaseManager | null = null,
+  _projectName?: string | null,
 ): Promise<ApplyReviewOperationsResult> {
   let appliedCount = 0;
   let skippedCount = 0;
@@ -332,7 +230,6 @@ export async function applyReviewOperations(
             failureReason: op.failure_reason,
           });
           if (result.success) {
-            await syncAdd(rawTarget, op.content, category, op.failure_reason, dbManager, projectName);
             appliedCount++;
           } else {
             skippedCount++;
@@ -340,8 +237,6 @@ export async function applyReviewOperations(
         } else {
           result = await activeStore.add(memoryTarget, op.content);
           if (result.success) {
-            await syncEvictions(rawTarget, result.evicted_entries, dbManager, projectName);
-            await syncAdd(rawTarget, op.content, undefined, undefined, dbManager, projectName);
             appliedCount++;
           } else {
             skippedCount++;
@@ -356,7 +251,6 @@ export async function applyReviewOperations(
         }
         result = await activeStore.replace(memoryTarget, op.old_text, op.content);
         if (result.success) {
-          await syncReplace(rawTarget, op.old_text, op.content, dbManager, projectName);
           appliedCount++;
         } else {
           skippedCount++;
@@ -370,7 +264,6 @@ export async function applyReviewOperations(
         }
         result = await activeStore.remove(memoryTarget, op.old_text);
         if (result.success) {
-          await syncRemove(rawTarget, op.old_text, dbManager, projectName);
           appliedCount++;
         } else {
           skippedCount++;
@@ -379,7 +272,9 @@ export async function applyReviewOperations(
       }
       default:
         skippedCount++;
+        continue;
     }
+
   }
 
   return { appliedCount, skippedCount };

--- a/src/handlers/sync-markdown-memories.ts
+++ b/src/handlers/sync-markdown-memories.ts
@@ -1,6 +1,6 @@
 /**
- * Markdown memory sync command — /memory-sync-markdown imports existing
- * Markdown-backed memories into the SQLite search store.
+ * Markdown memory sync command — /memory-sync-markdown reconciles the SQLite
+ * search mirror with authoritative Markdown memory files.
  */
 
 import fs from 'node:fs';
@@ -8,18 +8,28 @@ import path from 'node:path';
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { DatabaseManager } from '../store/db.js';
 import {
-  parseMarkdownMemoryEntry,
-  syncMemoryEntry,
+  reconcileMarkdownFailureScopes,
+  reconcileMarkdownMemoryScope,
 } from '../store/sqlite-memory-store.js';
 import { ENTRY_DELIMITER, MEMORY_FILE, USER_FILE } from '../constants.js';
 import { AGENT_ROOT } from '../paths.js';
+import {
+  migrateExtensionRoot,
+  type ExtensionRootMigrationOptions,
+} from '../extension-root-migration.js';
+import { withMarkdownMutationLock } from '../store/markdown-mutation-lock.js';
 
 export interface BackfillCounters {
   filesScanned: number;
   entriesScanned: number;
   imported: number;
   skipped: number;
+  removed: number;
   warnings: string[];
+}
+
+export interface MigrationSyncOptions extends ExtensionRootMigrationOptions {
+  onMigrationSucceeded?: () => void;
 }
 
 function readEntries(filePath: string): string[] {
@@ -29,37 +39,15 @@ function readEntries(filePath: string): string[] {
   return raw.split(ENTRY_DELIMITER).map((entry) => entry.trim()).filter(Boolean);
 }
 
-function importEntries(
-  dbManager: DatabaseManager,
-  counters: BackfillCounters,
-  entries: string[],
-  target: 'memory' | 'user' | 'failure',
-  project: string | null = null,
-): void {
-  for (const rawEntry of entries) {
-    counters.entriesScanned++;
-    try {
-      const parsed = parseMarkdownMemoryEntry(rawEntry, target, project);
-      const result = syncMemoryEntry(dbManager, parsed);
-      if (result.action === 'inserted') counters.imported++;
-      else counters.skipped++;
-    } catch (err) {
-      counters.warnings.push(
-        `${path.basename(project ?? 'global')}/${target}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
-  }
-}
-
 function scanProjectDirs(agentRoot: string, globalDir: string, projectsMemoryDir = "projects-memory"): Array<{ name: string; memoryFile: string }> {
-  const projectsRoot = path.join(agentRoot, projectsMemoryDir);
+  const projectsRoot = path.resolve(agentRoot, projectsMemoryDir);
   const projects = new Map<string, string>();
 
   if (fs.existsSync(projectsRoot)) {
     for (const name of fs.readdirSync(projectsRoot)) {
-      const dir = path.join(projectsRoot, name);
-      const memoryFile = path.join(dir, MEMORY_FILE);
-      if (fs.existsSync(dir) && fs.statSync(dir).isDirectory() && fs.existsSync(memoryFile)) {
+      if (!isSafeProjectName(name, projectsRoot)) continue;
+      const memoryFile = resolveAuthoritativeMemoryFile(projectsRoot, name);
+      if (memoryFile) {
         projects.set(name, memoryFile);
       }
     }
@@ -74,9 +62,9 @@ function scanProjectDirs(agentRoot: string, globalDir: string, projectsMemoryDir
     for (const name of fs.readdirSync(agentRoot)) {
       if ((globalDirName && name === globalDirName) || name === projectsMemoryDir || name === 'skills' || name.startsWith('.')) continue;
       if (projects.has(name)) continue;
-      const dir = path.join(agentRoot, name);
-      const memoryFile = path.join(dir, MEMORY_FILE);
-      if (fs.existsSync(dir) && fs.statSync(dir).isDirectory() && fs.existsSync(memoryFile)) {
+      if (!isSafeProjectName(name, resolvedAgentRoot)) continue;
+      const memoryFile = resolveAuthoritativeMemoryFile(resolvedAgentRoot, name);
+      if (memoryFile) {
         projects.set(name, memoryFile);
       }
     }
@@ -87,17 +75,73 @@ function scanProjectDirs(agentRoot: string, globalDir: string, projectsMemoryDir
     .filter(({ memoryFile }) => fs.existsSync(memoryFile));
 }
 
-export function syncMarkdownMemoriesToSqlite(
+function realpathIfPresent(filePath: string): string {
+  try {
+    return fs.realpathSync(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return path.resolve(filePath);
+    throw error;
+  }
+}
+
+function resolveAuthoritativeMemoryFile(root: string, projectName: string): string | null {
+  const canonicalRoot = realpathIfPresent(root);
+  if (!isSafeProjectName(projectName, path.resolve(root))) return null;
+
+  const projectDir = path.join(root, projectName);
+  let projectStat: fs.Stats;
+  try {
+    projectStat = fs.lstatSync(projectDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return path.join(canonicalRoot, projectName, MEMORY_FILE);
+    }
+    throw error;
+  }
+  if (projectStat.isSymbolicLink() || !projectStat.isDirectory()) return null;
+
+  const canonicalProjectDir = fs.realpathSync(projectDir);
+  if (path.dirname(canonicalProjectDir) !== canonicalRoot) return null;
+
+  const memoryFile = path.join(projectDir, MEMORY_FILE);
+  let memoryStat: fs.Stats;
+  try {
+    memoryStat = fs.lstatSync(memoryFile);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return path.join(canonicalProjectDir, MEMORY_FILE);
+    }
+    throw error;
+  }
+  if (memoryStat.isSymbolicLink() || !memoryStat.isFile()) return null;
+
+  const canonicalMemoryFile = fs.realpathSync(memoryFile);
+  if (path.dirname(canonicalMemoryFile) !== canonicalProjectDir || path.basename(canonicalMemoryFile) !== MEMORY_FILE) {
+    return null;
+  }
+  return canonicalMemoryFile;
+}
+
+function isSafeProjectName(name: string, projectsRoot: string): boolean {
+  if (!name || name === '.' || name === '..' || name.includes('/') || name.includes('\\') || path.isAbsolute(name)) {
+    return false;
+  }
+  const projectDir = path.resolve(projectsRoot, name);
+  return path.dirname(projectDir) === projectsRoot && path.basename(projectDir) === name;
+}
+
+export async function syncMarkdownMemoriesToSqlite(
   dbManager: DatabaseManager,
   globalDir: string,
   projectsMemoryDir?: string,
   agentRoot = AGENT_ROOT,
-): BackfillCounters & { projectCount: number } {
+): Promise<BackfillCounters & { projectCount: number }> {
   const counters: BackfillCounters = {
     filesScanned: 0,
     entriesScanned: 0,
     imported: 0,
     skipped: 0,
+    removed: 0,
     warnings: [],
   };
 
@@ -105,27 +149,74 @@ export function syncMarkdownMemoriesToSqlite(
   const globalUserFile = path.join(globalDir, USER_FILE);
   const globalFailureFile = path.join(globalDir, 'failures.md');
 
-  const importFile = (
-    filePath: string,
+  const reconcileFile = async (
+    filePath: string | null,
     target: 'memory' | 'user' | 'failure',
     project: string | null = null,
   ) => {
-    if (!fs.existsSync(filePath)) return;
-    counters.filesScanned++;
-    const entries = readEntries(filePath);
-    importEntries(dbManager, counters, entries, target, project);
+    const reconcile = () => {
+      if (filePath && fs.existsSync(filePath)) counters.filesScanned++;
+      const entries = filePath ? readEntries(filePath) : [];
+      counters.entriesScanned += entries.length;
+      try {
+        const result = target === 'failure'
+          ? reconcileMarkdownFailureScopes(dbManager, entries)
+          : reconcileMarkdownMemoryScope(dbManager, entries, target, project);
+        counters.imported += result.inserted;
+        counters.skipped += result.existing;
+        counters.removed += result.removed;
+      } catch (err) {
+        counters.warnings.push(
+          `${path.basename(project ?? 'global')}/${target}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    };
+    if (filePath) await withMarkdownMutationLock(filePath, reconcile);
+    else reconcile();
   };
 
-  importFile(globalMemoryFile, 'memory');
-  importFile(globalUserFile, 'user');
-  importFile(globalFailureFile, 'failure');
+  await reconcileFile(globalMemoryFile, 'memory');
+  await reconcileFile(globalUserFile, 'user');
+  await reconcileFile(globalFailureFile, 'failure');
 
   const projects = scanProjectDirs(agentRoot, globalDir, projectsMemoryDir);
-  for (const project of projects) {
-    importFile(project.memoryFile, 'memory', project.name);
+  const projectFiles = new Map(projects.map((project) => [project.name, project.memoryFile]));
+  const mirroredProjects = dbManager.getDb().prepare(`
+    SELECT DISTINCT project
+    FROM memories
+    WHERE project IS NOT NULL AND target = 'memory'
+  `).all() as Array<{ project: string }>;
+  const projectNames = new Set([
+    ...projectFiles.keys(),
+    ...mirroredProjects.map(({ project }) => project),
+  ]);
+  const projectsRoot = path.resolve(agentRoot, projectsMemoryDir ?? 'projects-memory');
+  for (const projectName of projectNames) {
+    const memoryFile = projectFiles.get(projectName)
+      ?? resolveAuthoritativeMemoryFile(projectsRoot, projectName);
+    await reconcileFile(memoryFile, 'memory', projectName);
   }
 
-  return { ...counters, projectCount: projects.length };
+  return { ...counters, projectCount: projectNames.size };
+}
+
+export async function migrateThenSyncMarkdownMemories(
+  dbManager: DatabaseManager,
+  legacyGlobalDir: string | null,
+  globalDir: string,
+  projectsMemoryDir?: string,
+  agentRoot = AGENT_ROOT,
+  migrationOptions: MigrationSyncOptions = {},
+): Promise<BackfillCounters & { projectCount: number }> {
+  if (legacyGlobalDir) {
+    const migration = await migrateExtensionRoot(legacyGlobalDir, globalDir, migrationOptions);
+    const sessionsFailure = migration.criticalFailures.find((failure) => failure.name === 'sessions.db');
+    if (sessionsFailure) {
+      throw new Error(`sessions.db migration failed: ${sessionsFailure.message}`);
+    }
+    migrationOptions.onMigrationSucceeded?.();
+  }
+  return await syncMarkdownMemoriesToSqlite(dbManager, globalDir, projectsMemoryDir, agentRoot);
 }
 
 export function registerSyncMarkdownMemoriesCommand(
@@ -136,19 +227,20 @@ export function registerSyncMarkdownMemoriesCommand(
   agentRoot = AGENT_ROOT,
 ): void {
   pi.registerCommand('memory-sync-markdown', {
-    description: 'Backfill Markdown memories into the SQLite search store',
+    description: 'Reconcile the SQLite search mirror with Markdown memories',
     handler: async (_args, ctx: ExtensionCommandContext) => {
-      ctx.ui.notify('🔄 Scanning Markdown memory files for SQLite backfill...', 'info');
+      ctx.ui.notify('🔄 Reconciling the SQLite search mirror with Markdown memories...', 'info');
 
       try {
-        const counters = syncMarkdownMemoriesToSqlite(dbManager, globalDir, projectsMemoryDir, agentRoot);
+        const counters = await syncMarkdownMemoriesToSqlite(dbManager, globalDir, projectsMemoryDir, agentRoot);
 
         let output = `\n✅ Markdown → SQLite sync complete!\n\n`;
         output += `📊 Results:\n`;
         output += `├─ Files scanned: ${counters.filesScanned}\n`;
         output += `├─ Entries scanned: ${counters.entriesScanned}\n`;
         output += `├─ Imported into SQLite: ${counters.imported}\n`;
-        output += `└─ Skipped as duplicates: ${counters.skipped}\n`;
+        output += `├─ Skipped as duplicates: ${counters.skipped}\n`;
+        output += `└─ Removed orphaned rows: ${counters.removed}\n`;
 
         if (counters.projectCount > 0) {
           output += `\n📁 Project memories scanned: ${counters.projectCount}\n`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@
  */
 
 import * as path from "node:path";
+import * as fs from "node:fs";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { MemoryStore } from "./store/memory-store.js";
 import { SkillStore } from "./store/skill-store.js";
@@ -45,14 +46,14 @@ import { registerInterviewCommand } from "./handlers/interview.js";
 import { registerSwitchProjectCommand } from "./handlers/switch-project.js";
 import { registerIndexSessionsCommand } from "./handlers/index-sessions.js";
 import { registerLearnMemoryCommand } from "./handlers/learn-memory.js";
-import { registerSyncMarkdownMemoriesCommand, syncMarkdownMemoriesToSqlite } from "./handlers/sync-markdown-memories.js";
+import { migrateThenSyncMarkdownMemories, registerSyncMarkdownMemoriesCommand } from "./handlers/sync-markdown-memories.js";
 import { registerPreviewContextCommand } from "./handlers/preview-context.js";
 import { loadConfig } from "./config.js";
 import { detectProject, detectProjectSkills } from "./project.js";
 import { buildPromptContext } from "./prompt-context.js";
 import { migrateLegacyProjectMemoryDirs } from "./project-memory-migration.js";
-import { migrateExtensionRoot } from "./extension-root-migration.js";
 import { AGENT_ROOT } from "./paths.js";
+import { isDatabaseMigrationPending } from "./extension-root-migration.js";
 
 export function resolveProjectSkillDiscovery(
   skillStore: SkillStore,
@@ -95,7 +96,7 @@ export default function (pi: ExtensionAPI) {
     : configuredMemoryDir;
 
   const shouldMigrateExtensionRoot = !configuredMemoryDir || pointsToLegacyMemoryDir;
-  let extensionRootMigrated = false;
+  let persistenceInitialized = false;
 
   const store = new MemoryStore({ ...config, memoryDir: globalDir });
   const project = detectProject(config.projectsMemoryDir);
@@ -109,6 +110,15 @@ export default function (pi: ExtensionAPI) {
     migrationSentinelPath: path.join(globalDir, ".skills-migrated-to-extension-storage"),
   });
   const dbManager = new DatabaseManager(globalDir);
+  let databaseMigrationPending = shouldMigrateExtensionRoot
+    && isDatabaseMigrationPending(legacyGlobalDir, globalDir);
+  if (databaseMigrationPending) {
+    dbManager.setOpenGuard(() => {
+      if (databaseMigrationPending) {
+        throw new Error("Legacy sessions.db migration is pending");
+      }
+    });
+  }
   const sessionsDir = path.join(agentRoot, "sessions");
 
   const refreshSkillProjectContext = (cwd?: string) => {
@@ -124,12 +134,6 @@ export default function (pi: ExtensionAPI) {
   // ~/.pi/agent/<project>/ layout. This is non-destructive: legacy folders
   // remain in place while entries are copied/merged into projects-memory/.
   migrateLegacyProjectMemoryDirs(agentRoot, config.projectsMemoryDir);
-  try {
-    syncMarkdownMemoriesToSqlite(dbManager, globalDir, config.projectsMemoryDir, agentRoot);
-  } catch {
-    // Best-effort only: failed SQLite backfill should not block extension startup.
-  }
-
   // Detect project from cwd using shared helper
   // Project-scoped store: ~/.pi/agent/<projectsMemoryDir>/<project_name>/
   const projectConfig = project.memoryDir
@@ -139,13 +143,25 @@ export default function (pi: ExtensionAPI) {
 
   // ── 1. Load memory from disk on session start ──
   pi.on("session_start", async (_event, ctx) => {
-    if (shouldMigrateExtensionRoot && !extensionRootMigrated) {
+    if (!persistenceInitialized) {
       try {
-        await migrateExtensionRoot(legacyGlobalDir, globalDir);
+        await migrateThenSyncMarkdownMemories(
+          dbManager,
+          shouldMigrateExtensionRoot ? legacyGlobalDir : null,
+          globalDir,
+          config.projectsMemoryDir,
+          agentRoot,
+          {
+            onMigrationSucceeded: () => {
+              databaseMigrationPending = false;
+              dbManager.setOpenGuard(null);
+            },
+          },
+        );
+        persistenceInitialized = true;
       } catch {
-        // best effort migration only
+        // Best-effort only: migration or SQLite backfill must not block startup.
       }
-      extensionRootMigrated = true;
     }
 
     refreshSkillProjectContext(ctx.cwd);
@@ -154,7 +170,7 @@ export default function (pi: ExtensionAPI) {
     await store.loadFromDisk();
     if (projectStore) await projectStore.loadFromDisk();
 
-    scheduleSessionBackfill(dbManager, sessionsDir, {
+    if (persistenceInitialized) scheduleSessionBackfill(dbManager, sessionsDir, {
       notify: (message, level) => {
         const ui = (ctx as { ui?: { notify?: (message: string, level?: string) => void } }).ui;
         if (ui?.notify) {

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -2,6 +2,8 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import { SCHEMA_SQL } from './schema.js';
+import { AtomicLockCoordinator } from './atomic-lock-coordinator.js';
+import { canonicalStoragePathSync } from './canonical-storage-path.js';
 
 type StatementLike = {
   run: (...args: any[]) => any;
@@ -34,10 +36,28 @@ type MovedDatabaseFile = {
 };
 
 export interface DatabaseRecoveryResult {
-  strategy: 'rebuilt' | 'recreated-empty';
+  strategy: 'rebuilt' | 'recreated-empty' | 'reused';
   backupPaths: string[];
   recoveredRows?: Record<string, number>;
   error?: string;
+}
+
+export interface DatabaseRecoveryOptions {
+  recoveryLockWaitMs?: number;
+  recoveryLockPollMs?: number;
+  recoveryLockStaleMs?: number;
+  recoveryCircuitLimit?: number;
+  recoveryCircuitWindowMs?: number;
+  recoveryBackupRetention?: number;
+}
+
+interface ResolvedDatabaseRecoveryOptions {
+  recoveryLockWaitMs: number;
+  recoveryLockPollMs: number;
+  recoveryLockStaleMs: number;
+  recoveryCircuitLimit: number;
+  recoveryCircuitWindowMs: number;
+  recoveryBackupRetention: number;
 }
 
 class DatabaseCorruptionError extends Error {
@@ -54,6 +74,14 @@ export const SQLITE_WAL_AUTOCHECKPOINT_PAGES = 1000;
 const DATABASE_FILE_SUFFIXES: readonly DatabaseFileSuffix[] = ['', '-wal', '-shm'];
 const MEMORY_TARGETS = new Set(['memory', 'user', 'failure']);
 const MEMORY_CATEGORIES = new Set(['failure', 'correction', 'insight', 'preference', 'convention', 'tool-quirk']);
+const DEFAULT_RECOVERY_OPTIONS: ResolvedDatabaseRecoveryOptions = {
+  recoveryLockWaitMs: 5000,
+  recoveryLockPollMs: 50,
+  recoveryLockStaleMs: 300000,
+  recoveryCircuitLimit: 3,
+  recoveryCircuitWindowMs: 300000,
+  recoveryBackupRetention: 3,
+};
 
 function quoteIdentifier(identifier: string): string {
   return `"${identifier.replace(/"/g, '""')}"`;
@@ -110,11 +138,26 @@ const Database = loadDatabaseCtor();
 
 export class DatabaseManager {
   private db: DatabaseLike | null = null;
-  private readonly dbPath: string;
+  private readonly displayDbPath: string;
+  private canonicalDbPath: string | null = null;
+  private readonly recoveryOptions: ResolvedDatabaseRecoveryOptions;
   private lastRecovery: DatabaseRecoveryResult | null = null;
+  private openGuard: (() => void) | null = null;
 
-  constructor(memoryDir: string) {
-    this.dbPath = path.join(memoryDir, 'sessions.db');
+  constructor(memoryDir: string, recoveryOptions: DatabaseRecoveryOptions = {}) {
+    this.displayDbPath = path.join(memoryDir, 'sessions.db');
+    this.recoveryOptions = { ...DEFAULT_RECOVERY_OPTIONS, ...recoveryOptions };
+  }
+
+  private get dbPath(): string {
+    if (!this.canonicalDbPath) {
+      this.canonicalDbPath = canonicalStoragePathSync(this.displayDbPath);
+    }
+    return this.canonicalDbPath;
+  }
+
+  setOpenGuard(guard: (() => void) | null): void {
+    this.openGuard = guard;
   }
 
   /**
@@ -147,6 +190,7 @@ export class DatabaseManager {
    */
   getDb(): DatabaseLike {
     if (!this.db) {
+      this.openGuard?.();
       this.db = this.open();
     }
     return this.db;
@@ -181,7 +225,15 @@ export class DatabaseManager {
    */
   recoverFromCorruption(cause?: unknown): DatabaseRecoveryResult {
     this.close();
-    const recovery = this.recoverDatabaseFile(cause);
+    let verifiedDb: DatabaseLike | null = null;
+    let recovery: DatabaseRecoveryResult;
+    try {
+      recovery = this.recoverDatabaseFile(cause, () => {
+        verifiedDb = this.openUnchecked();
+      });
+    } finally {
+      if (verifiedDb) this.safeClose(verifiedDb);
+    }
     this.lastRecovery = recovery;
     return recovery;
   }
@@ -202,9 +254,19 @@ export class DatabaseManager {
         throw err;
       }
 
-      const recovery = this.recoverDatabaseFile(err);
+      let recoveredDb: DatabaseLike | null = null;
+      let recovery: DatabaseRecoveryResult;
+      try {
+        recovery = this.recoverDatabaseFile(err, () => {
+          recoveredDb = this.openUnchecked();
+        });
+      } catch (error) {
+        if (recoveredDb) this.safeClose(recoveredDb);
+        throw error;
+      }
       this.lastRecovery = recovery;
-      return this.openUnchecked();
+      if (!recoveredDb) throw new Error(`SQLite recovery verification did not open ${this.displayDbPath}`);
+      return recoveredDb;
     }
   }
 
@@ -297,7 +359,55 @@ export class DatabaseManager {
     }
   }
 
-  private recoverDatabaseFile(cause?: unknown): DatabaseRecoveryResult {
+  private recoverDatabaseFile(cause: unknown, verify: () => void): DatabaseRecoveryResult {
+    const coordinator = new AtomicLockCoordinator(path.join(path.dirname(this.dbPath), '.pi-hermes-locks.sqlite'));
+    const lockKey = `recovery:${this.dbPath}`;
+    const deadline = Date.now() + Math.max(0, this.recoveryOptions.recoveryLockWaitMs);
+
+    while (true) {
+      const lease = coordinator.tryAcquire(lockKey, { staleMs: this.recoveryOptions.recoveryLockStaleMs });
+      if (!lease) {
+        if (Date.now() >= deadline) {
+          throw new Error(`SQLite recovery already in progress for ${this.displayDbPath}; timed out after ${this.recoveryOptions.recoveryLockWaitMs}ms`);
+        }
+        DatabaseManager.sleepSync(Math.min(
+          this.recoveryOptions.recoveryLockPollMs,
+          Math.max(1, deadline - Date.now()),
+        ));
+        continue;
+      }
+
+      try {
+        if (this.currentDatabaseIsHealthy()) {
+          try {
+            verify();
+            this.clearRecoveryFailuresBestEffort();
+            return { strategy: 'reused', backupPaths: [] };
+          } catch (error) {
+            this.recordRecoveryFailure();
+            throw error;
+          }
+        }
+
+        this.assertRecoveryCircuitClosed();
+        try {
+          this.cleanupRecoveryArtifactsBestEffort();
+          const result = this.recoverDatabaseFileUnlocked(cause);
+          verify();
+          this.cleanupRecoveryArtifactsBestEffort();
+          this.clearRecoveryFailuresBestEffort();
+          return result;
+        } catch (error) {
+          this.recordRecoveryFailure();
+          throw error;
+        }
+      } finally {
+        lease.release();
+      }
+    }
+  }
+
+  private recoverDatabaseFileUnlocked(cause?: unknown): DatabaseRecoveryResult {
     const backupBase = this.corruptBackupBase();
     let rebuildError: unknown;
 
@@ -315,6 +425,112 @@ export class DatabaseManager {
       backupPaths: moved.map((file) => file.backup),
       error: DatabaseManager.errorMessage(rebuildError ?? cause ?? 'unknown corruption'),
     };
+  }
+
+  private currentDatabaseIsHealthy(): boolean {
+    if (!this.hasExistingMainDatabaseFile()) return false;
+    let db: DatabaseLike | null = null;
+    try {
+      db = new Database(this.dbPath);
+      this.assertIntegrityOk(db, 'quick_check', 'while joining corruption recovery');
+      return true;
+    } catch {
+      return false;
+    } finally {
+      if (db) this.safeClose(db);
+    }
+  }
+
+  private recoveryCircuitPath(): string {
+    return `${this.dbPath}.recovery-state.json`;
+  }
+
+  private recentRecoveryFailures(): number[] {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(this.recoveryCircuitPath(), 'utf-8')) as { failures?: unknown };
+      if (!Array.isArray(parsed.failures)) return [];
+      const cutoff = Date.now() - Math.max(0, this.recoveryOptions.recoveryCircuitWindowMs);
+      return parsed.failures.filter((value): value is number => typeof value === 'number' && value >= cutoff);
+    } catch {
+      return [];
+    }
+  }
+
+  private assertRecoveryCircuitClosed(): void {
+    if (this.recentRecoveryFailures().length >= Math.max(1, this.recoveryOptions.recoveryCircuitLimit)) {
+      throw new Error(
+        `SQLite recovery circuit is open for ${this.displayDbPath}: too many failed recovery attempts within ${this.recoveryOptions.recoveryCircuitWindowMs}ms`,
+      );
+    }
+  }
+
+  private recordRecoveryFailure(): void {
+    const statePath = this.recoveryCircuitPath();
+    const tempPath = `${statePath}.tmp-${process.pid}-${Math.random().toString(16).slice(2, 8)}`;
+    const failures = [...this.recentRecoveryFailures(), Date.now()];
+    try {
+      fs.writeFileSync(tempPath, JSON.stringify({ failures }), { encoding: 'utf-8', mode: 0o600 });
+      fs.renameSync(tempPath, statePath);
+    } finally {
+      fs.rmSync(tempPath, { force: true });
+    }
+  }
+
+  private clearRecoveryFailures(): void {
+    fs.rmSync(this.recoveryCircuitPath(), { force: true });
+  }
+
+  private clearRecoveryFailuresBestEffort(): void {
+    try { this.clearRecoveryFailures(); } catch {}
+  }
+
+  private cleanupRecoveryArtifactsBestEffort(): void {
+    try { this.cleanupRecoveryArtifacts(); } catch {}
+  }
+
+  private cleanupRecoveryArtifacts(): void {
+    const dir = path.dirname(this.dbPath);
+    const databaseName = path.basename(this.dbPath);
+    let names: string[];
+    try {
+      names = fs.readdirSync(dir);
+    } catch {
+      return;
+    }
+
+    for (const name of names) {
+      if (name.startsWith(`${databaseName}.rebuild-`)) {
+        fs.rmSync(path.join(dir, name), { recursive: true, force: true });
+      }
+    }
+
+    const backupGroups = new Map<string, number>();
+    for (const name of names) {
+      if (!name.startsWith(`${databaseName}.corrupt-`)) continue;
+      const group = name.replace(/-(?:wal|shm)$/, '');
+      try {
+        const mtimeMs = fs.statSync(path.join(dir, name)).mtimeMs;
+        backupGroups.set(group, Math.max(backupGroups.get(group) ?? 0, mtimeMs));
+      } catch {
+        // Artifact disappeared while scanning.
+      }
+    }
+
+    const retained = Math.max(0, this.recoveryOptions.recoveryBackupRetention);
+    const expired = [...backupGroups.entries()]
+      .sort((left, right) => right[1] - left[1])
+      .slice(retained);
+    for (const [group] of expired) {
+      for (const suffix of DATABASE_FILE_SUFFIXES) {
+        fs.rmSync(path.join(dir, `${group}${suffix}`), { force: true });
+      }
+    }
+  }
+
+  private static sleepSync(milliseconds: number): void {
+    if (milliseconds <= 0) return;
+    const signal = new Int32Array(new SharedArrayBuffer(4));
+    Atomics.wait(signal, 0, 0, milliseconds);
   }
 
   private rebuildDatabaseFromReadableRows(backupBase: string): DatabaseRecoveryResult {
@@ -765,7 +981,7 @@ export class DatabaseManager {
    * Get the database file path.
    */
   getPath(): string {
-    return this.dbPath;
+    return this.displayDbPath;
   }
 
   /**

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -143,6 +143,7 @@ export class DatabaseManager {
   private readonly recoveryOptions: ResolvedDatabaseRecoveryOptions;
   private lastRecovery: DatabaseRecoveryResult | null = null;
   private openGuard: (() => void) | null = null;
+  private activeRecoveryLease: { coordinator: AtomicLockCoordinator; key: string; token: string } | null = null;
 
   constructor(memoryDir: string, recoveryOptions: DatabaseRecoveryOptions = {}) {
     this.displayDbPath = path.join(memoryDir, 'sessions.db');
@@ -377,6 +378,7 @@ export class DatabaseManager {
         continue;
       }
 
+      this.activeRecoveryLease = { coordinator, key: lockKey, token: lease.token };
       try {
         if (this.currentDatabaseIsHealthy()) {
           try {
@@ -402,6 +404,7 @@ export class DatabaseManager {
           throw error;
         }
       } finally {
+        this.activeRecoveryLease = null;
         lease.release();
       }
     }
@@ -771,6 +774,7 @@ export class DatabaseManager {
   }
 
   private moveDatabaseFilesToBackup(backupBase: string): MovedDatabaseFile[] {
+    this.assertStillRecoveryOwner();
     const moved: MovedDatabaseFile[] = [];
     for (const suffix of DATABASE_FILE_SUFFIXES) {
       const original = `${this.dbPath}${suffix}`;
@@ -782,6 +786,21 @@ export class DatabaseManager {
       moved.push({ original, backup });
     }
     return moved;
+  }
+
+  /**
+   * Verifies this instance still holds the recovery lease immediately before
+   * a destructive rename that has no independent compare-and-swap of its
+   * own (unlike the Markdown mutation path, which re-checks a content
+   * fingerprint at publish time). If the lease was reclaimed as stale while
+   * this call was in flight, abort rather than race the new owner.
+   */
+  private assertStillRecoveryOwner(): void {
+    const active = this.activeRecoveryLease;
+    if (!active) return;
+    if (!active.coordinator.isCurrentOwner(active.key, active.token)) {
+      throw new Error(`SQLite recovery lease lost for ${this.displayDbPath}; another process took over`);
+    }
   }
 
   private restoreMovedDatabaseFiles(moved: MovedDatabaseFile[]): void {

--- a/src/store/sqlite-memory-store.ts
+++ b/src/store/sqlite-memory-store.ts
@@ -74,6 +74,12 @@ export interface SqliteMemoryRemoveOptions {
   project?: string | null;
 }
 
+export interface MarkdownMemoryReconcileResult {
+  inserted: number;
+  existing: number;
+  removed: number;
+}
+
 export interface ParsedMarkdownMemoryEntry extends SqliteMemorySyncInput {}
 
 function today(): string {
@@ -179,13 +185,18 @@ function escapeLikePattern(text: string): string {
   return text.replace(/[\\%_]/g, '\\$&');
 }
 
-function parseMetadataComment(raw: string): { text: string; created: string; lastReferenced: string } {
-  const match = raw.match(/^(.*?)\s*<!--\s*created=([^,]+),\s*last=([^>]+)\s*-->\s*$/);
+function parseMetadataComment(raw: string): { text: string; created: string; lastReferenced: string; project: string | null } {
+  const match = raw.match(/^(.*?)\s*<!--\s*created=([^,]+),\s*last=([^,>]+)(?:,\s*project64=([A-Za-z0-9_-]+))?\s*-->\s*$/);
   if (match) {
+    let project: string | null = null;
+    if (match[4]) {
+      try { project = Buffer.from(match[4], 'base64url').toString('utf-8').trim() || null; } catch {}
+    }
     return {
       text: match[1].trim(),
       created: match[2].trim(),
       lastReferenced: match[3].trim(),
+      project,
     };
   }
 
@@ -194,6 +205,7 @@ function parseMetadataComment(raw: string): { text: string; created: string; las
     text: raw.trim(),
     created: fallback,
     lastReferenced: fallback,
+    project: null,
   };
 }
 
@@ -251,7 +263,6 @@ export function formatFailureMemoryContent(
   if (options.failureReason) parts.push(`Failed: ${options.failureReason}`);
   if (options.toolState) parts.push(`Tool state: ${options.toolState}`);
   if (options.correctedTo) parts.push(`Corrected to: ${options.correctedTo}`);
-  if (options.project) parts.push(`Project: ${options.project}`);
   return parts.join(' — ');
 }
 
@@ -265,7 +276,8 @@ export function parseMarkdownMemoryEntry(
   target: 'memory' | 'user' | 'failure',
   project: string | null = null,
 ): ParsedMarkdownMemoryEntry {
-  const { text, created, lastReferenced } = parseMetadataComment(rawEntry);
+  const metadata = parseMetadataComment(rawEntry);
+  const { text, created, lastReferenced } = metadata;
   const parsedProject = normalizeNullable(project);
 
   if (target !== 'failure') {
@@ -401,6 +413,111 @@ export function syncMemoryEntry(
     action: 'existing',
     entry: getMemoryById(dbManager, existing.id)!,
   };
+}
+
+/**
+ * Make one exact Markdown target/project scope authoritative in SQLite.
+ * Upserts and orphan deletion are committed together when transactions are
+ * supported by the active SQLite driver.
+ */
+export function reconcileMarkdownMemoryScope(
+  dbManager: DatabaseManager,
+  rawEntries: string[],
+  target: 'memory' | 'user' | 'failure',
+  project: string | null = null,
+): MarkdownMemoryReconcileResult {
+  const db = dbManager.getDb();
+  const normalizedProject = normalizeNullable(project);
+
+  const reconcile = (): MarkdownMemoryReconcileResult => {
+    let inserted = 0;
+    let existing = 0;
+    const desiredIdentities = new Set<string>();
+
+    for (const rawEntry of rawEntries) {
+      const parsed = parseMarkdownMemoryEntry(rawEntry, target, normalizedProject);
+      desiredIdentities.add(JSON.stringify([
+        normalizeCategory(parsed.category),
+        parsed.content.trim(),
+      ]));
+      const result = syncMemoryEntry(dbManager, parsed);
+      if (result.action === 'inserted') inserted++;
+      else existing++;
+    }
+
+    const params: unknown[] = [];
+    const conditions = buildScopeConditions(params, target, normalizedProject);
+    const scopedRows = db.prepare(`
+      SELECT id, content, category
+      FROM memories
+      WHERE ${conditions.join(' AND ')}
+      ORDER BY id ASC
+    `).all(...params) as Array<{ id: number; content: string; category: MemoryCategory | null }>;
+    const retainedIdentities = new Set<string>();
+    const orphanIds: number[] = [];
+    for (const row of scopedRows) {
+      const identity = JSON.stringify([normalizeCategory(row.category), row.content.trim()]);
+      if (!desiredIdentities.has(identity) || retainedIdentities.has(identity)) {
+        orphanIds.push(row.id);
+      } else {
+        retainedIdentities.add(identity);
+      }
+    }
+
+    let removed = 0;
+    if (orphanIds.length > 0) {
+      const placeholders = orphanIds.map(() => '?').join(', ');
+      removed = db.prepare(`DELETE FROM memories WHERE id IN (${placeholders})`).run(...orphanIds).changes;
+    }
+
+    return { inserted, existing, removed };
+  };
+
+  const transactional = db.transaction?.(reconcile);
+  return transactional ? transactional() : reconcile();
+}
+
+function failureProject(rawEntry: string): string | null {
+  return parseMetadataComment(rawEntry).project;
+}
+
+export function reconcileMarkdownFailureScopes(
+  dbManager: DatabaseManager,
+  rawEntries: string[],
+): MarkdownMemoryReconcileResult {
+  const entriesByProject = new Map<string | null, string[]>();
+  for (const rawEntry of rawEntries) {
+    const project = failureProject(rawEntry);
+    const entries = entriesByProject.get(project) ?? [];
+    entries.push(rawEntry);
+    entriesByProject.set(project, entries);
+  }
+
+  const mirroredProjects = dbManager.getDb().prepare(`
+    SELECT DISTINCT project
+    FROM memories
+    WHERE target = 'failure'
+  `).all() as Array<{ project: string | null }>;
+  const projects = new Set<string | null>([
+    null,
+    ...entriesByProject.keys(),
+    ...mirroredProjects.map(({ project }) => normalizeNullable(project)),
+  ]);
+  const total: MarkdownMemoryReconcileResult = { inserted: 0, existing: 0, removed: 0 };
+
+  for (const project of projects) {
+    const result = reconcileMarkdownMemoryScope(
+      dbManager,
+      entriesByProject.get(project) ?? [],
+      'failure',
+      project,
+    );
+    total.inserted += result.inserted;
+    total.existing += result.existing;
+    total.removed += result.removed;
+  }
+
+  return total;
 }
 
 /**

--- a/src/tools/memory-tool.ts
+++ b/src/tools/memory-tool.ts
@@ -11,6 +11,8 @@ import { MemoryStore } from "../store/memory-store.js";
 import { DatabaseManager } from "../store/db.js";
 import {
   formatFailureMemoryContent,
+  reconcileMarkdownFailureScopes,
+  reconcileMarkdownMemoryScope,
   removeExactSyncedMemories,
   removeSyncedMemories,
   replaceSyncedMemories,
@@ -185,6 +187,31 @@ async function syncEvictionsFromSqlite(
   }
 }
 
+async function reconcileStoreScope(
+  entries: string[],
+  rawTarget: "memory" | "user" | "project" | "failure",
+  dbManager: DatabaseManager | null,
+  projectName?: string | null,
+): Promise<string | null | undefined> {
+  if (!dbManager) return undefined;
+  try {
+    if (rawTarget === "failure") {
+      reconcileMarkdownFailureScopes(dbManager, entries);
+      return null;
+    }
+    const target = sqliteTargetFor(rawTarget);
+    reconcileMarkdownMemoryScope(
+      dbManager,
+      entries,
+      target,
+      sqliteProjectFor(rawTarget, projectName) ?? null,
+    );
+    return null;
+  } catch (err) {
+    return `Saved to Markdown, but SQLite search reconciliation failed: ${err instanceof Error ? err.message : String(err)}`;
+  }
+}
+
 export function registerMemoryTool(
   pi: ExtensionAPI,
   store: MemoryStore,
@@ -192,6 +219,16 @@ export function registerMemoryTool(
   dbManager: DatabaseManager | null = null,
   projectName?: string | null,
 ): void {
+  const reconciledStores = new WeakSet<MemoryStore>();
+  if (typeof store.setMutationObserver === "function") {
+    store.setMutationObserver((target, entries) => reconcileStoreScope(entries, target, dbManager, projectName));
+    reconciledStores.add(store);
+  }
+  if (projectStore && typeof projectStore.setMutationObserver === "function") {
+    projectStore.setMutationObserver((_target, entries) => reconcileStoreScope(entries, "project", dbManager, projectName));
+    reconciledStores.add(projectStore);
+  }
+
   pi.registerTool({
     name: "memory",
     label: "Memory",
@@ -244,6 +281,7 @@ export function registerMemoryTool(
 
       let result: MemoryResult;
       let syncWarning: string | null = null;
+      const syncHandled = reconciledStores.has(store_);
       switch (action) {
         case "add":
           if (!content) {
@@ -267,12 +305,12 @@ export function registerMemoryTool(
               category: memoryCategory,
               failureReason: failure_reason,
             });
-            if (result.success) {
+            if (result.success && !syncHandled) {
               syncWarning = await syncAddToSqlite(rawTarget, content, memoryCategory, failure_reason, dbManager, projectName);
             }
           } else {
-            result = await store_.add(target, content);
-            if (result.success) {
+            result = await store_.add(target, content, signal);
+            if (result.success && !syncHandled) {
               await syncEvictionsFromSqlite(rawTarget, result.evicted_entries, dbManager, projectName);
               syncWarning = await syncAddToSqlite(rawTarget, content, undefined, undefined, dbManager, projectName);
             }
@@ -309,9 +347,7 @@ export function registerMemoryTool(
             };
           }
           result = await store_.replace(target, old_text, content);
-          if (result.success) {
-            syncWarning = await syncReplaceToSqlite(rawTarget, old_text, content, dbManager, projectName);
-          }
+          if (result.success && !syncHandled) syncWarning = await syncReplaceToSqlite(rawTarget, old_text, content, dbManager, projectName);
           break;
 
         case "remove":
@@ -330,9 +366,7 @@ export function registerMemoryTool(
             };
           }
           result = await store_.remove(target, old_text);
-          if (result.success) {
-            syncWarning = await syncRemoveFromSqlite(rawTarget, old_text, dbManager, projectName);
-          }
+          if (result.success && !syncHandled) syncWarning = await syncRemoveFromSqlite(rawTarget, old_text, dbManager, projectName);
           break;
 
         default:
@@ -340,6 +374,11 @@ export function registerMemoryTool(
             success: false,
             error: `Unknown action '${action}'. Use: add, replace, remove`,
           };
+      }
+
+      if (result.success && !syncHandled && typeof store_.getRawEntriesForSync === "function") {
+        const reconciliationWarning = await reconcileStoreScope(store_.getRawEntriesForSync(target), rawTarget, dbManager, projectName);
+        if (reconciliationWarning !== undefined) syncWarning = reconciliationWarning;
       }
 
       if (syncWarning && result.success) {

--- a/tests/extension-root-migration.test.ts
+++ b/tests/extension-root-migration.test.ts
@@ -3,7 +3,11 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { migrateExtensionRoot } from "../src/extension-root-migration.js";
+import Database from "better-sqlite3";
+import {
+  isDatabaseMigrationPending,
+  migrateExtensionRoot,
+} from "../src/extension-root-migration.js";
 
 let tmpDir = "";
 
@@ -44,5 +48,321 @@ describe("migrateExtensionRoot", () => {
 
     assert.strictEqual(fs.readFileSync(path.join(target, "MEMORY.md"), "utf-8"), "new memory");
     assert.ok(result.skipped >= 1);
+  });
+
+  it("reports a failed sessions database move as critical", async () => {
+    const legacy = path.join(tmpDir, "memory");
+    const target = path.join(tmpDir, "pi-hermes-memory");
+    fs.mkdirSync(legacy, { recursive: true });
+    const sourceDb = new Database(path.join(legacy, "sessions.db"));
+    sourceDb.exec("CREATE TABLE retained (value TEXT); INSERT INTO retained VALUES ('legacy')");
+    sourceDb.close();
+
+    const result = await migrateExtensionRoot(legacy, target, {
+      publishDatabaseFile: async () => {
+        throw new Error("injected sessions.db move failure");
+      },
+    });
+
+    assert.deepStrictEqual(
+      result.criticalFailures.map((failure) => failure.name),
+      ["sessions.db"],
+    );
+    assert.equal(fs.existsSync(path.join(target, "sessions.db")), false);
+    assert.equal(fs.existsSync(path.join(legacy, "sessions.db")), true);
+  });
+
+  it("publishes the complete SQLite generation and removes the legacy set", async () => {
+    const legacy = path.join(tmpDir, "memory");
+    const target = path.join(tmpDir, "pi-hermes-memory");
+    fs.mkdirSync(legacy, { recursive: true });
+    const sourceDb = new Database(path.join(legacy, "sessions.db"));
+    try {
+      sourceDb.pragma("journal_mode = WAL");
+      sourceDb.pragma("wal_autocheckpoint = 0");
+      sourceDb.exec("CREATE TABLE memories (content TEXT)");
+      sourceDb.pragma("wal_checkpoint(TRUNCATE)");
+      sourceDb.prepare("INSERT INTO memories VALUES (?)").run("committed only in WAL");
+      assert.equal(fs.existsSync(path.join(legacy, "sessions.db-wal")), true);
+
+      const result = await migrateExtensionRoot(legacy, target);
+
+      assert.deepStrictEqual(result.criticalFailures, []);
+      const migrated = new Database(path.join(target, "sessions.db"), { readonly: true });
+      try {
+        assert.equal(
+          (migrated.prepare("SELECT content FROM memories").get() as { content: string }).content,
+          "committed only in WAL",
+        );
+      } finally {
+        migrated.close();
+      }
+      for (const name of ["sessions.db", "sessions.db-wal", "sessions.db-shm"]) {
+        assert.equal(fs.existsSync(path.join(legacy, name)), false);
+      }
+    } finally {
+      sourceDb.close();
+    }
+  });
+
+  it("migrates one SQLite snapshot while a checkpoint runs", async () => {
+    const legacy = path.join(tmpDir, "memory");
+    const target = path.join(tmpDir, "pi-hermes-memory");
+    fs.mkdirSync(legacy, { recursive: true });
+    const sourceDb = new Database(path.join(legacy, "sessions.db"));
+    let checkpointTriggered = false;
+    try {
+      sourceDb.pragma("journal_mode = WAL");
+      sourceDb.pragma("wal_autocheckpoint = 0");
+      sourceDb.pragma("busy_timeout = 0");
+      sourceDb.exec("CREATE TABLE memories (content TEXT)");
+      sourceDb.pragma("wal_checkpoint(TRUNCATE)");
+      const insert = sourceDb.prepare("INSERT INTO memories VALUES (?)");
+      const insertMany = sourceDb.transaction(() => {
+        for (let index = 0; index < 500; index++) insert.run(`committed-${index}-${"x".repeat(1024)}`);
+      });
+      insertMany();
+
+      const result = await migrateExtensionRoot(legacy, target, {
+        onDatabaseBackupProgress: () => {
+          if (checkpointTriggered) return;
+          checkpointTriggered = true;
+          sourceDb.pragma("wal_checkpoint(TRUNCATE)");
+        },
+      });
+
+      assert.equal(checkpointTriggered, true);
+      assert.deepStrictEqual(result.criticalFailures, []);
+      assert.equal(fs.existsSync(path.join(target, "sessions.db-wal")), false);
+      assert.equal(fs.existsSync(path.join(target, "sessions.db-shm")), false);
+      const migrated = new Database(path.join(target, "sessions.db"), { readonly: true });
+      try {
+        assert.equal(
+          (migrated.prepare("SELECT COUNT(*) AS count FROM memories").get() as { count: number }).count,
+          500,
+        );
+        assert.deepStrictEqual(migrated.pragma("integrity_check"), [{ integrity_check: "ok" }]);
+      } finally {
+        migrated.close();
+      }
+    } finally {
+      sourceDb.close();
+    }
+  });
+
+  it("holds a write exclusion through snapshot publication and source retirement", async () => {
+    const legacy = path.join(tmpDir, "memory");
+    const target = path.join(tmpDir, "pi-hermes-memory");
+    fs.mkdirSync(legacy, { recursive: true });
+    const sourceDb = new Database(path.join(legacy, "sessions.db"));
+    let concurrentWriteCode = "";
+    try {
+      sourceDb.pragma("journal_mode = WAL");
+      sourceDb.pragma("busy_timeout = 0");
+      sourceDb.exec("CREATE TABLE memories (content TEXT); INSERT INTO memories VALUES ('before migration')");
+
+      const result = await migrateExtensionRoot(legacy, target, {
+        onDatabaseBackupProgress: () => {
+          if (concurrentWriteCode) return;
+          try {
+            sourceDb.prepare("INSERT INTO memories VALUES (?)").run("raced migration");
+          } catch (error) {
+            concurrentWriteCode = (error as { code?: string }).code ?? "unknown";
+          }
+        },
+      });
+
+      assert.equal(concurrentWriteCode, "SQLITE_BUSY");
+      assert.deepStrictEqual(result.criticalFailures, []);
+      const migrated = new Database(path.join(target, "sessions.db"), { readonly: true });
+      try {
+        assert.deepStrictEqual(
+          migrated.prepare("SELECT content FROM memories ORDER BY rowid").all(),
+          [{ content: "before migration" }],
+        );
+      } finally {
+        migrated.close();
+      }
+      assert.equal(fs.existsSync(path.join(legacy, "sessions.db")), false);
+    } finally {
+      sourceDb.close();
+    }
+  });
+
+  it("rolls back a failed source retirement so migration can retry", async () => {
+    const legacy = path.join(tmpDir, "memory");
+    const target = path.join(tmpDir, "pi-hermes-memory");
+    fs.mkdirSync(legacy, { recursive: true });
+    const sourceDb = new Database(path.join(legacy, "sessions.db"));
+    sourceDb.exec("CREATE TABLE retained (value TEXT); INSERT INTO retained VALUES ('legacy')");
+    sourceDb.close();
+
+    const failed = await migrateExtensionRoot(legacy, target, {
+      retireDatabaseFile: async (source, destination) => {
+        await fs.promises.rename(source, destination);
+        throw new Error("injected source retirement failure");
+      },
+    });
+
+    assert.deepStrictEqual(failed.criticalFailures.map(({ name }) => name), ["sessions.db"]);
+    assert.equal(fs.existsSync(path.join(legacy, "sessions.db")), true);
+    assert.equal(fs.existsSync(path.join(target, "sessions.db")), false);
+
+    const retried = await migrateExtensionRoot(legacy, target);
+    assert.deepStrictEqual(retried.criticalFailures, []);
+    const migrated = new Database(path.join(target, "sessions.db"), { readonly: true });
+    try {
+      assert.deepStrictEqual(migrated.prepare("SELECT value FROM retained").all(), [{ value: "legacy" }]);
+    } finally {
+      migrated.close();
+    }
+  });
+
+  it("does not delete a destination created while source retirement fails", async () => {
+    const legacy = path.join(tmpDir, "memory");
+    const target = path.join(tmpDir, "pi-hermes-memory");
+    fs.mkdirSync(legacy, { recursive: true });
+    const sourceDb = new Database(path.join(legacy, "sessions.db"));
+    sourceDb.exec("CREATE TABLE retained (value TEXT); INSERT INTO retained VALUES ('legacy')");
+    sourceDb.close();
+
+    const failed = await migrateExtensionRoot(legacy, target, {
+      retireDatabaseFile: async (source, destination) => {
+        await fs.promises.rename(source, destination);
+        const concurrent = new Database(path.join(target, "sessions.db"));
+        concurrent.exec("CREATE TABLE retained (value TEXT); INSERT INTO retained VALUES ('concurrent')");
+        concurrent.close();
+        throw new Error("injected source retirement failure");
+      },
+    });
+
+    assert.deepStrictEqual(failed.criticalFailures.map(({ name }) => name), ["sessions.db"]);
+    const concurrent = new Database(path.join(target, "sessions.db"), { readonly: true });
+    try {
+      assert.deepStrictEqual(concurrent.prepare("SELECT value FROM retained").all(), [{ value: "concurrent" }]);
+    } finally {
+      concurrent.close();
+    }
+    assert.equal(fs.existsSync(path.join(legacy, "sessions.db")), true);
+    assert.equal(isDatabaseMigrationPending(legacy, target), true);
+    const retried = await migrateExtensionRoot(legacy, target);
+    assert.deepStrictEqual(retried.criticalFailures.map(({ name }) => name), ["sessions.db"]);
+  });
+
+  it("keeps corrupt generation publication behind the pending boundary", async () => {
+    const legacy = path.join(tmpDir, "memory");
+    const target = path.join(tmpDir, "pi-hermes-memory");
+    fs.mkdirSync(legacy, { recursive: true });
+    fs.writeFileSync(path.join(legacy, "sessions.db"), "not sqlite", "utf-8");
+    fs.writeFileSync(path.join(legacy, "sessions.db-wal"), "legacy wal", "utf-8");
+    const observations: boolean[] = [];
+
+    const result = await migrateExtensionRoot(legacy, target, {
+      publishDatabaseFile: async (source, destination) => {
+        observations.push(isDatabaseMigrationPending(legacy, target));
+        await fs.promises.link(source, destination);
+      },
+    });
+
+    assert.deepStrictEqual(result.criticalFailures, []);
+    assert.ok(observations.length >= 1);
+    assert.ok(observations.every(Boolean));
+    assert.equal(isDatabaseMigrationPending(legacy, target), false);
+    assert.equal(fs.readFileSync(path.join(target, "sessions.db"), "utf-8"), "not sqlite");
+  });
+
+  it("preserves the retirement directory when rollback restoration is incomplete", async () => {
+    const legacy = path.join(tmpDir, "memory");
+    const target = path.join(tmpDir, "pi-hermes-memory");
+    fs.mkdirSync(legacy, { recursive: true });
+    const sourceDb = new Database(path.join(legacy, "sessions.db"));
+    sourceDb.exec("CREATE TABLE retained (value TEXT); INSERT INTO retained VALUES ('legacy')");
+    sourceDb.close();
+
+    const failed = await migrateExtensionRoot(legacy, target, {
+      retireDatabaseFile: async (source, destination) => {
+        await fs.promises.rename(source, destination);
+        fs.writeFileSync(source, "concurrent legacy successor", "utf-8");
+        throw new Error("injected retirement failure after move");
+      },
+    });
+
+    assert.deepStrictEqual(failed.criticalFailures.map(({ name }) => name), ["sessions.db"]);
+    const retirementDirs = fs.readdirSync(legacy).filter((name) => name.startsWith(".sessions-db-retirement-"));
+    assert.equal(retirementDirs.length, 1);
+    assert.equal(fs.existsSync(path.join(legacy, retirementDirs[0], "sessions.db")), true);
+    assert.equal(fs.readFileSync(path.join(legacy, "sessions.db"), "utf-8"), "concurrent legacy successor");
+    assert.match(failed.criticalFailures[0].message, /recovery artifacts preserved at/);
+    assert.equal(isDatabaseMigrationPending(legacy, target), true);
+  });
+
+  it("preserves the raw generation when backup detects corruption after locking", async () => {
+    const legacy = path.join(tmpDir, "memory");
+    const target = path.join(tmpDir, "pi-hermes-memory");
+    fs.mkdirSync(legacy, { recursive: true });
+    const sourceDb = new Database(path.join(legacy, "sessions.db"));
+    sourceDb.exec("CREATE TABLE retained (value TEXT); INSERT INTO retained VALUES ('raw generation')");
+    sourceDb.close();
+    let backupAttempted = false;
+
+    const result = await migrateExtensionRoot(legacy, target, {
+      backupDatabase: async () => {
+        backupAttempted = true;
+        throw Object.assign(new Error("database disk image is malformed"), { code: "SQLITE_CORRUPT" });
+      },
+    });
+
+    assert.equal(backupAttempted, true);
+    assert.deepStrictEqual(result.criticalFailures, []);
+    assert.equal(fs.existsSync(path.join(legacy, "sessions.db")), false);
+    const migrated = new Database(path.join(target, "sessions.db"), { readonly: true });
+    try {
+      assert.deepStrictEqual(migrated.prepare("SELECT value FROM retained").all(), [{ value: "raw generation" }]);
+    } finally {
+      migrated.close();
+    }
+  });
+
+  it("leaves the legacy SQLite generation retryable when snapshot publish fails", async () => {
+    const legacy = path.join(tmpDir, "memory");
+    const target = path.join(tmpDir, "pi-hermes-memory");
+    fs.mkdirSync(legacy, { recursive: true });
+    const sourceDb = new Database(path.join(legacy, "sessions.db"));
+    sourceDb.pragma("journal_mode = WAL");
+    sourceDb.exec("CREATE TABLE retained (value TEXT); INSERT INTO retained VALUES ('legacy')");
+    sourceDb.close();
+    let publishes = 0;
+
+    const result = await migrateExtensionRoot(legacy, target, {
+      publishDatabaseFile: async (source, destination) => {
+        publishes++;
+        if (publishes === 1) throw new Error("injected snapshot publish failure");
+        await fs.promises.link(source, destination);
+      },
+    });
+
+    assert.deepStrictEqual(result.criticalFailures.map(({ name }) => name), ["sessions.db"]);
+    assert.equal(publishes, 1);
+    for (const name of ["sessions.db", "sessions.db-wal", "sessions.db-shm"]) {
+      if (name === "sessions.db") assert.equal(fs.existsSync(path.join(legacy, name)), true);
+      assert.equal(fs.existsSync(path.join(target, name)), false);
+    }
+  });
+
+  it("never mixes legacy sidecars into an existing destination generation", async () => {
+    const legacy = path.join(tmpDir, "memory");
+    const target = path.join(tmpDir, "pi-hermes-memory");
+    fs.mkdirSync(legacy, { recursive: true });
+    fs.mkdirSync(target, { recursive: true });
+    fs.writeFileSync(path.join(legacy, "sessions.db"), "legacy database", "utf-8");
+    fs.writeFileSync(path.join(legacy, "sessions.db-wal"), "legacy wal", "utf-8");
+    fs.writeFileSync(path.join(target, "sessions.db"), "destination database", "utf-8");
+
+    const result = await migrateExtensionRoot(legacy, target);
+
+    assert.deepStrictEqual(result.criticalFailures, []);
+    assert.equal(fs.readFileSync(path.join(target, "sessions.db"), "utf-8"), "destination database");
+    assert.equal(fs.existsSync(path.join(target, "sessions.db-wal")), false);
+    assert.equal(fs.readFileSync(path.join(legacy, "sessions.db-wal"), "utf-8"), "legacy wal");
   });
 });

--- a/tests/handlers/auto-consolidate.test.ts
+++ b/tests/handlers/auto-consolidate.test.ts
@@ -43,16 +43,6 @@ after(async () => {
   try { await fs.rm(LOCK_DIR, { recursive: true, force: true }); } catch { /* ignore */ }
 });
 
-function captureExecArgs(args: any[]): any[] {
-  const [command, childArgs, options] = args;
-  const capturedArgs = [...childArgs];
-  const promptReference = capturedArgs.at(-1);
-  if (typeof promptReference === "string" && promptReference.startsWith("@")) {
-    capturedArgs[capturedArgs.length - 1] = readFileSync(promptReference.slice(1), "utf-8");
-  }
-  return [command, capturedArgs, options];
-}
-
 function logicalChildArgs(call: any[]): string[] {
   const [cmd, args] = call;
   const logicalArgs = cmd === "pi" ? args : args.slice(1);

--- a/tests/handlers/correction-detector.test.ts
+++ b/tests/handlers/correction-detector.test.ts
@@ -10,6 +10,8 @@ import os from "node:os";
 import path from "node:path";
 import { DatabaseManager } from "../../src/store/db.js";
 import { getMemories } from "../../src/store/sqlite-memory-store.js";
+import { MemoryStore } from "../../src/store/memory-store.js";
+import { registerMemoryTool } from "../../src/tools/memory-tool.js";
 import { isCorrection, setupCorrectionDetector } from "../../src/handlers/correction-detector.js";
 import { resolveChildPiInvocation } from "../../src/handlers/pi-child-process.js";
 
@@ -377,10 +379,9 @@ describe("setupCorrectionDetector handler", () => {
 
   it("syncs direct correction saves into SQLite", async () => {
     const pi = createMockPi();
-    const correctionStore = {
-      ...mockStore,
-      addFailure: async () => ({ success: true, target: 'failure', entry_count: 1, message: 'Failure memory saved: correction' }),
-    } as any;
+    const correctionStore = new MemoryStore({ ...config, memoryDir: tmpDir } as any);
+    await correctionStore.loadFromDisk();
+    registerMemoryTool(pi, correctionStore, null, dbManager);
 
     setupCorrectionDetector(pi, correctionStore, null, config, dbManager);
 
@@ -396,17 +397,17 @@ describe("setupCorrectionDetector handler", () => {
     assert.strictEqual(failures.length, 1);
     assert.match(failures[0].content, /use pnpm instead/);
     assert.strictEqual(failures[0].category, 'correction');
+    assert.strictEqual(failures[0].project, null);
   });
 
   it("syncs project correction saves into SQLite with project scope", async () => {
     const pi = createMockPi();
-    const correctionStore = {
-      ...mockStore,
-      addFailure: async () => ({ success: true, target: 'failure', entry_count: 1, message: 'Failure memory saved: correction' }),
-    } as any;
+    const correctionStore = new MemoryStore({ ...config, memoryDir: tmpDir } as any);
+    await correctionStore.loadFromDisk();
     const projectStore = {
       getMemoryEntries: () => [],
     } as any;
+    registerMemoryTool(pi, correctionStore, projectStore, dbManager, 'project-a');
 
     setupCorrectionDetector(pi, correctionStore, projectStore, config, dbManager, 'project-a');
 
@@ -421,20 +422,15 @@ describe("setupCorrectionDetector handler", () => {
     const projectFailures = getMemories(dbManager, { target: 'failure', project: 'project-a' });
     assert.strictEqual(projectFailures.length, 1);
     assert.match(projectFailures[0].content, /use pnpm in this repo/);
-    assert.match(projectFailures[0].content, /Project: project-a/);
+    assert.doesNotMatch(projectFailures[0].content, /Project: project-a/);
     assert.strictEqual(projectFailures[0].category, 'correction');
+    assert.strictEqual(getMemories(dbManager, { target: 'failure', project: null }).length, 0);
   });
 
   it("does not break correction handling when SQLite sync fails", async () => {
     const pi = createMockPi();
-    let addFailureCalls = 0;
-    const correctionStore = {
-      ...mockStore,
-      addFailure: async () => {
-        addFailureCalls++;
-        return { success: true, target: 'failure', entry_count: 1, message: 'Failure memory saved: correction' };
-      },
-    } as any;
+    const correctionStore = new MemoryStore({ ...config, memoryDir: tmpDir } as any);
+    await correctionStore.loadFromDisk();
 
     const failingDbManager = {
       getDb: () => {
@@ -442,6 +438,7 @@ describe("setupCorrectionDetector handler", () => {
       },
     } as unknown as DatabaseManager;
 
+    registerMemoryTool(pi, correctionStore, null, failingDbManager);
     setupCorrectionDetector(pi, correctionStore, null, config, failingDbManager);
 
     const branch = [
@@ -453,7 +450,7 @@ describe("setupCorrectionDetector handler", () => {
     await fireTurnEnd(branch);
 
     assert.ok(execCalls.length >= 1, 'correction review should still run');
-    assert.strictEqual(addFailureCalls, 1, 'Markdown correction save should still happen');
+    assert.strictEqual(correctionStore.getFailureEntries().length, 1, 'Markdown correction save should still happen');
   });
 
   it("does not register handlers when correctionDetection is false", () => {

--- a/tests/handlers/review-memory-ops.test.ts
+++ b/tests/handlers/review-memory-ops.test.ts
@@ -10,6 +10,8 @@ import {
   buildDirectReviewCompletionOptions,
   parseReviewOperations,
 } from "../../src/handlers/review-memory-ops.js";
+import { DatabaseManager } from "../../src/store/db.js";
+import { reconcileMarkdownMemoryScope } from "../../src/store/sqlite-memory-store.js";
 
 function mockModel(reasoning: boolean): Model<Api> {
   return {
@@ -134,5 +136,42 @@ describe("applyReviewOperations", () => {
 
     assert.strictEqual(result.appliedCount, 0);
     assert.strictEqual(result.skippedCount, 1);
+  });
+
+  it("uses the in-lock mutation observer as the sole SQLite reconciliation path", async () => {
+    const store = new MemoryStore({
+      memoryDir: tmpDir,
+      memoryCharLimit: 5000,
+      userCharLimit: 5000,
+      autoConsolidate: true,
+    });
+    await store.loadFromDisk();
+
+    const dbManager = new DatabaseManager(path.join(tmpDir, "db"));
+    const originalGetDb = dbManager.getDb.bind(dbManager);
+    let insideObserver = false;
+    (dbManager as any).getDb = () => {
+      if (!insideObserver) throw new Error("out-of-lock SQLite access");
+      return originalGetDb();
+    };
+    store.setMutationObserver((_target, entries) => {
+      insideObserver = true;
+      try {
+        reconcileMarkdownMemoryScope(dbManager, entries, "memory", null);
+      } finally {
+        insideObserver = false;
+      }
+      return null;
+    });
+
+    try {
+      const result = await applyReviewOperations(store, null, [
+        { action: "add", target: "memory", content: "observer owns reconciliation" },
+      ], dbManager);
+
+      assert.strictEqual(result.appliedCount, 1);
+    } finally {
+      dbManager.close();
+    }
   });
 });

--- a/tests/handlers/session-live-index.test.ts
+++ b/tests/handlers/session-live-index.test.ts
@@ -194,7 +194,7 @@ describe('session live indexing handler', () => {
 
     assert.equal(attempts, 2);
     assert.equal(errors.length, 0);
-    assert.equal(dbManager.getLastRecovery()?.strategy, 'rebuilt');
+    assert.equal(dbManager.getLastRecovery()?.strategy, 'reused');
   });
 
   it('shutdown wait resolves true when live indexing completes before timeout', async () => {

--- a/tests/handlers/sync-markdown-memories.test.ts
+++ b/tests/handlers/sync-markdown-memories.test.ts
@@ -7,11 +7,13 @@ import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { DatabaseManager } from '../../src/store/db.js';
 import { registerMemoryTool } from '../../src/tools/memory-tool.js';
 import {
+  migrateThenSyncMarkdownMemories,
   registerSyncMarkdownMemoriesCommand,
   syncMarkdownMemoriesToSqlite,
 } from '../../src/handlers/sync-markdown-memories.js';
 import { ENTRY_DELIMITER } from '../../src/constants.js';
-import { getMemories, searchMemories } from '../../src/store/sqlite-memory-store.js';
+import { addMemory, getMemories, searchMemories } from '../../src/store/sqlite-memory-store.js';
+import { AtomicLockCoordinator } from '../../src/store/atomic-lock-coordinator.js';
 
 describe('memory sqlite sync + markdown backfill', () => {
   let tmpDir: string;
@@ -159,7 +161,7 @@ describe('memory sqlite sync + markdown backfill', () => {
     assert.strictEqual(projectRows[0].content, 'legacy project entry');
   });
 
-  it('makes new-layout project markdown searchable when startup sync runs', () => {
+  it('makes new-layout project markdown searchable when startup sync runs', async () => {
     const projectDir = path.join(agentRoot, 'projects-memory', 'latest-project');
     fs.mkdirSync(projectDir, { recursive: true });
     fs.writeFileSync(
@@ -168,7 +170,7 @@ describe('memory sqlite sync + markdown backfill', () => {
       'utf-8',
     );
 
-    const counters = syncMarkdownMemoriesToSqlite(dbManager, globalDir, undefined, agentRoot);
+    const counters = await syncMarkdownMemoriesToSqlite(dbManager, globalDir, undefined, agentRoot);
 
     assert.strictEqual(counters.projectCount, 1);
     assert.strictEqual(counters.imported, 1);
@@ -181,7 +183,167 @@ describe('memory sqlite sync + markdown backfill', () => {
     assert.strictEqual(results[0].content, 'latest path searchable entry');
   });
 
-  it('still scans project markdown under ~/.pi/agent when memoryDir is customized elsewhere', () => {
+  it('prunes Markdown orphans while preserving other targets and projects', async () => {
+    fs.writeFileSync(path.join(globalDir, 'MEMORY.md'), 'kept global memory', 'utf-8');
+    fs.writeFileSync(path.join(globalDir, 'USER.md'), 'kept global user', 'utf-8');
+    const projectDir = path.join(agentRoot, 'projects-memory', 'project-a');
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.writeFileSync(path.join(projectDir, 'MEMORY.md'), 'kept project memory', 'utf-8');
+
+    await syncMarkdownMemoriesToSqlite(dbManager, globalDir, undefined, agentRoot);
+    dbManager.getDb().prepare(`
+      INSERT INTO memories (project, target, category, content, created, last_referenced)
+      VALUES (NULL, 'memory', NULL, 'orphaned global memory', '2026-07-01', '2026-07-01')
+    `).run();
+
+    const counters = await syncMarkdownMemoriesToSqlite(dbManager, globalDir, undefined, agentRoot);
+
+    assert.strictEqual(counters.removed, 1);
+    assert.deepStrictEqual(
+      getMemories(dbManager).map((entry) => `${entry.project ?? 'global'}:${entry.target}:${entry.content}`).sort(),
+      [
+        'global:memory:kept global memory',
+        'global:user:kept global user',
+        'project-a:memory:kept project memory',
+      ].sort(),
+    );
+  });
+
+  it('waits for the canonical Markdown mutation before reading and reconciling', async () => {
+    const memoryFile = path.join(globalDir, 'MEMORY.md');
+    fs.writeFileSync(memoryFile, 'stale memory', 'utf-8');
+    addMemory(dbManager, 'stale memory');
+
+    const identity = fs.realpathSync(memoryFile);
+    const coordinator = new AtomicLockCoordinator(path.join(path.dirname(path.dirname(identity)), '.pi-hermes-locks.sqlite'));
+    const lease = coordinator.tryAcquire(`mutation:${identity}`, { staleMs: 300_000 });
+    assert.ok(lease);
+
+    let settled = false;
+    const syncing = Promise.resolve()
+      .then(() => syncMarkdownMemoriesToSqlite(dbManager, globalDir, undefined, agentRoot))
+      .then((result) => {
+        settled = true;
+        return result;
+      });
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const waitedForMutation = !settled;
+    fs.writeFileSync(memoryFile, ['stale memory', 'newer writer memory'].join(ENTRY_DELIMITER), 'utf-8');
+    addMemory(dbManager, 'newer writer memory');
+    lease.release();
+    await syncing;
+
+    assert.ok(waitedForMutation, 'reconciliation must wait for the active Markdown mutation');
+    assert.deepStrictEqual(
+      getMemories(dbManager, { target: 'memory', project: null }).map((entry) => entry.content).sort(),
+      ['newer writer memory', 'stale memory'],
+    );
+  });
+
+  it('prunes a deleted project Markdown scope without touching unrelated rows', async () => {
+    const deletedProjectDir = path.join(agentRoot, 'projects-memory', 'deleted-project');
+    const keptProjectDir = path.join(agentRoot, 'projects-memory', 'kept-project');
+    fs.mkdirSync(deletedProjectDir, { recursive: true });
+    fs.mkdirSync(keptProjectDir, { recursive: true });
+    fs.writeFileSync(path.join(deletedProjectDir, 'MEMORY.md'), 'deleted project memory', 'utf-8');
+    fs.writeFileSync(path.join(keptProjectDir, 'MEMORY.md'), 'kept project memory', 'utf-8');
+    fs.writeFileSync(path.join(globalDir, 'MEMORY.md'), 'kept global memory', 'utf-8');
+
+    await syncMarkdownMemoriesToSqlite(dbManager, globalDir, undefined, agentRoot);
+    dbManager.getDb().prepare(`
+      INSERT INTO memories (project, target, category, content, created, last_referenced)
+      VALUES ('deleted-project', 'user', NULL, 'unrelated project user', '2026-07-01', '2026-07-01')
+    `).run();
+    fs.rmSync(deletedProjectDir, { recursive: true });
+
+    const counters = await syncMarkdownMemoriesToSqlite(dbManager, globalDir, undefined, agentRoot);
+
+    assert.strictEqual(counters.removed, 1);
+    assert.ok(!fs.existsSync(deletedProjectDir));
+    assert.deepStrictEqual(
+      getMemories(dbManager).map((entry) => `${entry.project ?? 'global'}:${entry.target}:${entry.content}`).sort(),
+      [
+        'deleted-project:user:unrelated project user',
+        'global:memory:kept global memory',
+        'kept-project:memory:kept project memory',
+      ],
+    );
+  });
+
+  it('treats a missing canonical project file as empty despite a retained legacy backup', async () => {
+    const projectName = 'canonical-deleted-project';
+    const canonicalProjectDir = path.join(agentRoot, 'projects-memory', projectName);
+    const legacyProjectDir = path.join(agentRoot, projectName);
+    fs.mkdirSync(canonicalProjectDir, { recursive: true });
+    fs.mkdirSync(legacyProjectDir, { recursive: true });
+    fs.writeFileSync(path.join(legacyProjectDir, 'MEMORY.md'), 'retained legacy backup', 'utf-8');
+    addMemory(dbManager, 'stale canonical row', 'memory', projectName);
+
+    const counters = await syncMarkdownMemoriesToSqlite(dbManager, globalDir, undefined, agentRoot);
+
+    assert.strictEqual(counters.removed, 1);
+    assert.deepStrictEqual(getMemories(dbManager, { project: projectName, target: 'memory' }), []);
+    assert.strictEqual(
+      fs.readFileSync(path.join(legacyProjectDir, 'MEMORY.md'), 'utf-8'),
+      'retained legacy backup',
+    );
+  });
+
+  it('reconciles unsafe SQLite project scopes empty without reading outside projects-memory', async () => {
+    const outsideDir = path.join(agentRoot, 'outside');
+    fs.mkdirSync(outsideDir, { recursive: true });
+    fs.writeFileSync(path.join(outsideDir, 'MEMORY.md'), 'outside traversal bait', 'utf-8');
+    addMemory(dbManager, 'outside traversal bait', 'memory', '../outside');
+
+    const counters = await syncMarkdownMemoriesToSqlite(dbManager, globalDir, undefined, agentRoot);
+
+    assert.strictEqual(counters.removed, 1);
+    assert.deepStrictEqual(getMemories(dbManager, { project: '../outside', target: 'memory' }), []);
+    assert.strictEqual(fs.readFileSync(path.join(outsideDir, 'MEMORY.md'), 'utf-8'), 'outside traversal bait');
+  });
+
+  it('reconciles a symlinked project directory empty without reading its target', async (t) => {
+    const outsideDir = path.join(tmpDir, 'outside-project');
+    const projectLink = path.join(agentRoot, 'projects-memory', 'linked-project');
+    fs.mkdirSync(outsideDir, { recursive: true });
+    fs.mkdirSync(path.dirname(projectLink), { recursive: true });
+    fs.writeFileSync(path.join(outsideDir, 'MEMORY.md'), 'outside directory bait', 'utf-8');
+    try {
+      fs.symlinkSync(outsideDir, projectLink, 'dir');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EPERM') return t.skip('directory symlinks unavailable');
+      throw error;
+    }
+    addMemory(dbManager, 'stale linked project row', 'memory', 'linked-project');
+
+    const counters = await syncMarkdownMemoriesToSqlite(dbManager, globalDir, undefined, agentRoot);
+
+    assert.strictEqual(counters.removed, 1);
+    assert.deepStrictEqual(getMemories(dbManager, { project: 'linked-project', target: 'memory' }), []);
+  });
+
+  it('reconciles a symlinked project memory file empty without reading its target', async (t) => {
+    const outsideFile = path.join(tmpDir, 'outside-memory.md');
+    const projectDir = path.join(agentRoot, 'projects-memory', 'linked-file-project');
+    const memoryLink = path.join(projectDir, 'MEMORY.md');
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.writeFileSync(outsideFile, 'outside file bait', 'utf-8');
+    try {
+      fs.symlinkSync(outsideFile, memoryLink, 'file');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EPERM') return t.skip('file symlinks unavailable');
+      throw error;
+    }
+    addMemory(dbManager, 'stale linked file row', 'memory', 'linked-file-project');
+
+    const counters = await syncMarkdownMemoriesToSqlite(dbManager, globalDir, undefined, agentRoot);
+
+    assert.strictEqual(counters.removed, 1);
+    assert.deepStrictEqual(getMemories(dbManager, { project: 'linked-file-project', target: 'memory' }), []);
+  });
+
+  it('still scans project markdown under ~/.pi/agent when memoryDir is customized elsewhere', async () => {
     const customGlobalDir = path.join(tmpDir, 'external-memory-root');
     fs.mkdirSync(customGlobalDir, { recursive: true });
 
@@ -195,7 +357,7 @@ describe('memory sqlite sync + markdown backfill', () => {
         'utf-8',
       );
 
-      const counters = syncMarkdownMemoriesToSqlite(customDbManager, customGlobalDir, undefined, agentRoot);
+      const counters = await syncMarkdownMemoriesToSqlite(customDbManager, customGlobalDir, undefined, agentRoot);
 
       assert.strictEqual(counters.projectCount, 1);
       const results = searchMemories(customDbManager, 'custom root project entry', {
@@ -206,6 +368,124 @@ describe('memory sqlite sync + markdown backfill', () => {
       assert.strictEqual(results[0].content, 'custom root project entry');
     } finally {
       customDbManager.close();
+    }
+  });
+
+  it('migrates a populated legacy database before startup reconciliation', async () => {
+    dbManager.close();
+    const legacyDir = path.join(agentRoot, 'memory');
+    const targetDir = path.join(agentRoot, 'pi-hermes-memory');
+    fs.mkdirSync(legacyDir, { recursive: true });
+    const legacyManager = new DatabaseManager(legacyDir);
+    legacyManager.getDb().prepare(`
+      INSERT INTO sessions (id, project, cwd, started_at, ended_at, message_count)
+      VALUES ('legacy-session', 'legacy-project', '/legacy/project', '2026-07-01', NULL, 1)
+    `).run();
+    legacyManager.close();
+
+    const targetManager = new DatabaseManager(targetDir);
+    try {
+      await migrateThenSyncMarkdownMemories(targetManager, legacyDir, targetDir, undefined, agentRoot);
+
+      const sessions = targetManager.getDb().prepare('SELECT id FROM sessions').all() as Array<{ id: string }>;
+      assert.deepStrictEqual(sessions.map((session) => session.id), ['legacy-session']);
+    } finally {
+      targetManager.close();
+    }
+  });
+
+  it('does not create a destination database after critical migration failure', async () => {
+    dbManager.close();
+    const legacyDir = path.join(agentRoot, 'memory');
+    const targetDir = path.join(agentRoot, 'pi-hermes-memory');
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.writeFileSync(path.join(legacyDir, 'sessions.db'), 'populated legacy database', 'utf-8');
+    const targetManager = new DatabaseManager(targetDir);
+    let migrationSucceeded = false;
+
+    try {
+      await assert.rejects(
+        migrateThenSyncMarkdownMemories(
+          targetManager,
+          legacyDir,
+          targetDir,
+          undefined,
+          agentRoot,
+          {
+            moveFile: async () => {
+              throw new Error('injected sessions.db move failure');
+            },
+            onMigrationSucceeded: () => {
+              migrationSucceeded = true;
+            },
+          },
+        ),
+        /sessions\.db migration failed/,
+      );
+      assert.equal(fs.existsSync(path.join(targetDir, 'sessions.db')), false);
+      assert.equal(fs.existsSync(path.join(legacyDir, 'sessions.db')), true);
+      assert.equal(migrationSucceeded, false);
+    } finally {
+      targetManager.close();
+    }
+  });
+
+  it('hands a corrupt legacy database to bounded destination recovery', async () => {
+    dbManager.close();
+    const legacyDir = path.join(agentRoot, 'memory');
+    const targetDir = path.join(agentRoot, 'pi-hermes-memory');
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.writeFileSync(path.join(legacyDir, 'sessions.db'), 'not a sqlite database', 'utf-8');
+    const targetManager = new DatabaseManager(targetDir);
+
+    try {
+      await migrateThenSyncMarkdownMemories(targetManager, legacyDir, targetDir, undefined, agentRoot);
+
+      assert.equal(fs.existsSync(path.join(legacyDir, 'sessions.db')), false);
+      assert.deepStrictEqual(targetManager.getDb().pragma?.('quick_check'), [{ quick_check: 'ok' }]);
+      assert.equal(targetManager.getLastRecovery()?.strategy, 'recreated-empty');
+      assert.ok(
+        fs.readdirSync(targetDir).some((name) => name.startsWith('sessions.db.corrupt-')),
+        'the corrupt generation should be quarantined by DatabaseManager',
+      );
+    } finally {
+      targetManager.close();
+    }
+  });
+
+  it('resolves a migrated file-symlink database at first I/O', { skip: process.platform === 'win32' }, async () => {
+    dbManager.close();
+    const legacyDir = path.join(agentRoot, 'memory');
+    const targetDir = path.join(agentRoot, 'pi-hermes-memory');
+    const realDir = path.join(tmpDir, 'real-database');
+    const realDbPath = path.join(realDir, 'sessions.db');
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.mkdirSync(realDir, { recursive: true });
+    fs.writeFileSync(realDbPath, 'not a sqlite database');
+    fs.symlinkSync(path.relative(legacyDir, realDbPath), path.join(legacyDir, 'sessions.db'), 'file');
+    const targetManager = new DatabaseManager(targetDir);
+
+    try {
+      await migrateThenSyncMarkdownMemories(targetManager, legacyDir, targetDir, undefined, agentRoot);
+      targetManager.getDb().prepare(
+        "INSERT INTO extension_metadata (key, value) VALUES ('migrated-alias', 'kept')",
+      ).run();
+      targetManager.close();
+
+      assert.equal(fs.lstatSync(path.join(targetDir, 'sessions.db')).isSymbolicLink(), true);
+      const directManager = new DatabaseManager(realDir);
+      try {
+        assert.deepEqual(
+          directManager.getDb().prepare(
+            "SELECT value FROM extension_metadata WHERE key = 'migrated-alias'",
+          ).get(),
+          { value: 'kept' },
+        );
+      } finally {
+        directManager.close();
+      }
+    } finally {
+      targetManager.close();
     }
   });
 });

--- a/tests/store/db.test.ts
+++ b/tests/store/db.test.ts
@@ -320,7 +320,7 @@ describe('DatabaseManager', () => {
       const lockDbPath = path.join(path.dirname(canonicalDbPath), '.pi-hermes-locks.sqlite');
       const lockKey = `recovery:${canonicalDbPath}`;
       const coordinator = new AtomicLockCoordinator(lockDbPath);
-      const lease = coordinator.tryAcquire(lockKey, { staleMs: 1 });
+      const lease = coordinator.tryAcquire(lockKey, { staleMs: 10_000 });
       assert.ok(lease);
       spawn(process.execPath, [
         '-e',
@@ -335,7 +335,7 @@ describe('DatabaseManager', () => {
         lease.token,
       ], { stdio: 'ignore' });
 
-      dbManager = new DatabaseManager(tmpDir, { recoveryLockWaitMs: 1000, recoveryLockPollMs: 10, recoveryLockStaleMs: 1 });
+      dbManager = new DatabaseManager(tmpDir, { recoveryLockWaitMs: 1000, recoveryLockPollMs: 10, recoveryLockStaleMs: 10_000 });
       const started = Date.now();
       const result = dbManager.recoverFromCorruption(corruptSqliteError());
 
@@ -362,6 +362,48 @@ describe('DatabaseManager', () => {
       const db = dbManager.getDb();
 
       assertQuickCheckOk(db as InstanceType<typeof Database>);
+    });
+
+    it('aborts destructive recovery rename when the recovery lease was stolen mid-flight', () => {
+      dbManager.close();
+      fs.writeFileSync(path.join(tmpDir, 'sessions.db'), 'not a sqlite database');
+      dbManager = new DatabaseManager(tmpDir, { recoveryLockStaleMs: 60_000 });
+
+      type MoveDatabaseFilesToBackup = (this: DatabaseManager, backupBase: string) => unknown;
+      const prototype = DatabaseManager.prototype as unknown as {
+        moveDatabaseFilesToBackup: MoveDatabaseFilesToBackup;
+      };
+      const originalMove = prototype.moveDatabaseFilesToBackup;
+      let moveCalls = 0;
+      prototype.moveDatabaseFilesToBackup = function (this: DatabaseManager, backupBase: string) {
+        moveCalls++;
+        if (moveCalls === 1) {
+          const canonicalDbPath = fs.realpathSync(path.join(tmpDir, 'sessions.db'));
+          const lockDbPath = path.join(path.dirname(canonicalDbPath), '.pi-hermes-locks.sqlite');
+          const lockKey = `recovery:${canonicalDbPath}`;
+          const lockDb = new Database(lockDbPath);
+          try {
+            lockDb.prepare('UPDATE locks SET acquired_at = ? WHERE lock_key = ?').run(Date.now() - 100_000, lockKey);
+          } finally {
+            lockDb.close();
+          }
+          const thief = new AtomicLockCoordinator(lockDbPath);
+          const stolen = thief.tryAcquire(lockKey, { staleMs: 50 });
+          assert.ok(stolen);
+          stolen.release();
+        }
+        return originalMove.call(this, backupBase);
+      };
+
+      try {
+        assert.throws(
+          () => dbManager.getDb(),
+          /SQLite recovery lease lost/,
+        );
+        assert.strictEqual(moveCalls, 1);
+      } finally {
+        prototype.moveDatabaseFilesToBackup = originalMove;
+      }
     });
 
     it('serializes recovery through symlinked database aliases', { skip: process.platform === 'win32' }, () => {

--- a/tests/store/db.test.ts
+++ b/tests/store/db.test.ts
@@ -3,8 +3,10 @@ import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import { spawn } from 'node:child_process';
 import Database from 'better-sqlite3';
 import { DatabaseManager, SQLITE_WAL_AUTOCHECKPOINT_PAGES } from '../../src/store/db.js';
+import { AtomicLockCoordinator } from '../../src/store/atomic-lock-coordinator.js';
 
 describe('DatabaseManager', () => {
   let tmpDir: string;
@@ -94,6 +96,22 @@ describe('DatabaseManager', () => {
       const manager = new DatabaseManager(nestedDir);
       manager.getDb();
       assert.ok(fs.existsSync(path.join(nestedDir, 'sessions.db')));
+      manager.close();
+    });
+
+    it('defers database creation while an initialization guard is active', () => {
+      const guardedDir = path.join(tmpDir, 'guarded');
+      const manager = new DatabaseManager(guardedDir);
+      manager.setOpenGuard(() => {
+        throw new Error('legacy database migration pending');
+      });
+
+      assert.throws(() => manager.getDb(), /legacy database migration pending/);
+      assert.equal(fs.existsSync(path.join(guardedDir, 'sessions.db')), false);
+
+      manager.setOpenGuard(null);
+      assert.ok(manager.getDb());
+      assert.equal(fs.existsSync(path.join(guardedDir, 'sessions.db')), true);
       manager.close();
     });
   });
@@ -295,6 +313,300 @@ describe('DatabaseManager', () => {
   });
 
   describe('corruption recovery', () => {
+    it('waits for a recovery owner and reuses the healthy database it leaves behind', () => {
+      dbManager.getDb();
+      dbManager.close();
+      const canonicalDbPath = fs.realpathSync(path.join(tmpDir, 'sessions.db'));
+      const lockDbPath = path.join(path.dirname(canonicalDbPath), '.pi-hermes-locks.sqlite');
+      const lockKey = `recovery:${canonicalDbPath}`;
+      const coordinator = new AtomicLockCoordinator(lockDbPath);
+      const lease = coordinator.tryAcquire(lockKey, { staleMs: 1 });
+      assert.ok(lease);
+      spawn(process.execPath, [
+        '-e',
+        `setTimeout(() => {
+          const Database = require('better-sqlite3');
+          const db = new Database(process.argv[1]);
+          db.prepare('DELETE FROM locks WHERE lock_key = ? AND token = ?').run(process.argv[2], process.argv[3]);
+          db.close();
+        }, 100)`,
+        lockDbPath,
+        lockKey,
+        lease.token,
+      ], { stdio: 'ignore' });
+
+      dbManager = new DatabaseManager(tmpDir, { recoveryLockWaitMs: 1000, recoveryLockPollMs: 10, recoveryLockStaleMs: 1 });
+      const started = Date.now();
+      const result = dbManager.recoverFromCorruption(corruptSqliteError());
+
+      assert.strictEqual(result.strategy, 'reused');
+      assert.ok(Date.now() - started >= 50, 'peer should wait for the active recovery owner');
+      assert.strictEqual(fs.readdirSync(tmpDir).filter((name) => name.startsWith('sessions.db.corrupt-')).length, 0);
+    });
+
+    it('takes over a stale recovery lock', () => {
+      dbManager.close();
+      fs.writeFileSync(path.join(tmpDir, 'sessions.db'), 'not a sqlite database');
+      const canonicalDbPath = fs.realpathSync(path.join(tmpDir, 'sessions.db'));
+      const lockDbPath = path.join(path.dirname(canonicalDbPath), '.pi-hermes-locks.sqlite');
+      const coordinator = new AtomicLockCoordinator(lockDbPath);
+      coordinator.tryAcquire('schema-init', { staleMs: 50 })!.release();
+      const lockDb = new Database(lockDbPath);
+      lockDb.prepare(`
+        INSERT INTO locks (lock_key, token, pid, acquired_at)
+        VALUES (?, 'dead-owner', 999999, ?)
+      `).run(`recovery:${canonicalDbPath}`, Date.now() - 10_000);
+      lockDb.close();
+
+      dbManager = new DatabaseManager(tmpDir, { recoveryLockStaleMs: 50 });
+      const db = dbManager.getDb();
+
+      assertQuickCheckOk(db as InstanceType<typeof Database>);
+    });
+
+    it('serializes recovery through symlinked database aliases', { skip: process.platform === 'win32' }, () => {
+      dbManager.close();
+      const realDir = path.join(tmpDir, 'real');
+      const aliasDir = path.join(tmpDir, 'alias');
+      fs.mkdirSync(realDir);
+      fs.symlinkSync(realDir, aliasDir, 'dir');
+      fs.writeFileSync(path.join(realDir, 'sessions.db'), 'not a sqlite database');
+
+      const canonicalDbPath = fs.realpathSync(path.join(realDir, 'sessions.db'));
+      const coordinator = new AtomicLockCoordinator(path.join(path.dirname(canonicalDbPath), '.pi-hermes-locks.sqlite'));
+      const lease = coordinator.tryAcquire(`recovery:${canonicalDbPath}`, { staleMs: 60_000 });
+      assert.ok(lease);
+
+      const aliasManager = new DatabaseManager(aliasDir, {
+        recoveryLockWaitMs: 25,
+        recoveryLockPollMs: 5,
+        recoveryLockStaleMs: 60_000,
+      });
+      try {
+        assert.throws(
+          () => aliasManager.getDb(),
+          /SQLite recovery already in progress/,
+        );
+      } finally {
+        aliasManager.close();
+        lease.release();
+      }
+    });
+
+    it('repairs a file-symlinked database target without replacing the link', { skip: process.platform === 'win32' }, () => {
+      dbManager.close();
+      const realDir = path.join(tmpDir, 'real');
+      const aliasDir = path.join(tmpDir, 'alias');
+      fs.mkdirSync(realDir);
+      fs.mkdirSync(aliasDir);
+      const realDbPath = path.join(realDir, 'sessions.db');
+      const aliasDbPath = path.join(aliasDir, 'sessions.db');
+      fs.writeFileSync(realDbPath, 'not a sqlite database');
+      fs.symlinkSync(realDbPath, aliasDbPath, 'file');
+
+      const aliasManager = new DatabaseManager(aliasDir);
+      const aliasDb = aliasManager.getDb();
+      aliasDb.prepare("INSERT INTO extension_metadata (key, value) VALUES ('alias-write', 'kept')").run();
+      aliasManager.close();
+
+      assert.equal(fs.lstatSync(aliasDbPath).isSymbolicLink(), true);
+      const directManager = new DatabaseManager(realDir);
+      try {
+        const directDb = directManager.getDb();
+        assertQuickCheckOk(directDb as InstanceType<typeof Database>);
+        assert.deepEqual(
+          directDb.prepare("SELECT value FROM extension_metadata WHERE key = 'alias-write'").get(),
+          { value: 'kept' },
+        );
+      } finally {
+        directManager.close();
+      }
+    });
+
+    it('creates and repairs a dangling absolute database symlink through its target', { skip: process.platform === 'win32' }, () => {
+      dbManager.close();
+      const realDir = path.join(tmpDir, 'real');
+      const aliasDir = path.join(tmpDir, 'alias');
+      fs.mkdirSync(realDir);
+      fs.mkdirSync(aliasDir);
+      const realDbPath = path.join(realDir, 'sessions.db');
+      const aliasDbPath = path.join(aliasDir, 'sessions.db');
+      fs.symlinkSync(realDbPath, aliasDbPath, 'file');
+
+      const aliasManager = new DatabaseManager(aliasDir);
+      aliasManager.getDb().prepare(
+        "INSERT INTO extension_metadata (key, value) VALUES ('before-corruption', 'kept')",
+      ).run();
+      aliasManager.close();
+      fs.writeFileSync(realDbPath, 'not a sqlite database');
+
+      try {
+        assertQuickCheckOk(aliasManager.getDb() as InstanceType<typeof Database>);
+      } finally {
+        aliasManager.close();
+      }
+      assert.equal(fs.lstatSync(aliasDbPath).isSymbolicLink(), true);
+      const directDb = new Database(realDbPath);
+      try {
+        assertQuickCheckOk(directDb);
+      } finally {
+        directDb.close();
+      }
+    });
+
+    it('rejects database symlink loops before opening SQLite', { skip: process.platform === 'win32' }, () => {
+      dbManager.close();
+      const loopDir = path.join(tmpDir, 'loop');
+      fs.mkdirSync(loopDir);
+      fs.symlinkSync('sessions.other', path.join(loopDir, 'sessions.db'), 'file');
+      fs.symlinkSync('sessions.db', path.join(loopDir, 'sessions.other'), 'file');
+
+      const manager = new DatabaseManager(loopDir);
+      assert.throws(() => manager.getDb(), /symbolic link loop/i);
+      manager.close();
+    });
+
+    it('cleans abandoned rebuild files and caps corrupt backup sets', () => {
+      dbManager.close();
+      for (let index = 0; index < 5; index++) {
+        fs.writeFileSync(path.join(tmpDir, `sessions.db.corrupt-20260701-${index}`), `backup-${index}`);
+      }
+      fs.writeFileSync(path.join(tmpDir, 'sessions.db.rebuild-abandoned.tmp'), 'abandoned');
+      fs.writeFileSync(path.join(tmpDir, 'sessions.db'), 'not a sqlite database');
+
+      dbManager = new DatabaseManager(tmpDir, { recoveryBackupRetention: 3 });
+      dbManager.getDb();
+
+      const names = fs.readdirSync(tmpDir);
+      assert.strictEqual(names.some((name) => name.startsWith('sessions.db.rebuild-')), false);
+      assert.ok(names.filter((name) => name.startsWith('sessions.db.corrupt-')).length <= 3);
+    });
+
+    it('does not count successful recreations toward the recovery circuit', () => {
+      dbManager.close();
+      const dbPath = path.join(tmpDir, 'sessions.db');
+      fs.writeFileSync(dbPath, 'first corrupt database');
+      dbManager = new DatabaseManager(tmpDir, {
+        recoveryCircuitLimit: 1,
+        recoveryCircuitWindowMs: 60_000,
+      });
+      dbManager.getDb();
+      dbManager.close();
+
+      fs.writeFileSync(dbPath, 'second corrupt database');
+      dbManager = new DatabaseManager(tmpDir, {
+        recoveryCircuitLimit: 1,
+        recoveryCircuitWindowMs: 60_000,
+      });
+
+      assert.doesNotThrow(() => dbManager.getDb());
+      assert.strictEqual(dbManager.getLastRecovery()?.strategy, 'recreated-empty');
+    });
+
+    it('keeps verified recovery successful when cleanup state removal fails', () => {
+      dbManager.close();
+      fs.writeFileSync(path.join(tmpDir, 'sessions.db'), 'corrupt database');
+      dbManager = new DatabaseManager(tmpDir);
+      let cleanupCalls = 0;
+      (dbManager as any).cleanupRecoveryArtifacts = () => {
+        cleanupCalls++;
+        if (cleanupCalls > 1) throw new Error('injected cleanup failure');
+      };
+      (dbManager as any).clearRecoveryFailures = () => {
+        throw new Error('injected circuit cleanup failure');
+      };
+
+      const db = dbManager.getDb();
+
+      assert.ok(db);
+      assert.strictEqual(dbManager.getLastRecovery()?.strategy, 'recreated-empty');
+      assertQuickCheckOk(db as InstanceType<typeof Database>);
+    });
+
+    it('keeps verified recovery successful and clears a failed release before retry', () => {
+      const prototype = AtomicLockCoordinator.prototype as any;
+      const originalDeleteOwnedLock = prototype.deleteOwnedLock;
+      let deleteAttempts = 0;
+      prototype.deleteOwnedLock = function (key: string, token: string): void {
+        deleteAttempts++;
+        if (deleteAttempts <= 3) throw new Error('injected recovery release failure');
+        return originalDeleteOwnedLock.call(this, key, token);
+      };
+
+      try {
+        dbManager.close();
+        const dbPath = path.join(tmpDir, 'sessions.db');
+        fs.writeFileSync(dbPath, 'first corrupt database');
+        dbManager = new DatabaseManager(tmpDir);
+        assert.doesNotThrow(() => dbManager.getDb());
+        assert.strictEqual(dbManager.getLastRecovery()?.strategy, 'recreated-empty');
+
+        dbManager.close();
+        fs.writeFileSync(dbPath, 'second corrupt database');
+        dbManager = new DatabaseManager(tmpDir);
+        assert.doesNotThrow(() => dbManager.getDb());
+        assert.strictEqual(dbManager.getLastRecovery()?.strategy, 'recreated-empty');
+        assert.ok(deleteAttempts >= 4);
+      } finally {
+        prototype.deleteOwnedLock = originalDeleteOwnedLock;
+      }
+    });
+
+    it('opens the recovery circuit after a failed recovery', () => {
+      dbManager.close();
+      fs.writeFileSync(path.join(tmpDir, 'sessions.db'), 'corrupt database');
+      dbManager = new DatabaseManager(tmpDir, {
+        recoveryCircuitLimit: 1,
+        recoveryCircuitWindowMs: 60_000,
+      });
+      let recoveryCalls = 0;
+      (dbManager as any).recoverDatabaseFileUnlocked = () => {
+        recoveryCalls++;
+        throw new Error('injected recovery failure');
+      };
+
+      assert.throws(() => dbManager.recoverFromCorruption(corruptSqliteError()), /injected recovery failure/);
+      assert.throws(() => dbManager.recoverFromCorruption(corruptSqliteError()), /recovery circuit is open/i);
+      assert.strictEqual(recoveryCalls, 1);
+    });
+
+    it('counts a failed post-recovery open before clearing the circuit', () => {
+      dbManager.close();
+      fs.writeFileSync(path.join(tmpDir, 'sessions.db'), 'corrupt database');
+      dbManager = new DatabaseManager(tmpDir, {
+        recoveryCircuitLimit: 1,
+        recoveryCircuitWindowMs: 60_000,
+      });
+      const originalOpenUnchecked = (dbManager as any).openUnchecked.bind(dbManager);
+      let openCalls = 0;
+      (dbManager as any).openUnchecked = () => {
+        openCalls++;
+        if (openCalls === 2) throw new Error('injected post-recovery open failure');
+        return originalOpenUnchecked();
+      };
+
+      assert.throws(() => dbManager.getDb(), /injected post-recovery open failure/);
+      const state = JSON.parse(
+        fs.readFileSync(path.join(tmpDir, 'sessions.db.recovery-state.json'), 'utf-8'),
+      );
+      assert.strictEqual(state.failures.length, 1);
+    });
+
+    it('does not treat legacy recovery attempt state as failed recoveries', () => {
+      dbManager.close();
+      fs.writeFileSync(path.join(tmpDir, 'sessions.db'), 'corrupt database');
+      fs.writeFileSync(
+        path.join(tmpDir, 'sessions.db.recovery-state.json'),
+        JSON.stringify({ attempts: [Date.now()] }),
+      );
+      dbManager = new DatabaseManager(tmpDir, {
+        recoveryCircuitLimit: 1,
+        recoveryCircuitWindowMs: 60_000,
+      });
+
+      assert.doesNotThrow(() => dbManager.getDb());
+    });
+
     it('repairs recoverable corruption on open and preserves readable rows', () => {
       const db = dbManager.getDb();
       db.prepare(`
@@ -362,7 +674,7 @@ describe('DatabaseManager', () => {
 
       assert.strictEqual(result, 'ok');
       assert.strictEqual(attempts, 2);
-      assert.strictEqual(dbManager.getLastRecovery()?.strategy, 'rebuilt');
+      assert.strictEqual(dbManager.getLastRecovery()?.strategy, 'reused');
     });
   });
 

--- a/tests/store/sqlite-memory-store.test.ts
+++ b/tests/store/sqlite-memory-store.test.ts
@@ -16,7 +16,10 @@ import {
   removeSyncedMemories,
   parseMarkdownMemoryEntry,
   formatFailureMemoryContent,
+  reconcileMarkdownMemoryScope,
+  reconcileMarkdownFailureScopes,
 } from '../../src/store/sqlite-memory-store.js';
+import { MemoryStore } from '../../src/store/memory-store.js';
 
 describe('sqlite-memory-store', () => {
   let tmpDir: string;
@@ -114,6 +117,140 @@ describe('sqlite-memory-store', () => {
       assert.strictEqual(parsed.failureReason, 'npm install rewrote lockfile');
       assert.strictEqual(parsed.created, '2026-05-08');
       assert.strictEqual(parsed.lastReferenced, '2026-05-09');
+    });
+
+    it('does not infer project scope from spoofable failure content', () => {
+      const raw = '[correction] literal user text — Project: other-project <!-- created=2026-05-08, last=2026-05-09 -->';
+
+      reconcileMarkdownFailureScopes(dbManager, [raw]);
+
+      assert.strictEqual(getMemories(dbManager, { target: 'failure', project: 'other-project' }).length, 0);
+      assert.strictEqual(getMemories(dbManager, { target: 'failure', project: null }).length, 1);
+    });
+
+    it('round-trips project correction scope through authoritative Markdown metadata', async () => {
+      const store = new MemoryStore({
+        memoryDir: tmpDir,
+        memoryCharLimit: 5_000,
+        userCharLimit: 5_000,
+        failureCharLimit: 5_000,
+      } as any);
+      await store.loadFromDisk();
+
+      await store.addFailure('use pnpm in this repo', {
+        category: 'correction',
+        failureReason: 'User corrected the agent',
+        project: 'project-a',
+      });
+      const [raw] = store.getRawEntriesForSync('failure');
+      reconcileMarkdownFailureScopes(dbManager, [raw]);
+
+      const entries = getMemories(dbManager, { target: 'failure', project: 'project-a' });
+      assert.strictEqual(entries.length, 1);
+      assert.strictEqual(entries[0].project, 'project-a');
+      assert.doesNotMatch(entries[0].content, /Project: project-a/);
+    });
+  });
+
+  describe('reconcileMarkdownMemoryScope', () => {
+    it('keeps explicit global MEMORY and USER scope despite embedded project metadata', () => {
+      const marker = 'c3Bvb2ZlZC1wcm9qZWN0';
+
+      reconcileMarkdownMemoryScope(
+        dbManager,
+        [`global memory <!-- created=2026-07-01, last=2026-07-02, project64=${marker} -->`],
+        'memory',
+        null,
+      );
+      reconcileMarkdownMemoryScope(
+        dbManager,
+        [`global user <!-- created=2026-07-01, last=2026-07-02, project64=${marker} -->`],
+        'user',
+        null,
+      );
+
+      assert.deepStrictEqual(
+        getMemories(dbManager).map((entry) => [entry.project, entry.target, entry.content]),
+        [
+          [null, 'memory', 'global memory'],
+          [null, 'user', 'global user'],
+        ],
+      );
+      assert.deepStrictEqual(getMemories(dbManager, { project: 'spoofed-project' }), []);
+    });
+
+    it('prunes only absent rows in the exact target and project scope', () => {
+      addMemory(dbManager, 'kept global memory', 'memory', null);
+      addMemory(dbManager, 'orphaned global memory', 'memory', null);
+      addMemory(dbManager, 'unrelated global user', 'user', null);
+      addMemory(dbManager, 'unrelated project memory', 'memory', 'project-a');
+
+      const first = reconcileMarkdownMemoryScope(
+        dbManager,
+        ['kept global memory <!-- created=2026-07-01, last=2026-07-02 -->'],
+        'memory',
+        null,
+      );
+      const second = reconcileMarkdownMemoryScope(
+        dbManager,
+        ['kept global memory <!-- created=2026-07-01, last=2026-07-02 -->'],
+        'memory',
+        null,
+      );
+
+      assert.strictEqual(first.removed, 1);
+      assert.strictEqual(second.removed, 0);
+      assert.deepStrictEqual(
+        getMemories(dbManager).map((entry) => entry.content).sort(),
+        ['kept global memory', 'unrelated global user', 'unrelated project memory'].sort(),
+      );
+    });
+
+    it('removes duplicate and stale-category rows by full Markdown identity', () => {
+      const first = addMemory(
+        dbManager,
+        '[correction] use pnpm',
+        'failure',
+        'project-a',
+        'correction',
+        'original reason',
+        null,
+        'pnpm install',
+        '2026-06-01',
+        '2026-07-05',
+      );
+      addMemory(dbManager, '[correction] use pnpm', 'failure', 'project-a', 'correction');
+      addMemory(dbManager, '[correction] use pnpm', 'failure', 'project-a', 'tool-quirk');
+
+      const result = reconcileMarkdownMemoryScope(
+        dbManager,
+        ['[correction] use pnpm <!-- created=2026-07-01, last=2026-07-02, project64=cHJvamVjdC1h -->'],
+        'failure',
+        'project-a',
+      );
+
+      const rows = dbManager.getDb().prepare(`
+        SELECT id, category, failure_reason, corrected_to, created, last_referenced
+        FROM memories
+        WHERE project = 'project-a' AND target = 'failure'
+      `).all() as Array<{
+        id: number;
+        category: string | null;
+        failure_reason: string | null;
+        corrected_to: string | null;
+        created: string;
+        last_referenced: string;
+      }>;
+
+      assert.strictEqual(result.removed, 2);
+      assert.deepStrictEqual(rows, [{
+        id: first.id,
+        category: 'correction',
+        failure_reason: 'original reason',
+        corrected_to: 'pnpm install',
+        created: '2026-06-01',
+        last_referenced: '2026-07-05',
+      }]);
     });
   });
 

--- a/tests/tools/memory-tool.test.ts
+++ b/tests/tools/memory-tool.test.ts
@@ -10,6 +10,7 @@ import { registerMemoryTool } from "../../src/tools/memory-tool.js";
 import { MemoryStore } from "../../src/store/memory-store.js";
 import { DatabaseManager } from "../../src/store/db.js";
 import { getMemories, syncMemoryEntry } from "../../src/store/sqlite-memory-store.js";
+import { ENTRY_DELIMITER, MEMORY_FILE } from "../../src/constants.js";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 describe("registerMemoryTool", () => {
@@ -148,6 +149,99 @@ describe("registerMemoryTool", () => {
     const results = getMemories(dbManager, { target: 'memory', project: null });
     assert.strictEqual(results.length, 1);
     assert.strictEqual(results[0].content, 'Entry one');
+  });
+
+  it("prunes same-scope SQLite orphans after a Markdown mutation", async () => {
+    let capturedResult: any;
+    const mockPi = {
+      registerTool: (definition: any) => { capturedResult = definition; },
+    } as unknown as ExtensionAPI;
+    const store = new MemoryStore({
+      memoryMode: "policy-only",
+      memoryCharLimit: 5000,
+      userCharLimit: 5000,
+      projectCharLimit: 5000,
+      nudgeInterval: 10,
+      reviewEnabled: false,
+      flushOnCompact: false,
+      flushOnShutdown: false,
+      flushMinTurns: 6,
+      autoConsolidate: false,
+      correctionDetection: false,
+      failureInjectionEnabled: true,
+      failureInjectionMaxAgeDays: 7,
+      failureInjectionMaxEntries: 5,
+      nudgeToolCalls: 15,
+      consolidationTimeoutMs: 60000,
+      memoryDir: tmpDir,
+    });
+    await store.loadFromDisk();
+    syncMemoryEntry(dbManager, { content: "orphaned row", target: "memory", project: null });
+
+    registerMemoryTool(mockPi, store, null, dbManager);
+    await capturedResult.execute(
+      "tc-1",
+      { action: "add", target: "memory", content: "authoritative Markdown row" },
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    assert.deepStrictEqual(
+      getMemories(dbManager, { target: "memory", project: null }).map((entry) => entry.content),
+      ["authoritative Markdown row"],
+    );
+  });
+
+  it("reconciles SQLite from fresh authoritative Markdown state", async () => {
+    let capturedResult: any;
+    const mockPi = {
+      registerTool: (definition: any) => { capturedResult = definition; },
+    } as unknown as ExtensionAPI;
+    const store = new MemoryStore({
+      memoryMode: "policy-only",
+      memoryCharLimit: 5000,
+      userCharLimit: 5000,
+      projectCharLimit: 5000,
+      nudgeInterval: 10,
+      reviewEnabled: false,
+      flushOnCompact: false,
+      flushOnShutdown: false,
+      flushMinTurns: 6,
+      autoConsolidate: false,
+      correctionDetection: false,
+      failureInjectionEnabled: true,
+      failureInjectionMaxAgeDays: 7,
+      failureInjectionMaxEntries: 5,
+      nudgeToolCalls: 15,
+      consolidationTimeoutMs: 60000,
+      memoryDir: tmpDir,
+    });
+    await store.loadFromDisk();
+
+    const originalSave = (store as any).saveToDisk.bind(store);
+    (store as any).saveToDisk = async (target: "memory") => {
+      await originalSave(target);
+      const markdownPath = path.join(tmpDir, MEMORY_FILE);
+      const existing = fs.readFileSync(markdownPath, "utf-8");
+      const date = new Date().toISOString().split("T")[0];
+      fs.writeFileSync(markdownPath, `${existing}${ENTRY_DELIMITER}newer writer <!-- created=${date}, last=${date} -->`);
+      syncMemoryEntry(dbManager, { content: "newer writer", target: "memory", project: null });
+    };
+
+    registerMemoryTool(mockPi, store, null, dbManager);
+    await capturedResult.execute(
+      "tc-1",
+      { action: "add", target: "memory", content: "first writer" },
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    assert.deepStrictEqual(
+      getMemories(dbManager, { target: "memory", project: null }).map((entry) => entry.content).sort(),
+      ["first writer", "newer writer"],
+    );
   });
 
   it("removes FIFO-evicted entries from the SQLite mirror", async () => {


### PR DESCRIPTION
## Summary

- reconcile each Markdown target/project scope transactionally so deleted, duplicate, stale-category, and orphaned SQLite rows self-heal
- run reconciliation inside the same canonical Markdown mutation lease as the write
- make SQLite corruption recovery single-owner, token-safe, bounded, and circuit-broken across processes and symlink aliases
- cap quarantine/rebuild artifacts and clean abandoned rebuilds
- migrate legacy SQLite generations through a write-excluded, integrity-checked snapshot/readiness protocol
- preserve corrupt generations for the recovery path and preserve all rollback artifacts when restoration is incomplete
- protect migration publication/rollback from concurrent source or destination successors
- make missing canonical project memory authoritative empty instead of resurrecting retained legacy backups

## Root causes

Markdown is the source of truth, but the old write path only added mirror rows; it never reconciled deletions or stale scope/category identities. Corruption recovery was independently attempted by every Pi process, creating rebuild children and unbounded artifacts. Legacy DB migration also exposed partial generations and could lose WAL commits or rollback over concurrent paths.

Closes #96.
Closes #98.

Thanks to @paxcalpt for the corruption fork-storm reproduction and @niksite for the orphaned mirror-row diagnosis.

## Stack

This is stacked on #102 (which is stacked on #101). The commits are separated by subsystem; after the earlier PRs merge, GitHub will reduce this PR to the SQLite recovery/reconciliation commit.

## Verification

- all 38 test files passed on Node 24.16
- focused SQLite/migration/reconciliation suite: 185 tests passed
- `npm run check`
- regressions cover recovery owner races, PID reuse and stale tokens, symlink/dangling aliases, circuit semantics, artifact caps, Markdown deletion and exact-scope pruning, correction/failure scope metadata, WAL snapshot consistency, concurrent writers/openers, corrupt migration handoff, main-last readiness, rollback ownership, and preserved recovery directories
