### PR TITLE
fix: wait for concurrent SQLite writers

### DIFF
--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -69,6 +69,7 @@ class DatabaseCorruptionError extends Error {
   }
 }
 
+export const SQLITE_BUSY_TIMEOUT_MS = 5000;
 export const SQLITE_WAL_AUTOCHECKPOINT_PAGES = 1000;
 
 const DATABASE_FILE_SUFFIXES: readonly DatabaseFileSuffix[] = ['', '-wal', '-shm'];
@@ -297,6 +298,7 @@ export class DatabaseManager {
     // Enable WAL mode + FK enforcement for each connection. Keep SQLite's
     // default WAL autocheckpoint size; a very aggressive checkpoint cadence
     // increases the chance that abrupt VM/host shutdown catches a checkpoint.
+    db.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`);
     db.exec('PRAGMA journal_mode = WAL');
     db.exec(`PRAGMA wal_autocheckpoint = ${SQLITE_WAL_AUTOCHECKPOINT_PAGES}`);
     db.exec('PRAGMA journal_size_limit = 5242880');

--- a/tests/store/db.test.ts
+++ b/tests/store/db.test.ts
@@ -4,8 +4,9 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { spawn } from 'node:child_process';
+import { once } from 'node:events';
 import Database from 'better-sqlite3';
-import { DatabaseManager, SQLITE_WAL_AUTOCHECKPOINT_PAGES } from '../../src/store/db.js';
+import { DatabaseManager, SQLITE_BUSY_TIMEOUT_MS, SQLITE_WAL_AUTOCHECKPOINT_PAGES } from '../../src/store/db.js';
 import { AtomicLockCoordinator } from '../../src/store/atomic-lock-coordinator.js';
 
 describe('DatabaseManager', () => {
@@ -89,6 +90,30 @@ describe('DatabaseManager', () => {
       const db1 = dbManager.getDb();
       const db2 = dbManager.getDb();
       assert.strictEqual(db1, db2);
+    });
+
+    it('waits for a concurrent writer instead of failing immediately', async () => {
+      const db = dbManager.getDb();
+      const child = spawn(process.execPath, [
+        '-e',
+        `const Database = require('better-sqlite3');
+         const db = new Database(process.argv[1]);
+         db.exec('BEGIN IMMEDIATE');
+         process.stdout.write('locked');
+         setTimeout(() => { db.exec('COMMIT'); db.close(); }, 100);`,
+        path.join(tmpDir, 'sessions.db'),
+      ], { stdio: ['ignore', 'pipe', 'inherit'] });
+
+      const childExit = once(child, 'exit');
+      await once(child.stdout!, 'data');
+      db.prepare(`
+        INSERT INTO extension_metadata (key, value)
+        VALUES ('concurrent-writer', 'waited')
+      `).run();
+      await childExit;
+
+      const timeout = db.prepare('PRAGMA busy_timeout').get() as { timeout: number };
+      assert.strictEqual(timeout.timeout, SQLITE_BUSY_TIMEOUT_MS);
     });
 
     it('should create parent directory if it does not exist', () => {


### PR DESCRIPTION
## Summary

- configure a 5-second SQLite `busy_timeout` before WAL and schema setup
- add a regression test with a second process holding the write lock

## Why

Every Pi process opens the same `sessions.db`. Live session indexing, startup backfill, and memory synchronization can therefore overlap across processes. WAL permits concurrent readers but still has a single writer, and Bun SQLite defaults `busy_timeout` to `0`, so the losing writer immediately reports:

```
⚠️ Live session indexing failed: database is locked
```

The timeout is connection-local and applies to both the Bun compatibility path and `better-sqlite3`, allowing short write transactions to serialize instead of dropping the indexing attempt.

## Validation

- `npm run check` on Node 24
- `npm test` — all 38 test files passed
- manual Bun 1.3.13 contention check — a write waited for a separate SQLite writer and completed successfully
