### PR TITLE
fix: hard-stop runaway child process trees

### DIFF
--- a/src/handlers/auto-consolidate.ts
+++ b/src/handlers/auto-consolidate.ts
@@ -87,7 +87,7 @@ function describeConsolidationFailure(
   timeoutMs: number,
 ): string {
   const stderr = result.stderr?.trim();
-  const terminated = result.killed || result.code === 143;
+  const terminated = result.killed || result.code === 124 || result.code === 143;
 
   if (terminated) {
     return `Consolidation subprocess was terminated (likely timeout or cancellation). Timeout: ${timeoutMs}ms. Consider increasing consolidationTimeoutMs if this is a manual run.`;

--- a/src/handlers/child-process-watchdog.mjs
+++ b/src/handlers/child-process-watchdog.mjs
@@ -1,0 +1,76 @@
+import { spawn } from "node:child_process";
+
+const [timeoutValue, command, ...args] = process.argv.slice(2);
+const timeoutMs = Number(timeoutValue);
+
+if (!command || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+  process.stderr.write("pi-hermes-memory watchdog: invalid invocation\n");
+  process.exit(2);
+}
+
+const child = spawn(command, args, {
+  detached: process.platform !== "win32",
+  stdio: ["ignore", "pipe", "pipe"],
+});
+
+child.stdout?.pipe(process.stdout);
+child.stderr?.pipe(process.stderr);
+
+let timedOut = false;
+let terminating = false;
+let forceTimer;
+
+function signalTree(signal) {
+  if (!child.pid) return;
+  if (process.platform === "win32") {
+    const killer = spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    killer.unref();
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try { child.kill(signal); } catch {}
+  }
+}
+
+function terminateTree() {
+  if (terminating) return;
+  terminating = true;
+  signalTree("SIGTERM");
+  forceTimer = setTimeout(() => signalTree("SIGKILL"), 500);
+  forceTimer.unref();
+}
+
+const timeout = setTimeout(() => {
+  timedOut = true;
+  process.stderr.write(`[pi-hermes-memory] child timed out after ${timeoutMs}ms; terminating process tree\n`);
+  terminateTree();
+}, timeoutMs);
+timeout.unref();
+
+for (const signal of ["SIGTERM", "SIGINT"]) {
+  process.on(signal, terminateTree);
+}
+
+child.once("error", (error) => {
+  clearTimeout(timeout);
+  if (forceTimer) clearTimeout(forceTimer);
+  process.stderr.write(`pi-hermes-memory watchdog: ${error.message}\n`);
+  process.exitCode = timedOut ? 124 : 127;
+});
+
+child.once("close", (code, signal) => {
+  clearTimeout(timeout);
+  if (forceTimer) clearTimeout(forceTimer);
+  if (timedOut) {
+    process.exitCode = 124;
+  } else if (typeof code === "number") {
+    process.exitCode = code;
+  } else {
+    process.exitCode = signal === "SIGTERM" ? 143 : 1;
+  }
+});

--- a/src/handlers/child-process-watchdog.mjs
+++ b/src/handlers/child-process-watchdog.mjs
@@ -1,9 +1,10 @@
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 
-const [timeoutValue, command, ...args] = process.argv.slice(2);
+const [timeoutValue, cancellationPath, command, ...args] = process.argv.slice(2);
 const timeoutMs = Number(timeoutValue);
 
-if (!command || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+if (!cancellationPath || !command || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
   process.stderr.write("pi-hermes-memory watchdog: invalid invocation\n");
   process.exit(2);
 }
@@ -17,6 +18,7 @@ child.stdout?.pipe(process.stdout);
 child.stderr?.pipe(process.stderr);
 
 let timedOut = false;
+let cancelled = false;
 let terminating = false;
 let forceTimer;
 
@@ -52,22 +54,34 @@ const timeout = setTimeout(() => {
 }, timeoutMs);
 timeout.unref();
 
+const cancellationPoll = cancellationPath === "-" ? undefined : setInterval(() => {
+  if (!existsSync(cancellationPath)) return;
+  cancelled = true;
+  process.stderr.write("[pi-hermes-memory] child cancellation requested; terminating process tree\n");
+  terminateTree();
+}, 25);
+cancellationPoll?.unref();
+
 for (const signal of ["SIGTERM", "SIGINT"]) {
   process.on(signal, terminateTree);
 }
 
 child.once("error", (error) => {
   clearTimeout(timeout);
+  if (cancellationPoll) clearInterval(cancellationPoll);
   if (forceTimer) clearTimeout(forceTimer);
   process.stderr.write(`pi-hermes-memory watchdog: ${error.message}\n`);
-  process.exitCode = timedOut ? 124 : 127;
+  process.exitCode = timedOut ? 124 : cancelled ? 143 : 127;
 });
 
 child.once("close", (code, signal) => {
   clearTimeout(timeout);
+  if (cancellationPoll) clearInterval(cancellationPoll);
   if (forceTimer) clearTimeout(forceTimer);
   if (timedOut) {
     process.exitCode = 124;
+  } else if (cancelled) {
+    process.exitCode = 143;
   } else if (typeof code === "number") {
     process.exitCode = code;
   } else {

--- a/src/handlers/pi-child-process.ts
+++ b/src/handlers/pi-child-process.ts
@@ -13,6 +13,7 @@ interface PiExecResult {
   code: number;
   stdout?: string;
   stderr?: string;
+  killed?: boolean;
 }
 
 interface ExecChildPromptOptions {
@@ -31,6 +32,10 @@ const DEFAULT_EXEC_CHILD_PROMPT_DEPENDENCIES: ExecChildPromptDependencies = {
   },
 };
 
+const WATCHDOG_EXIT_GRACE_MS = 5000;
+const CHILD_PROCESS_WATCHDOG_PATH = fileURLToPath(
+  new URL("./child-process-watchdog.mjs", import.meta.url),
+);
 export interface ChildPiInvocation {
   command: string;
   args: string[];
@@ -299,6 +304,21 @@ export function resolveChildPiInvocation(
   };
 }
 
+export function resolveWatchedChildPiInvocation(
+  invocation: ChildPiInvocation,
+  timeoutMs: number,
+): ChildPiInvocation {
+  return {
+    command: process.execPath,
+    args: [
+      CHILD_PROCESS_WATCHDOG_PATH,
+      String(timeoutMs),
+      invocation.command,
+      ...invocation.args,
+    ],
+  };
+}
+
 function shouldRetryWithoutOverridesFromText(text: string | undefined): boolean {
   if (!text) return false;
   return OVERRIDE_FAILURE_SUBJECT.test(text) && OVERRIDE_FAILURE_REASON.test(text);
@@ -333,14 +353,17 @@ export async function execChildPrompt(
 ): Promise<PiExecResult> {
   const execOptions = {
     signal: options.signal,
-    timeout: options.timeoutMs,
+    timeout: options.timeoutMs + WATCHDOG_EXIT_GRACE_MS,
   };
   const temporaryPrompt = await writePromptToTemporaryFile(prompt);
   const promptReference = `@${temporaryPrompt.filePath}`;
 
   try {
     try {
-      const invocation = resolveChildPiInvocation(buildChildPiPromptArgs(promptReference, config));
+      const invocation = resolveWatchedChildPiInvocation(
+        resolveChildPiInvocation(buildChildPiPromptArgs(promptReference, config)),
+        options.timeoutMs,
+      );
       const result = await pi.exec(invocation.command, invocation.args, execOptions) as PiExecResult;
       if (
         result.code === 0 ||
@@ -360,7 +383,10 @@ export async function execChildPrompt(
       }
     }
 
-    const retryInvocation = resolveChildPiInvocation(basePromptArgs(promptReference, config));
+    const retryInvocation = resolveWatchedChildPiInvocation(
+      resolveChildPiInvocation(basePromptArgs(promptReference, config)),
+      options.timeoutMs,
+    );
     return await pi.exec(retryInvocation.command, retryInvocation.args, execOptions) as PiExecResult;
   } finally {
     try { await dependencies.removeTemporaryDirectory(temporaryPrompt.dir); } catch {}

--- a/src/handlers/pi-child-process.ts
+++ b/src/handlers/pi-child-process.ts
@@ -284,6 +284,40 @@ function resolvedPiCliPath(options: ResolveChildPiInvocationOptions): string | u
   return resolvedInstalledPiCliPath();
 }
 
+function resolvedWindowsPiInvocation(
+  args: string[],
+  execPath: string,
+): ChildPiInvocation | undefined {
+  const pathEntries = (process.env.PATH ?? process.env.Path ?? "")
+    .split(";")
+    .map((entry) => entry.trim().replace(/^"|"$/g, ""))
+    .filter(Boolean);
+
+  for (const directory of pathEntries) {
+    for (const executableName of ["pi.exe", "pi.com"]) {
+      const executablePath = join(directory, executableName);
+      if (existsSync(executablePath)) {
+        return { command: executablePath, args };
+      }
+    }
+
+    if (!existsSync(join(directory, "pi.cmd")) && !existsSync(join(directory, "pi.bat"))) {
+      continue;
+    }
+
+    for (const cliPath of [
+      join(directory, "node_modules", "@earendil-works", "pi-coding-agent", "dist", "cli.js"),
+      join(directory, "node_modules", "@earendil-works", "pi-coding-agent", "cli.js"),
+    ]) {
+      if (existsSync(cliPath)) {
+        return { command: execPath, args: [cliPath, ...args] };
+      }
+    }
+  }
+
+  return undefined;
+}
+
 export function resolveChildPiInvocation(
   args: string[],
   options: ResolveChildPiInvocationOptions = {},
@@ -294,25 +328,30 @@ export function resolveChildPiInvocation(
   }
 
   const piCliPath = resolvedPiCliPath(options);
-  if (!piCliPath) {
-    return { command: "pi", args };
+  if (piCliPath) {
+    return {
+      command: options.execPath ?? process.execPath,
+      args: [piCliPath, ...args],
+    };
   }
 
-  return {
-    command: options.execPath ?? process.execPath,
-    args: [piCliPath, ...args],
-  };
+  const fallback = resolvedWindowsPiInvocation(args, options.execPath ?? process.execPath);
+  if (fallback) return fallback;
+
+  throw new Error("Unable to resolve a directly executable Pi CLI on Windows");
 }
 
 export function resolveWatchedChildPiInvocation(
   invocation: ChildPiInvocation,
   timeoutMs: number,
+  cancellationPath = "-",
 ): ChildPiInvocation {
   return {
     command: process.execPath,
     args: [
       CHILD_PROCESS_WATCHDOG_PATH,
       String(timeoutMs),
+      cancellationPath,
       invocation.command,
       ...invocation.args,
     ],
@@ -352,17 +391,23 @@ export async function execChildPrompt(
   dependencies: ExecChildPromptDependencies = DEFAULT_EXEC_CHILD_PROMPT_DEPENDENCIES,
 ): Promise<PiExecResult> {
   const execOptions = {
-    signal: options.signal,
     timeout: options.timeoutMs + WATCHDOG_EXIT_GRACE_MS,
   };
   const temporaryPrompt = await writePromptToTemporaryFile(prompt);
   const promptReference = `@${temporaryPrompt.filePath}`;
+  const cancellationPath = join(temporaryPrompt.dir, "cancel");
+  const requestCancellation = () => {
+    void fs.writeFile(cancellationPath, "", { mode: 0o600 }).catch(() => {});
+  };
+  options.signal?.addEventListener("abort", requestCancellation, { once: true });
+  if (options.signal?.aborted) requestCancellation();
 
   try {
     try {
       const invocation = resolveWatchedChildPiInvocation(
         resolveChildPiInvocation(buildChildPiPromptArgs(promptReference, config)),
         options.timeoutMs,
+        cancellationPath,
       );
       const result = await pi.exec(invocation.command, invocation.args, execOptions) as PiExecResult;
       if (
@@ -386,9 +431,15 @@ export async function execChildPrompt(
     const retryInvocation = resolveWatchedChildPiInvocation(
       resolveChildPiInvocation(basePromptArgs(promptReference, config)),
       options.timeoutMs,
+      cancellationPath,
     );
     return await pi.exec(retryInvocation.command, retryInvocation.args, execOptions) as PiExecResult;
   } finally {
-    try { await dependencies.removeTemporaryDirectory(temporaryPrompt.dir); } catch {}
+    options.signal?.removeEventListener("abort", requestCancellation);
+    try {
+      await dependencies.removeTemporaryDirectory(temporaryPrompt.dir);
+    } catch {
+      try { await fs.unlink(temporaryPrompt.filePath); } catch {}
+    }
   }
 }

--- a/tests/handlers/auto-consolidate.test.ts
+++ b/tests/handlers/auto-consolidate.test.ts
@@ -9,7 +9,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";
 import { registerConsolidateCommand, triggerConsolidation } from "../../src/handlers/auto-consolidate.js";
-import { resolveChildPiInvocation } from "../../src/handlers/pi-child-process.js";
+import { resolveWatchedChildPiInvocation } from "../../src/handlers/pi-child-process.js";
 import { MemoryStore } from "../../src/store/memory-store.js";
 import { AtomicLockCoordinator } from "../../src/store/atomic-lock-coordinator.js";
 import { ENTRY_DELIMITER } from "../../src/constants.js";
@@ -64,11 +64,10 @@ after(async () => {
 
 function logicalChildArgs(call: any[]): string[] {
   const [cmd, args] = call;
-  const logicalArgs = cmd === "pi" ? args : args.slice(1);
-  const expected = resolveChildPiInvocation(logicalArgs);
-  assert.strictEqual(cmd, expected.command);
-  assert.deepStrictEqual(args, expected.args);
-  return logicalArgs;
+  const underlying = { command: args[2], args: args.slice(3) };
+  const expected = resolveWatchedChildPiInvocation(underlying, Number(args[1]));
+  assert.deepStrictEqual({ command: cmd, args }, expected);
+  return underlying.command === "pi" ? underlying.args : underlying.args.slice(1);
 }
 
 function childPrompt(call: any[]): string {
@@ -566,7 +565,8 @@ describe("registerConsolidateCommand", () => {
     });
 
     for (const call of execCalls) {
-      assert.strictEqual(call[2]?.timeout, 180000);
+      assert.strictEqual(call[1][1], "180000");
+      assert.strictEqual(call[2]?.timeout, 185000);
     }
   });
 

--- a/tests/handlers/auto-consolidate.test.ts
+++ b/tests/handlers/auto-consolidate.test.ts
@@ -64,8 +64,8 @@ after(async () => {
 
 function logicalChildArgs(call: any[]): string[] {
   const [cmd, args] = call;
-  const underlying = { command: args[2], args: args.slice(3) };
-  const expected = resolveWatchedChildPiInvocation(underlying, Number(args[1]));
+  const underlying = { command: args[3], args: args.slice(4) };
+  const expected = resolveWatchedChildPiInvocation(underlying, Number(args[1]), args[2]);
   assert.deepStrictEqual({ command: cmd, args }, expected);
   return underlying.command === "pi" ? underlying.args : underlying.args.slice(1);
 }

--- a/tests/handlers/background-review.test.ts
+++ b/tests/handlers/background-review.test.ts
@@ -8,7 +8,7 @@ import {
   setupBackgroundReview,
   type BackgroundReviewDeps,
 } from "../../src/handlers/background-review.js";
-import { resolveChildPiInvocation } from "../../src/handlers/pi-child-process.js";
+import { resolveWatchedChildPiInvocation } from "../../src/handlers/pi-child-process.js";
 import type { DirectReviewResult } from "../../src/handlers/review-memory-ops.js";
 import type { MemoryConfig } from "../../src/types.js";
 
@@ -161,11 +161,11 @@ async function settle(ms = 10): Promise<void> {
 
 function logicalChildArgs(index = execCalls.length - 1): string[] {
   const [cmd, args] = execCalls[index];
-  const logicalArgs = cmd === "pi" ? args : args.slice(1);
-  const expected = resolveChildPiInvocation(logicalArgs);
+  const underlying = { command: args[3], args: args.slice(4) };
+  const expected = resolveWatchedChildPiInvocation(underlying, Number(args[1]), args[2]);
   assert.strictEqual(cmd, expected.command);
   assert.deepStrictEqual(args, expected.args);
-  return logicalArgs;
+  return underlying.command === "pi" ? underlying.args : underlying.args.slice(1);
 }
 
 function reviewPrompt(index = execCalls.length - 1): string {

--- a/tests/handlers/correction-detector.test.ts
+++ b/tests/handlers/correction-detector.test.ts
@@ -13,7 +13,7 @@ import { getMemories } from "../../src/store/sqlite-memory-store.js";
 import { MemoryStore } from "../../src/store/memory-store.js";
 import { registerMemoryTool } from "../../src/tools/memory-tool.js";
 import { isCorrection, setupCorrectionDetector } from "../../src/handlers/correction-detector.js";
-import { resolveChildPiInvocation } from "../../src/handlers/pi-child-process.js";
+import { resolveWatchedChildPiInvocation } from "../../src/handlers/pi-child-process.js";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { MemoryConfig } from "../../src/types.js";
 
@@ -284,11 +284,11 @@ describe("setupCorrectionDetector handler", () => {
 
   function logicalChildArgs(call: any[]): string[] {
     const [cmd, args] = call;
-    const logicalArgs = cmd === "pi" ? args : args.slice(1);
-    const expected = resolveChildPiInvocation(logicalArgs);
+    const underlying = { command: args[3], args: args.slice(4) };
+    const expected = resolveWatchedChildPiInvocation(underlying, Number(args[1]), args[2]);
     assert.strictEqual(cmd, expected.command);
     assert.deepStrictEqual(args, expected.args);
-    return logicalArgs;
+    return underlying.command === "pi" ? underlying.args : underlying.args.slice(1);
   }
 
   const mockStore = {

--- a/tests/handlers/pi-child-process.test.ts
+++ b/tests/handlers/pi-child-process.test.ts
@@ -15,8 +15,8 @@ import {
 } from "../../src/handlers/pi-child-process.js";
 
 function logicalChildArgs(call: { cmd: string; args: string[] }): string[] {
-  const underlying = { command: call.args[2], args: call.args.slice(3) };
-  const expected = resolveWatchedChildPiInvocation(underlying, 30000);
+  const underlying = { command: call.args[3], args: call.args.slice(4) };
+  const expected = resolveWatchedChildPiInvocation(underlying, 30000, call.args[2]);
   assert.deepStrictEqual(call, { cmd: expected.command, args: expected.args });
   return underlying.command === "pi" ? underlying.args : underlying.args.slice(1);
 }
@@ -305,13 +305,41 @@ describe("resolveChildPiInvocation", () => {
     );
   });
 
-  it("falls back to the existing pi invocation on Windows if cli.js cannot be resolved", () => {
-    const args = ["-p", "--no-session", "hello"];
-
-    assert.deepStrictEqual(
-      resolveChildPiInvocation(args, { platform: "win32", piCliPath: null }),
-      { command: "pi", args },
+  it("resolves a standard Windows command shim to its adjacent cli.js", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "pi-windows-shim-"));
+    const binDirectory = path.join(directory, "bin");
+    const cliPath = path.join(
+      binDirectory,
+      "node_modules",
+      "@earendil-works",
+      "pi-coding-agent",
+      "dist",
+      "cli.js",
     );
+    const args = ["-p", "--no-session", "hello"];
+    const originalPath = process.env.PATH;
+
+    await fs.mkdir(path.dirname(cliPath), { recursive: true });
+    await fs.writeFile(path.join(binDirectory, "pi.cmd"), "@echo off\r\n");
+    await fs.writeFile(cliPath, "");
+    process.env.PATH = `${binDirectory};C:\\Windows\\System32`;
+    try {
+      assert.deepStrictEqual(
+        resolveChildPiInvocation(args, {
+          platform: "win32",
+          execPath: "C:\\Program Files\\nodejs\\node.exe",
+          piCliPath: null,
+        }),
+        {
+          command: "C:\\Program Files\\nodejs\\node.exe",
+          args: [cliPath, ...args],
+        },
+      );
+    } finally {
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+      await fs.rm(directory, { recursive: true, force: true });
+    }
   });
 });
 
@@ -329,8 +357,37 @@ describe("execChildPrompt", () => {
     assert.equal(calls[0].cmd, process.execPath);
     assert.match(calls[0].args[0].replaceAll("\\", "/"), /child-process-watchdog\.mjs$/);
     assert.equal(calls[0].args[1], "30000");
-    assert.equal(calls[0].args[2], "pi");
+    assert.match(calls[0].args[2], /cancel$/);
+    assert.equal(calls[0].args[3], "pi");
     assert.equal(calls[0].timeout, 35000);
+  });
+
+  it("cancels through the watchdog without forwarding the abort signal to pi.exec", async () => {
+    const abortController = new AbortController();
+    let cancelPath = "";
+    const result = await execChildPrompt({
+      exec: async (_cmd: string, args: string[], options: { signal?: AbortSignal }) => {
+        cancelPath = args[2];
+        assert.equal(options.signal, undefined);
+        abortController.abort();
+        const deadline = Date.now() + 1000;
+        while (Date.now() < deadline) {
+          try {
+            await fs.access(cancelPath);
+            return { code: 143, stderr: "child cancelled" };
+          } catch {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+          }
+        }
+        assert.fail("abort did not notify the watchdog");
+      },
+    } as any, "cancel child", {}, {
+      signal: abortController.signal,
+      timeoutMs: 30000,
+    });
+
+    assert.equal(result.code, 143);
+    await assert.rejects(fs.access(cancelPath), { code: "ENOENT" });
   });
 
   it("hard-kills a child that ignores graceful timeout termination", async () => {
@@ -342,6 +399,7 @@ describe("execChildPrompt", () => {
       const child = spawn(process.execPath, [
         watchdogPath,
         "100",
+        "-",
         process.execPath,
         "-e",
         "process.on('SIGTERM',()=>{});setInterval(()=>{},1000)",
@@ -354,6 +412,37 @@ describe("execChildPrompt", () => {
     assert.equal(result.code, 124);
     assert.match(result.stderr, /timed out after 100ms/i);
     assert.ok(Date.now() - startedAt < 3000, "watchdog must enforce a bounded hard stop");
+  });
+
+  it("terminates the child tree when its cancellation marker appears", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "pi-watchdog-cancel-"));
+    const cancelPath = path.join(directory, "cancel");
+    const watchdogPath = fileURLToPath(
+      new URL("../../src/handlers/child-process-watchdog.mjs", import.meta.url),
+    );
+    const startedAt = Date.now();
+    try {
+      const result = await new Promise<{ code: number | null; stderr: string }>((resolve) => {
+        const child = spawn(process.execPath, [
+          watchdogPath,
+          "10000",
+          cancelPath,
+          process.execPath,
+          "-e",
+          "process.on('SIGTERM',()=>{});setInterval(()=>{},1000)",
+        ], { stdio: ["ignore", "ignore", "pipe"] });
+        let stderr = "";
+        child.stderr.on("data", (chunk) => { stderr += chunk.toString(); });
+        child.on("close", (code) => resolve({ code, stderr }));
+        setTimeout(() => void fs.writeFile(cancelPath, ""), 100);
+      });
+
+      assert.equal(result.code, 143);
+      assert.match(result.stderr, /child cancellation requested/i);
+      assert.ok(Date.now() - startedAt < 3000, "watchdog cancellation must be bounded");
+    } finally {
+      await fs.rm(directory, { recursive: true, force: true });
+    }
   });
 
   it("hard-kills descendants in the timed-out child process group", {
@@ -378,6 +467,7 @@ describe("execChildPrompt", () => {
         const child = spawn(process.execPath, [
           watchdogPath,
           "100",
+          "-",
           process.execPath,
           "-e",
           parent,
@@ -566,7 +656,22 @@ describe("execChildPrompt", () => {
   });
 
   it("uses the resolved Windows node.exe invocation for both override retry attempts", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "pi-windows-retry-"));
+    const binDirectory = path.join(directory, "bin");
+    const cliPath = path.join(
+      binDirectory,
+      "node_modules",
+      "@earendil-works",
+      "pi-coding-agent",
+      "dist",
+      "cli.js",
+    );
     const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+    const originalPath = process.env.PATH;
+    await fs.mkdir(path.dirname(cliPath), { recursive: true });
+    await fs.writeFile(path.join(binDirectory, "pi.cmd"), "@echo off\r\n");
+    await fs.writeFile(cliPath, "");
+    process.env.PATH = `${binDirectory};C:\\Windows\\System32`;
     Object.defineProperty(process, "platform", { value: "win32", configurable: true });
     try {
       const calls: Array<{ cmd: string; args: string[] }> = [];
@@ -591,8 +696,8 @@ describe("execChildPrompt", () => {
       assert.strictEqual(calls.length, 2);
       assert.strictEqual(calls[0].cmd, process.execPath);
       assert.strictEqual(calls[1].cmd, process.execPath);
-      assert.match(calls[0].args[3].replace(/\\/g, "/"), /\/cli\.js$/);
-      assert.match(calls[1].args[3].replace(/\\/g, "/"), /\/cli\.js$/);
+      assert.match(calls[0].args[4].replace(/\\/g, "/"), /\/cli\.js$/);
+      assert.match(calls[1].args[4].replace(/\\/g, "/"), /\/cli\.js$/);
       const promptReference = calls[0].args.at(-1)!;
       assert.match(promptReference, /^@/);
       assert.deepStrictEqual(calls.map(logicalChildArgs), [
@@ -601,6 +706,9 @@ describe("execChildPrompt", () => {
       ]);
     } finally {
       if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+      await fs.rm(directory, { recursive: true, force: true });
     }
   });
 

--- a/tests/handlers/pi-child-process.test.ts
+++ b/tests/handlers/pi-child-process.test.ts
@@ -1,4 +1,5 @@
 import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -10,13 +11,14 @@ import {
   execChildPrompt,
   inheritedExtensionArgs,
   resolveChildPiInvocation,
+  resolveWatchedChildPiInvocation,
 } from "../../src/handlers/pi-child-process.js";
 
 function logicalChildArgs(call: { cmd: string; args: string[] }): string[] {
-  const expected = resolveChildPiInvocation(call.cmd === "pi" ? call.args : call.args.slice(1));
-  assert.strictEqual(call.cmd, expected.command);
-  assert.deepStrictEqual(call.args, expected.args);
-  return call.cmd === "pi" ? call.args : call.args.slice(1);
+  const underlying = { command: call.args[2], args: call.args.slice(3) };
+  const expected = resolveWatchedChildPiInvocation(underlying, 30000);
+  assert.deepStrictEqual(call, { cmd: expected.command, args: expected.args });
+  return underlying.command === "pi" ? underlying.args : underlying.args.slice(1);
 }
 
 // Compute the expected OWN_EXTENSION_PATH same logic as pi-child-process.ts
@@ -314,6 +316,92 @@ describe("resolveChildPiInvocation", () => {
 });
 
 describe("execChildPrompt", () => {
+  it("runs child Pi behind a hard process-tree watchdog", async () => {
+    const calls: Array<{ cmd: string; args: string[]; timeout?: number }> = [];
+    await execChildPrompt({
+      exec: async (cmd: string, args: string[], options: { timeout?: number }) => {
+        calls.push({ cmd, args, timeout: options.timeout });
+        return { code: 0, stdout: "ok", stderr: "", killed: false };
+      },
+    } as any, "bounded child", {}, { timeoutMs: 30000 });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].cmd, process.execPath);
+    assert.match(calls[0].args[0].replaceAll("\\", "/"), /child-process-watchdog\.mjs$/);
+    assert.equal(calls[0].args[1], "30000");
+    assert.equal(calls[0].args[2], "pi");
+    assert.equal(calls[0].timeout, 35000);
+  });
+
+  it("hard-kills a child that ignores graceful timeout termination", async () => {
+    const watchdogPath = fileURLToPath(
+      new URL("../../src/handlers/child-process-watchdog.mjs", import.meta.url),
+    );
+    const startedAt = Date.now();
+    const result = await new Promise<{ code: number | null; stderr: string }>((resolve) => {
+      const child = spawn(process.execPath, [
+        watchdogPath,
+        "100",
+        process.execPath,
+        "-e",
+        "process.on('SIGTERM',()=>{});setInterval(()=>{},1000)",
+      ], { stdio: ["ignore", "ignore", "pipe"] });
+      let stderr = "";
+      child.stderr.on("data", (chunk) => { stderr += chunk.toString(); });
+      child.on("close", (code) => resolve({ code, stderr }));
+    });
+
+    assert.equal(result.code, 124);
+    assert.match(result.stderr, /timed out after 100ms/i);
+    assert.ok(Date.now() - startedAt < 3000, "watchdog must enforce a bounded hard stop");
+  });
+
+  it("hard-kills descendants in the timed-out child process group", {
+    skip: process.platform === "win32" ? "uses taskkill /T on Windows" : false,
+  }, async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "pi-watchdog-tree-"));
+    const pidPath = path.join(directory, "descendant.pid");
+    const watchdogPath = fileURLToPath(
+      new URL("../../src/handlers/child-process-watchdog.mjs", import.meta.url),
+    );
+    const descendant = "process.on('SIGTERM',()=>{});setInterval(()=>{},1000)";
+    const parent = [
+      "const {spawn}=require('node:child_process');",
+      "const fs=require('node:fs');",
+      `const child=spawn(process.execPath,['-e',${JSON.stringify(descendant)}],{stdio:'ignore'});`,
+      `fs.writeFileSync(${JSON.stringify(pidPath)},String(child.pid));`,
+      "process.on('SIGTERM',()=>{});setInterval(()=>{},1000);",
+    ].join("");
+
+    try {
+      const code = await new Promise<number | null>((resolve) => {
+        const child = spawn(process.execPath, [
+          watchdogPath,
+          "100",
+          process.execPath,
+          "-e",
+          parent,
+        ], { stdio: "ignore" });
+        child.on("close", resolve);
+      });
+      assert.equal(code, 124);
+      const descendantPid = Number(await fs.readFile(pidPath, "utf-8"));
+      const deadline = Date.now() + 1000;
+      while (Date.now() < deadline) {
+        try {
+          process.kill(descendantPid, 0);
+          await new Promise((resolve) => setTimeout(resolve, 20));
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === "ESRCH") return;
+          throw error;
+        }
+      }
+      assert.fail("watchdog left a descendant process alive");
+    } finally {
+      await fs.rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it("keeps a sensitive prompt out of argv and removes its mode-0600 temporary file", async () => {
     const secret = "PRIVATE-MEMORY-CONTENT";
     let promptPath = "";
@@ -503,11 +591,11 @@ describe("execChildPrompt", () => {
       assert.strictEqual(calls.length, 2);
       assert.strictEqual(calls[0].cmd, process.execPath);
       assert.strictEqual(calls[1].cmd, process.execPath);
-      assert.match(calls[0].args[0].replace(/\\/g, "/"), /\/cli\.js$/);
-      assert.match(calls[1].args[0].replace(/\\/g, "/"), /\/cli\.js$/);
+      assert.match(calls[0].args[3].replace(/\\/g, "/"), /\/cli\.js$/);
+      assert.match(calls[1].args[3].replace(/\\/g, "/"), /\/cli\.js$/);
       const promptReference = calls[0].args.at(-1)!;
       assert.match(promptReference, /^@/);
-      assert.deepStrictEqual(calls.map((call) => call.args.slice(1)), [
+      assert.deepStrictEqual(calls.map(logicalChildArgs), [
         ["-p", "--no-session", "--model", "openrouter/deepseek/deepseek-v4-flash", "--thinking", "off", ...EXT_ARGS, promptReference],
         ["-p", "--no-session", ...EXT_ARGS, promptReference],
       ]);

--- a/tests/handlers/session-flush.test.ts
+++ b/tests/handlers/session-flush.test.ts
@@ -2,7 +2,7 @@ import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { setupSessionFlush } from "../../src/handlers/session-flush.js";
-import { resolveChildPiInvocation } from "../../src/handlers/pi-child-process.js";
+import { resolveWatchedChildPiInvocation } from "../../src/handlers/pi-child-process.js";
 import { DIRECT_FLUSH_SYSTEM_PROMPT, FLUSH_PROMPT } from "../../src/constants.js";
 import type { MemoryConfig } from "../../src/types.js";
 import type { DirectReviewResult } from "../../src/handlers/review-memory-ops.js";
@@ -150,11 +150,11 @@ const mockStore = { getMemoryEntries: () => [], getUserEntries: () => [] } as an
 
 function logicalChildArgs(call: { args: any[] }): string[] {
   const [cmd, args] = call.args;
-  const logicalArgs = cmd === "pi" ? args : args.slice(1);
-  const expected = resolveChildPiInvocation(logicalArgs);
+  const underlying = { command: args[3], args: args.slice(4) };
+  const expected = resolveWatchedChildPiInvocation(underlying, Number(args[1]), args[2]);
   assert.equal(cmd, expected.command);
   assert.deepEqual(args, expected.args);
-  return logicalArgs;
+  return underlying.command === "pi" ? underlying.args : underlying.args.slice(1);
 }
 
 function flushMessage(call: { args: any[] }): string {
@@ -292,7 +292,7 @@ describe("setupSessionFlush", () => {
 
     // Options should include timeout
     assert.ok(opts, "options should be passed");
-    assert.equal(opts.timeout, 30000);
+    assert.equal(opts.timeout, 35000);
   });
 
   it("passes child LLM override args to flush subprocesses", async () => {
@@ -443,7 +443,7 @@ describe("setupSessionFlush", () => {
     assert.equal(mockPi.execCalls.length, 2, "both events should trigger flush");
   });
 
-  it("Passes signal from compact event to exec", async () => {
+  it("Routes compact cancellation through the watchdog", async () => {
     const config = defaultConfig();
     setupSessionFlush(mockPi.pi, mockStore, null, config);
 
@@ -457,7 +457,7 @@ describe("setupSessionFlush", () => {
 
     assert.equal(mockPi.execCalls.length, 1);
     const opts = mockPi.execCalls[0].args[2];
-    assert.equal(opts.signal, signal, "signal should be forwarded to exec");
+    assert.equal(opts.signal, undefined, "signal must not be forwarded to the watchdog process");
   });
 });
 
@@ -574,4 +574,3 @@ describe("direct transport", () => {
     assert.equal(mockPi.execCalls.length, 1);
   });
 });
-


### PR DESCRIPTION
## Summary

- run every non-interactive child Pi behind a bundled process-tree watchdog
- enforce the configured wall-clock timeout independently and escalate from graceful termination to a hard tree kill
- use POSIX process groups and Windows `taskkill /T /F` so descendants cannot survive
- route cancellation through a private marker so Windows cannot kill the watchdog before cleanup
- resolve Windows `pi.cmd` shims to the adjacent `cli.js` without shell interpolation
- preserve private prompt files, extension isolation, trusted auth adapters, and override retry behavior
- report timeout/cancellation explicitly to the parent

## Root cause

Pi's extension `execCommand` marks a process as `killed` as soon as `SIGTERM` is sent, then only sends `SIGKILL` when `proc.killed` is false. In Node, that property means the signal was sent—not that the process exited—so a child that ignores or traps `SIGTERM` can continue indefinitely. The old path also targeted only the direct process, not its descendants.

Closes #105.

## Verification

- watchdog regression: a child that ignores `SIGTERM` exits with code 124 within the hard bound
- process-tree regression: a stubborn descendant is also terminated
- cancellation-channel regression: abort terminates the tree without forwarding AbortSignal to the watchdog
- Windows shim and retry regressions
- focused child/consolidation/review/correction/flush suite: 158 tests passed
- full 38-file suite passed on Node 24.16 and Node 26
- `npm run check` and `git diff --check`