### PR TITLE
fix: guard check/test scripts for published package (#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-07-14
+
+### Fixed
+
+- **Published package exposed unusable `check`/`test` scripts** ([#108](https://github.com/chandra447/pi-hermes-memory/issues/108)): `npm run check` and `npm test` are source-checkout-only (they need TypeScript, `tsconfig.json`, and `tests/`, none of which ship in the production tarball). Running them after `pi install` now fails with a clear message pointing at a git clone + `npm install`, instead of cryptic `tsc: not found` / `tests/run-all.sh: not found` errors. Runtime extension behavior is unchanged; CI still runs these scripts before publish.
+
 ## [0.8.0] - 2026-07-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ Every write — memory and skills — passes through a scanner before being acce
 
 ![Security: Content Scanning](docs/images/security-flow.svg)
 
+## Development
+
+`npm run check` and `npm test` only work from a **full git checkout** after `npm install`. The published npm package intentionally omits `tests/`, TypeScript, and `tsconfig.json` (production install for Pi). Validate from source or rely on CI before publish.
+
+```bash
+git clone https://github.com/chandra447/pi-hermes-memory.git
+cd pi-hermes-memory
+npm install
+npm run check
+npm test
+```
+
 ## Installation
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hermes-memory",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-tui": "^0.80.2",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "🧠 Persistent memory + 🔍 session search + 🛡️ secret scanning for Pi. Token-aware policy-only memory by default, SQLite FTS5 search, auto-consolidation, procedural skills. 693 tests. Ported from Hermes agent.",
   "type": "module",
   "main": "src/index.ts",
   "files": [
     "src",
+    "scripts",
     "README.md",
     "LICENSE",
     "docs"
@@ -16,8 +17,8 @@
     ]
   },
   "scripts": {
-    "check": "tsc --noEmit",
-    "test": "tests/run-all.sh"
+    "check": "node scripts/ensure-dev.mjs check && tsc --noEmit",
+    "test": "node scripts/ensure-dev.mjs test && tests/run-all.sh"
   },
   "keywords": [
     "pi-package",

--- a/scripts/ensure-dev.mjs
+++ b/scripts/ensure-dev.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * Guard for check/test npm scripts.
+ *
+ * The published tarball intentionally omits tests/ and TypeScript (devDependency).
+ * When those scripts are run from an installed package (e.g. after `pi install`),
+ * fail with a clear message instead of `tsc: not found` / `tests/run-all.sh: not found`.
+ *
+ * @see https://github.com/chandra447/pi-hermes-memory/issues/108
+ */
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const mode = process.argv[2];
+const REPO = "https://github.com/chandra447/pi-hermes-memory";
+
+function fail(message) {
+  console.error(`\n[pi-hermes-memory] ${message}`);
+  console.error("");
+  console.error("These scripts only work from a full source checkout:");
+  console.error(`  git clone ${REPO}.git`);
+  console.error("  cd pi-hermes-memory && npm install");
+  console.error("  npm run check   # or: npm test");
+  console.error("");
+  console.error(
+    "The published package is for runtime use via Pi; CI validates check/test before publish.",
+  );
+  console.error("");
+  process.exit(1);
+}
+
+if (mode === "check") {
+  const require = createRequire(join(root, "package.json"));
+  try {
+    require.resolve("typescript/package.json");
+  } catch {
+    fail(
+      "`npm run check` requires TypeScript (a devDependency). The published npm package does not include it.",
+    );
+  }
+  if (!existsSync(join(root, "tsconfig.json"))) {
+    fail(
+      "`npm run check` requires tsconfig.json. The published npm package does not include it.",
+    );
+  }
+} else if (mode === "test") {
+  if (!existsSync(join(root, "tests", "run-all.sh"))) {
+    fail(
+      "`npm test` requires the tests/ directory. The published npm package intentionally omits it.",
+    );
+  }
+} else {
+  fail(`Unknown mode "${mode ?? ""}". Expected "check" or "test".`);
+}


### PR DESCRIPTION
## Summary
- Fixes [#108](https://github.com/chandra447/pi-hermes-memory/issues/108): `npm run check` / `npm test` after `pi install` no longer fail with cryptic `tsc: not found` / `tests/run-all.sh: not found`
- Adds `scripts/ensure-dev.mjs` so those scripts print a clear “source checkout only” message when TypeScript / `tests/` / `tsconfig.json` are missing
- Documents Development in README; bumps version to **0.8.1**

Runtime extension behavior is unchanged. CI continues to run check/test from full source before publish.

## Test plan
- [x] `npm run check` succeeds from full checkout
- [x] Simulated installed package (no `tests/`, no TypeScript) fails check/test with helpful message
- [x] `npm pack --dry-run` includes `scripts/ensure-dev.mjs`
- [ ] CI green on this PR

## Publish notes
After merge: `npm publish --access public`, then create GitHub release `v0.8.1`.