### PR TITLE
fix: recover better-sqlite3 ABI mismatches for brew Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,23 @@ Or test locally without installing:
 pi -e /path/to/pi-hermes-memory/src/index.ts
 ```
 
+### Homebrew / Node ABI mismatches
+
+`better-sqlite3` is a native addon. If Pi is installed via Homebrew and the extension was compiled for a different Node ABI, session search may warn:
+
+```text
+was compiled against a different Node.js version using NODE_MODULE_VERSION ...
+```
+
+The extension attempts one automatic `npm rebuild better-sqlite3` against the Node that is running Pi. If that still fails:
+
+```bash
+cd ~/.pi/agent/npm/node_modules/better-sqlite3
+npm rebuild better-sqlite3
+```
+
+Or install Pi with npm so the host runtime and extension install share one Node toolchain.
+
 ## Two-Tier Memory Architecture
 
 The extension stores memory at two levels:

--- a/src/extension-root-migration.ts
+++ b/src/extension-root-migration.ts
@@ -2,10 +2,27 @@ import fs from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
-import Database from "better-sqlite3";
 import { AtomicLockCoordinator, type AtomicLockLease } from "./store/atomic-lock-coordinator.js";
 import { canonicalStoragePathSync } from "./store/canonical-storage-path.js";
+import { loadBetterSqlite3 } from "./store/sqlite-native.js";
 
+type MigrationDatabase = {
+  exec: (sql: string) => void;
+  prepare: (sql: string) => { get: (...args: unknown[]) => unknown; run: (...args: unknown[]) => unknown };
+  close: () => void;
+  pragma: (query: string, options?: { simple?: boolean }) => unknown;
+  backup: (
+    destination: string,
+    options?: { progress?: () => void },
+  ) => Promise<void> | void;
+};
+
+type MigrationDatabaseCtor = new (
+  dbPath: string,
+  options?: { readonly?: boolean; fileMustExist?: boolean; timeout?: number },
+) => MigrationDatabase;
+
+const Database = loadBetterSqlite3() as MigrationDatabaseCtor;
 const DATABASE_FILES = ["sessions.db", "sessions.db-wal", "sessions.db-shm"] as const;
 const DATABASE_MIGRATION_PENDING_FILE = ".sessions-db-migration-pending";
 

--- a/src/store/atomic-lock-coordinator.ts
+++ b/src/store/atomic-lock-coordinator.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { createRequire } from 'node:module';
 import { spawnSync } from 'node:child_process';
+import { loadBetterSqlite3 } from './sqlite-native.js';
 
 type StatementLike = {
   run: (...args: unknown[]) => unknown;
@@ -39,8 +40,7 @@ function loadDatabaseCtor(): DatabaseCtor {
     const bunSqlite = require('bun:sqlite') as { Database: DatabaseCtor };
     return bunSqlite.Database;
   }
-  const mod = require('better-sqlite3') as { default?: DatabaseCtor } | DatabaseCtor;
-  return (mod as { default?: DatabaseCtor }).default ?? (mod as DatabaseCtor);
+  return loadBetterSqlite3({ requireImpl: require }) as DatabaseCtor;
 }
 
 const Database = loadDatabaseCtor();

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -4,6 +4,7 @@ import { createRequire } from 'node:module';
 import { SCHEMA_SQL } from './schema.js';
 import { AtomicLockCoordinator } from './atomic-lock-coordinator.js';
 import { canonicalStoragePathSync } from './canonical-storage-path.js';
+import { loadBetterSqlite3 } from './sqlite-native.js';
 
 type StatementLike = {
   run: (...args: any[]) => any;
@@ -127,12 +128,7 @@ function loadDatabaseCtor(): DatabaseCtor {
     return createBunCompatDatabaseCtor(require);
   }
 
-  try {
-    const mod = require('better-sqlite3') as { default?: DatabaseCtor } | DatabaseCtor;
-    return (mod as { default?: DatabaseCtor }).default ?? (mod as DatabaseCtor);
-  } catch (err) {
-    throw err;
-  }
+  return loadBetterSqlite3({ requireImpl: require }) as DatabaseCtor;
 }
 
 const Database = loadDatabaseCtor();

--- a/src/store/sqlite-native.ts
+++ b/src/store/sqlite-native.ts
@@ -1,0 +1,229 @@
+/**
+ * Shared better-sqlite3 loader with ABI mismatch recovery.
+ *
+ * Pi installs extension deps under ~/.pi/agent/npm. When the host Node that
+ * runs Pi (e.g. Homebrew) differs from the Node that compiled better-sqlite3,
+ * require() throws NODE_MODULE_VERSION errors. Detect that, attempt one
+ * npm rebuild against the current runtime, and surface a clear recovery path.
+ */
+
+import { createRequire } from "node:module";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+export type BetterSqlite3DatabaseCtor = new (
+  dbPath: string,
+  options?: { readonly?: boolean; fileMustExist?: boolean; timeout?: number },
+) => unknown;
+
+export interface SqliteNativeLoadOptions {
+  /** Override createRequire base URL (tests). */
+  requireFrom?: string | URL;
+  /** Inject require() for tests. */
+  requireImpl?: NodeRequire;
+  /** Inject rebuild runner for tests. */
+  rebuild?: (packageRoot: string) => { ok: boolean; detail: string };
+  /** Force treating the first load failure as rebuild-eligible (tests). */
+  allowRebuild?: boolean;
+}
+
+export class BetterSqlite3LoadError extends Error {
+  readonly code = "BETTER_SQLITE3_LOAD_FAILED";
+  readonly packageRoot: string | null;
+  readonly causeError: unknown;
+
+  constructor(message: string, options: { packageRoot?: string | null; cause?: unknown } = {}) {
+    super(message);
+    this.name = "BetterSqlite3LoadError";
+    this.packageRoot = options.packageRoot ?? null;
+    this.causeError = options.cause;
+  }
+}
+
+const ABI_MISMATCH_RE =
+  /NODE_MODULE_VERSION|was compiled against a different Node\.js version|ERR_DLOPEN_FAILED/i;
+
+export function isNativeModuleAbiMismatch(error: unknown): boolean {
+  if (!error) return false;
+  const message = error instanceof Error ? error.message : String(error);
+  if (ABI_MISMATCH_RE.test(message)) return true;
+  if (typeof error === "object" && error !== null) {
+    const code = "code" in error ? String((error as { code?: unknown }).code ?? "") : "";
+    if (code === "ERR_DLOPEN_FAILED") return true;
+  }
+  return false;
+}
+
+export function resolveBetterSqlite3PackageRoot(requireImpl: NodeRequire): string | null {
+  try {
+    const entry = requireImpl.resolve("better-sqlite3");
+    let dir = path.dirname(entry);
+    while (true) {
+      const pkgPath = path.join(dir, "package.json");
+      if (fs.existsSync(pkgPath)) {
+        try {
+          const raw = fs.readFileSync(pkgPath, "utf-8");
+          const pkg = JSON.parse(raw) as { name?: unknown };
+          if (pkg && typeof pkg === "object" && pkg.name === "better-sqlite3") return dir;
+        } catch {
+          // keep walking
+        }
+      }
+      const parent = path.dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+
+    // Classic layout fallback: .../node_modules/better-sqlite3/<...>
+    const parts = entry.split(path.sep);
+    const idx = parts.lastIndexOf("better-sqlite3");
+    if (idx >= 0) {
+      return parts.slice(0, idx + 1).join(path.sep) || null;
+    }
+    return path.dirname(entry);
+  } catch {
+    return null;
+  }
+}
+function defaultRebuild(packageRoot: string): { ok: boolean; detail: string } {
+  const npmExecPath = typeof process.env.npm_execpath === "string" && process.env.npm_execpath
+    ? process.env.npm_execpath
+    : null;
+
+  const attempts: Array<{ command: string; args: string[]; shell?: boolean }> = [];
+  if (npmExecPath) {
+    attempts.push({ command: process.execPath, args: [npmExecPath, "rebuild", "better-sqlite3"] });
+  }
+  attempts.push({ command: "npm", args: ["rebuild", "better-sqlite3"] });
+
+  const details: string[] = [];
+  for (const attempt of attempts) {
+    const result = spawnSync(attempt.command, attempt.args, {
+      cwd: packageRoot,
+      encoding: "utf-8",
+      env: process.env,
+      timeout: 120_000,
+      shell: attempt.shell ?? false,
+    });
+    if (result.error) {
+      details.push(`${attempt.command}: ${result.error.message}`);
+      continue;
+    }
+    if (result.status === 0) {
+      return { ok: true, detail: (result.stdout || result.stderr || "rebuild ok").trim() };
+    }
+    const output = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+    details.push(`${attempt.command} exited ${result.status}${output ? `: ${output}` : ""}`);
+  }
+
+  return { ok: false, detail: details.join(" | ") || "rebuild failed" };
+}
+
+function unwrapModule(mod: { default?: BetterSqlite3DatabaseCtor } | BetterSqlite3DatabaseCtor): BetterSqlite3DatabaseCtor {
+  return (mod as { default?: BetterSqlite3DatabaseCtor }).default ?? (mod as BetterSqlite3DatabaseCtor);
+}
+
+function clearBetterSqlite3RequireCache(requireImpl: NodeRequire, packageRoot: string | null): void {
+  for (const key of Object.keys(requireImpl.cache)) {
+    if (!key.includes(`${path.sep}better-sqlite3${path.sep}`) && !key.endsWith(`${path.sep}better-sqlite3`)) {
+      continue;
+    }
+    if (packageRoot && !key.startsWith(packageRoot)) continue;
+    delete requireImpl.cache[key];
+  }
+}
+
+export function formatBetterSqlite3AbiError(options: {
+  originalError: unknown;
+  packageRoot: string | null;
+  rebuildAttempted: boolean;
+  rebuildDetail?: string;
+}): string {
+  const original = options.originalError instanceof Error
+    ? options.originalError.message
+    : String(options.originalError);
+  const runtime = `Node ${process.version} (NODE_MODULE_VERSION ${process.versions.modules}) via ${process.execPath}`;
+  const location = options.packageRoot ?? "(better-sqlite3 package root unknown)";
+  const rebuildLine = options.rebuildAttempted
+    ? (options.rebuildDetail
+      ? `Automatic rebuild was attempted and failed: ${options.rebuildDetail}`
+      : "Automatic rebuild was attempted and failed.")
+    : "Automatic rebuild was not attempted.";
+
+  return [
+    "pi-hermes-memory could not load the native better-sqlite3 module for this Node runtime.",
+    `Runtime: ${runtime}`,
+    `Module: ${location}`,
+    `Original error: ${original}`,
+    rebuildLine,
+    "Fix: rebuild the extension install against the same Node that runs Pi, then restart Pi:",
+    options.packageRoot
+      ? `  cd "${options.packageRoot}" && npm rebuild better-sqlite3`
+      : "  cd ~/.pi/agent/npm && npm rebuild better-sqlite3",
+    "If you installed Pi with Homebrew, either rebuild as above after brew Node upgrades, or install Pi with npm so the extension and host share one Node toolchain.",
+  ].join("\n");
+}
+
+/**
+ * Load better-sqlite3, attempting one rebuild on ABI/dlopen mismatch.
+ */
+export function loadBetterSqlite3(options: SqliteNativeLoadOptions = {}): BetterSqlite3DatabaseCtor {
+  const requireImpl = options.requireImpl
+    ?? createRequire(options.requireFrom ?? import.meta.url);
+
+  const loadOnce = (): BetterSqlite3DatabaseCtor => {
+    const mod = requireImpl("better-sqlite3") as { default?: BetterSqlite3DatabaseCtor } | BetterSqlite3DatabaseCtor;
+    return unwrapModule(mod);
+  };
+
+  try {
+    return loadOnce();
+  } catch (firstError) {
+    const packageRoot = resolveBetterSqlite3PackageRoot(requireImpl);
+    const canRebuild = options.allowRebuild ?? isNativeModuleAbiMismatch(firstError);
+    if (!canRebuild || !packageRoot) {
+      if (isNativeModuleAbiMismatch(firstError)) {
+        throw new BetterSqlite3LoadError(
+          formatBetterSqlite3AbiError({
+            originalError: firstError,
+            packageRoot,
+            rebuildAttempted: false,
+          }),
+          { packageRoot, cause: firstError },
+        );
+      }
+      throw firstError;
+    }
+
+    const rebuild = options.rebuild ?? defaultRebuild;
+    const rebuildResult = rebuild(packageRoot);
+    clearBetterSqlite3RequireCache(requireImpl, packageRoot);
+
+    if (rebuildResult.ok) {
+      try {
+        return loadOnce();
+      } catch (secondError) {
+        throw new BetterSqlite3LoadError(
+          formatBetterSqlite3AbiError({
+            originalError: secondError,
+            packageRoot,
+            rebuildAttempted: true,
+            rebuildDetail: rebuildResult.detail,
+          }),
+          { packageRoot, cause: secondError },
+        );
+      }
+    }
+
+    throw new BetterSqlite3LoadError(
+      formatBetterSqlite3AbiError({
+        originalError: firstError,
+        packageRoot,
+        rebuildAttempted: true,
+        rebuildDetail: rebuildResult.detail,
+      }),
+      { packageRoot, cause: firstError },
+    );
+  }
+}

--- a/tests/store/sqlite-native.test.ts
+++ b/tests/store/sqlite-native.test.ts
@@ -1,0 +1,164 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import path from "node:path";
+import {
+  BetterSqlite3LoadError,
+  formatBetterSqlite3AbiError,
+  isNativeModuleAbiMismatch,
+  loadBetterSqlite3,
+  resolveBetterSqlite3PackageRoot,
+} from "../../src/store/sqlite-native.js";
+
+const require = createRequire(import.meta.url);
+
+type RequireCache = Record<string, unknown>;
+
+function fakeRequire(
+  impl: (id: string) => unknown,
+  resolveImpl: (id: string) => string,
+): NodeRequire {
+  return Object.assign(impl, {
+    resolve: resolveImpl,
+    cache: {} as RequireCache,
+  }) as NodeRequire;
+}
+
+describe("sqlite-native loader", () => {
+  it("detects NODE_MODULE_VERSION ABI mismatch errors", () => {
+    assert.equal(
+      isNativeModuleAbiMismatch(
+        new Error(
+          "The module '/tmp/better_sqlite3.node' was compiled against a different Node.js version using NODE_MODULE_VERSION 115",
+        ),
+      ),
+      true,
+    );
+    assert.equal(isNativeModuleAbiMismatch(new Error("SQLITE_BUSY")), false);
+  });
+
+  it("detects ERR_DLOPEN_FAILED codes", () => {
+    const err = Object.assign(new Error("dlopen failed"), { code: "ERR_DLOPEN_FAILED" });
+    assert.equal(isNativeModuleAbiMismatch(err), true);
+  });
+
+  it("resolves the installed better-sqlite3 package root", () => {
+    const root = resolveBetterSqlite3PackageRoot(require);
+    assert.ok(root);
+    assert.equal(path.basename(root!), "better-sqlite3");
+  });
+
+  it("loads better-sqlite3 successfully in the current runtime", () => {
+    const Database = loadBetterSqlite3({ requireImpl: require, allowRebuild: false });
+    const db = new (Database as new (path: string) => {
+      exec: (sql: string) => void;
+      close: () => void;
+    })(":memory:");
+    db.exec("SELECT 1");
+    db.close();
+  });
+
+  it("rebuilds once on ABI mismatch then succeeds", () => {
+    let calls = 0;
+    const ctor = class FakeDb {
+      constructor(_path: string) {}
+    };
+    const req = fakeRequire(
+      (id: string) => {
+        assert.equal(id, "better-sqlite3");
+        calls += 1;
+        if (calls === 1) {
+          throw new Error(
+            "was compiled against a different Node.js version using NODE_MODULE_VERSION 115. Please try re-compiling",
+          );
+        }
+        return ctor;
+      },
+      (id: string) => {
+        assert.equal(id, "better-sqlite3");
+        return path.join("/tmp/fake-npm/node_modules/better-sqlite3/lib/index.js");
+      },
+    );
+
+    let rebuilt = false;
+    const Database = loadBetterSqlite3({
+      requireImpl: req,
+      rebuild: (packageRoot) => {
+        rebuilt = true;
+        assert.equal(packageRoot, "/tmp/fake-npm/node_modules/better-sqlite3");
+        return { ok: true, detail: "rebuilt" };
+      },
+    });
+
+    assert.equal(Database, ctor);
+    assert.equal(rebuilt, true);
+    assert.equal(calls, 2);
+  });
+
+  it("throws BetterSqlite3LoadError with recovery guidance when rebuild fails", () => {
+    const req = fakeRequire(
+      (_id: string) => {
+        throw new Error(
+          "The module 'x.node' was compiled against a different Node.js version using NODE_MODULE_VERSION 108",
+        );
+      },
+      () => path.join("/tmp/fake-npm/node_modules/better-sqlite3/lib/index.js"),
+    );
+
+    assert.throws(
+      () =>
+        loadBetterSqlite3({
+          requireImpl: req,
+          rebuild: () => ({ ok: false, detail: "npm missing" }),
+        }),
+      (error: unknown) => {
+        assert.ok(error instanceof BetterSqlite3LoadError);
+        const message = error.message;
+        assert.match(message, /pi-hermes-memory could not load the native better-sqlite3 module/);
+        assert.match(message, /npm rebuild better-sqlite3/);
+        assert.match(message, /Homebrew/);
+        assert.match(message, /npm missing/);
+        assert.equal(error.packageRoot, "/tmp/fake-npm/node_modules/better-sqlite3");
+        return true;
+      },
+    );
+  });
+
+  it("formats actionable ABI recovery text", () => {
+    const message = formatBetterSqlite3AbiError({
+      originalError: new Error("NODE_MODULE_VERSION 115"),
+      packageRoot: "/Users/me/.pi/agent/npm/node_modules/better-sqlite3",
+      rebuildAttempted: true,
+      rebuildDetail: "exit 1",
+    });
+    assert.match(message, /NODE_MODULE_VERSION/);
+    assert.match(message, /\/Users\/me\/\.pi\/agent\/npm\/node_modules\/better-sqlite3/);
+    assert.match(message, /npm rebuild better-sqlite3/);
+    assert.match(message, /Homebrew/);
+  });
+
+  it("does not rebuild for non-ABI load failures", () => {
+    let rebuilt = false;
+    const req = fakeRequire(
+      () => {
+        throw new Error("Cannot find module 'better-sqlite3'");
+      },
+      () => {
+        throw new Error("not found");
+      },
+    );
+
+    assert.throws(
+      () =>
+        loadBetterSqlite3({
+          requireImpl: req,
+          rebuild: () => {
+            rebuilt = true;
+            return { ok: true, detail: "should not run" };
+          },
+        }),
+      /Cannot find module 'better-sqlite3'/,
+    );
+    assert.equal(rebuilt, false);
+  });
+});


### PR DESCRIPTION
## Summary
- Detect `better-sqlite3` native ABI / `ERR_DLOPEN_FAILED` load failures (the Homebrew Pi + extension install mismatch from #111).
- Attempt **one** automatic `npm rebuild better-sqlite3` against the Node that is currently running Pi.
- If rebuild still fails, throw a clear `BetterSqlite3LoadError` with runtime path, package root, and exact recovery commands.
- Route all production loaders through the shared helper: `db.ts`, `atomic-lock-coordinator.ts`, `extension-root-migration.ts`.
- Document the brew/ABI recovery path in the README install section.

## Why
```
was compiled against a different Node.js version using NODE_MODULE_VERSION 147
```
This is not fixed by “upgrading node modules.” Extension deps land under `~/.pi/agent/npm`, and brew Pi can run a different Node than the one that compiled the addon. npm-installed Pi works because host and install share one toolchain.

## Issues
- Closes #111

## Test plan
- [x] `npx tsx --test tests/store/sqlite-native.test.ts` (8/8)
- [x] `npx tsx --test tests/store/db.test.ts tests/store/atomic-lock-coordinator.test.ts tests/extension-root-migration.test.ts` (all pass)
- [x] `npm run check`
- [ ] CI green on this PR