### PR TITLE
fix: stabilize skill_manage patch content formats

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -70,7 +70,7 @@ If memory conflicts with current evidence, prefer current evidence and mention t
 Procedural skills:
 - Use the skill_manage tool during normal work when a task reveals a reusable how-to workflow, or when the user asks you to remember how to do something later.
 - Always pass scope explicitly on create: scope="global" for portable procedures, scope="project" for workflows tied to this repo's paths, scripts, architecture, deploy steps, or conventions.
-- Prefer structured fields for create/update: when_to_use, procedure_steps, pitfalls, verification_steps. Use patch to improve a specific section of an existing skill, update for a full rewrite, and view to inspect existing skills before changing them.
+- Prefer structured fields for create/update/patch: when_to_use, procedure_steps, pitfalls, verification_steps. Use patch with the matching structured field for one section, update for a full rewrite, and view before changing an existing skill.
 - Do not create skills for one-off task state, generic summaries, or overly file-specific notes that will create noisy future matches.
 
 Do not use memory_search for generic questions, one-off examples, or explanations where durable memory would not help.
@@ -92,7 +92,7 @@ Memory write targets: user for preferences/profile; memory for global notes and 
 
 memory_search filters: target searches user/global/failure memories; project filters project-scoped memories; category filters categorized failure/lesson memories only.
 
-Use the skill_manage tool during normal work for reusable procedures. On create, scope is required: global for transferable workflows, project for repo-specific ones. Prefer structured fields for create/update, patch for focused changes, and update for full rewrites. Skip one-off or overly narrow skills.
+Use the skill_manage tool during normal work for reusable procedures. On create, scope is required: global for transferable workflows, project for repo-specific ones. Prefer structured fields for create/update/patch, patch for one section, and update for full rewrites. Skip one-off or overly narrow skills.
 
 Use category only for categorized failure/lesson searches. Do not use memory_search for generic questions, one-off examples, or explanations where durable memory would not help.
 
@@ -315,20 +315,21 @@ SCOPE:
 - 'global': transferable procedures that can be reused across repositories
 - 'project': procedures tied to this repo's paths, scripts, architecture, deploy flow, or conventions
 
-WHEN TO UPDATE A SKILL (use 'patch'):
-- You discover a better approach for an existing skill
-- A pitfall or edge case not covered by the skill
-- A step in the procedure changed
+WHEN TO UPDATE A SKILL:
+- Prefer 'patch' for one section when you can pass structured fields
+- Prefer 'update' for multi-section rewrites or when patch formatting would be unstable
+- Use patch when you discover a better approach, pitfall, or changed step in one section
 
 SKILL FORMAT:
 - name: short, descriptive (e.g., "debug-typescript-errors")
 - description: one-line summary of when to use it
 - body: structured with sections — ## When to Use, ## Procedure, ## Pitfalls, ## Verification
-- Prefer structured create/update fields over raw markdown when possible:
+- Prefer structured fields over raw markdown when possible:
   - when_to_use: trigger conditions and boundaries
   - procedure_steps: ordered concrete steps
   - pitfalls: caveats or failure modes
   - verification_steps: checks that prove success
+- For patch, pass section plus the matching structured field (section="Procedure" + procedure_steps, etc.). Do not pass JSON array/object strings as content.
 
 ONE-SHOT EXAMPLE:
 {

--- a/src/store/skill-store.ts
+++ b/src/store/skill-store.ts
@@ -46,6 +46,111 @@ export interface LegacySkillMigrationResult {
   warnings: string[];
 }
 
+const LIST_SECTIONS = new Set(["procedure", "pitfalls", "verification"]);
+
+function normalizeSectionName(section: string): string {
+  return section.replace(/^#+\s*/, "").trim();
+}
+
+function isExactSectionHeader(line: string, section: string): boolean {
+  const heading = line.trim().match(/^##\s+(.+?)\s*$/);
+  if (!heading) return false;
+  return heading[1].trim().toLowerCase() === section.trim().toLowerCase();
+}
+
+function looksLikeJsonArray(content: string): boolean {
+  const trimmed = content.trim();
+  return trimmed.startsWith("[") && trimmed.endsWith("]");
+}
+
+function looksLikeJsonObject(content: string): boolean {
+  const trimmed = content.trim();
+  return trimmed.startsWith("{") && trimmed.endsWith("}");
+}
+
+function formatPatchList(section: string, items: string[]): string {
+  const cleaned = items.map((item) => item.trim()).filter(Boolean);
+  if (cleaned.length === 0) return "";
+  const key = section.trim().toLowerCase();
+  if (key === "pitfalls") {
+    return cleaned.map((item) => `- ${item.replace(/^[-*]\s+/, "")}`).join("\n");
+  }
+  // Procedure / Verification default to ordered steps.
+  return cleaned
+    .map((item, index) => `${index + 1}. ${item.replace(/^\d+\.\s+/, "").replace(/^[-*]\s+/, "")}`)
+    .join("\n");
+}
+
+/**
+ * Normalize/validate free-form patch content so LLM format drift cannot wipe
+ * or splice skill sections. Coerces JSON string arrays into Markdown lists for
+ * list-shaped sections and rejects empty / object / header-injecting payloads.
+ */
+export function normalizeSkillPatchContent(
+  section: string,
+  rawContent: string,
+): { content: string } | { error: string } {
+  const sectionName = normalizeSectionName(section);
+  if (!sectionName) {
+    return { error: "section is required for patch." };
+  }
+
+  let content = typeof rawContent === "string" ? rawContent.trim() : "";
+  if (!content) {
+    return {
+      error: "New content is required for patch. Prefer structured fields (procedure_steps, pitfalls, verification_steps, when_to_use) over free-form content.",
+    };
+  }
+
+  if (looksLikeJsonObject(content)) {
+    return {
+      error: "Patch content looks like a JSON object. Provide Markdown section body or a string array via structured fields.",
+    };
+  }
+
+  if (looksLikeJsonArray(content)) {
+    try {
+      const parsed: unknown = JSON.parse(content);
+      if (!Array.isArray(parsed)) {
+        return { error: "Patch content looks like JSON but is not a string array." };
+      }
+      const items = parsed
+        .filter((item): item is string => typeof item === "string")
+        .map((item) => item.trim())
+        .filter(Boolean);
+      if (items.length === 0) {
+        return { error: "Patch content JSON array must contain non-empty strings." };
+      }
+      const key = sectionName.toLowerCase();
+      if (key === "when to use") {
+        content = items.join("\n\n");
+      } else if (LIST_SECTIONS.has(key)) {
+        content = formatPatchList(sectionName, items);
+      } else {
+        content = items.map((item) => `- ${item}`).join("\n");
+      }
+    } catch {
+      return {
+        error: "Patch content looks like a JSON array but could not be parsed. Use Markdown or structured string[] fields.",
+      };
+    }
+  }
+
+  // Reject payloads that would inject extra ## sections mid-body.
+  if (/^#{1,6}\s+\S/m.test(content)) {
+    return {
+      error: "Patch content must not include Markdown section headers (## ...). Patch only the body of the target section.",
+    };
+  }
+
+  if (!content.trim()) {
+    return { error: "New content is required for patch." };
+  }
+
+  return { content: content.trim() };
+}
+
+
 export class SkillStore {
   private globalSkillsDir: string;
   private projectSkillsDir: string | null;
@@ -352,34 +457,47 @@ export class SkillStore {
   }
 
   async patch(skillId: string, section: string, newContent: string): Promise<SkillResult> {
-    newContent = newContent.trim();
-    if (!newContent) return { success: false, error: "New content is required for patch." };
+    const sectionName = normalizeSectionName(section);
+    if (!sectionName) return { success: false, error: "section is required for patch." };
 
-    const scanError = scanContent(newContent);
+    const normalized = normalizeSkillPatchContent(sectionName, newContent);
+    if ("error" in normalized) return { success: false, error: normalized.error };
+    const content = normalized.content;
+
+    const scanError = scanContent(content);
     if (scanError) return { success: false, error: scanError };
 
     const doc = await this.loadSkill(skillId);
     if (!doc) return { success: false, error: `Skill '${skillId}' not found.` };
 
-    const sectionHeader = `## ${section}`;
+    const sectionHeader = `## ${sectionName}`;
     const lines = doc.body.split("\n");
     let found = false;
     const result: string[] = [];
 
     for (let i = 0; i < lines.length; i++) {
-      if (lines[i].startsWith(sectionHeader)) {
+      if (isExactSectionHeader(lines[i], sectionName)) {
         result.push(sectionHeader);
-        result.push(newContent);
+        // Preserve multi-line body as discrete lines so later headers stay exact.
+        for (const bodyLine of content.split("\n")) {
+          result.push(bodyLine);
+        }
         found = true;
         i++;
-        while (i < lines.length && !lines[i].startsWith("## ")) i++;
+        while (i < lines.length && !lines[i].trim().startsWith("## ")) i++;
         if (i < lines.length) result.push(lines[i]);
       } else {
         result.push(lines[i]);
       }
     }
 
-    if (!found) result.push("", sectionHeader, newContent);
+    if (!found) {
+      if (result.length > 0 && result[result.length - 1] !== "") result.push("");
+      result.push(sectionHeader);
+      for (const bodyLine of content.split("\n")) {
+        result.push(bodyLine);
+      }
+    }
 
     await this.atomicWrite(doc.path, formatFrontmatter({
       name: doc.name,
@@ -393,7 +511,7 @@ export class SkillStore {
 
     return {
       success: true,
-      message: `Skill '${doc.displayName || doc.name}' section '${section}' updated.`,
+      message: `Skill '${doc.displayName || doc.name}' section '${sectionName}' updated.`,
       fileName: doc.fileName,
       skillId: doc.skillId,
       scope: doc.scope,

--- a/src/tools/skill-tool.ts
+++ b/src/tools/skill-tool.ts
@@ -66,22 +66,22 @@ const SKILL_TOOL_PARAMETERS = Type.Object({
     description: "Required for create. Use 'global' for portable procedures and 'project' for repo-specific workflows.",
   })),
   section: Type.Optional(Type.String({
-    description: "Required for patch. Section header to patch. e.g., 'Procedure', 'Pitfalls'.",
+    description: "Required for patch. Section header to patch. e.g., 'Procedure', 'Pitfalls', 'Verification', 'When to Use'.",
   })),
   content: Type.Optional(Type.String({
-    description: "Raw markdown body for create/update/edit, or new section content for patch. For create/update/edit you can provide this or the structured fields below.",
+    description: "Raw markdown body for create/update/edit, or Markdown section body for patch. Prefer structured fields over free-form content when possible. For patch, JSON arrays are auto-coerced for list sections; JSON objects are rejected.",
   })),
   when_to_use: Type.Optional(Type.String({
-    description: "Structured create/update/edit field. Explain when this skill should be used and where its boundaries are.",
+    description: "Structured create/update/edit field, or structured patch body when section is 'When to Use'.",
   })),
   procedure_steps: Type.Optional(Type.Array(Type.String(), {
-    description: "Structured create/update/edit field. Ordered concrete steps for the workflow.",
+    description: "Structured create/update/edit field, or structured patch body when section is 'Procedure'. Ordered concrete steps.",
   })),
   pitfalls: Type.Optional(Type.Array(Type.String(), {
-    description: "Structured create/update/edit field. Optional common mistakes, caveats, or failure modes to avoid.",
+    description: "Structured create/update/edit field, or structured patch body when section is 'Pitfalls'.",
   })),
   verification_steps: Type.Optional(Type.Array(Type.String(), {
-    description: "Structured create/update/edit field. Concrete checks that confirm the workflow succeeded.",
+    description: "Structured create/update/edit field, or structured patch body when section is 'Verification'.",
   })),
 }, { additionalProperties: false });
 
@@ -97,7 +97,9 @@ export function registerSkillTool(pi: ExtensionAPI, store: SkillStore): void {
       "Use the skill_manage tool after completing complex tasks that required trial and error or multiple tool calls.",
       "Use 'create' to save a new reusable procedure, 'patch' to update a section of an existing skill by skill_id, and 'update' for a full rewrite.",
       "Scope is required on create: choose scope='global' for transferable procedures and scope='project' when the workflow depends on this repo's paths, scripts, conventions, or deploy steps.",
-      "Prefer structured fields for create/update: when_to_use, procedure_steps, pitfalls, and verification_steps. The tool will render valid SKILL.md sections for you.",
+      "Prefer structured fields for create/update/patch: when_to_use, procedure_steps, pitfalls, and verification_steps. The tool renders valid SKILL.md sections for you.",
+      "For patch, pass section plus the matching structured field (e.g. section='Procedure' with procedure_steps). Avoid free-form content that is a JSON array/object string.",
+      "Prefer 'update' for multi-section rewrites when patch content would be large or format-unstable.",
       "Use 'view' before patching or updating when you need to inspect an existing skill.",
       "Do NOT use skills for temporary task state — only for durable, reusable procedures.",
     ],
@@ -206,7 +208,7 @@ export function registerSkillTool(pi: ExtensionAPI, store: SkillStore): void {
           result = { success: true, ...doc };
           break;
 
-        case "patch":
+        case "patch": {
           if (!skill_id) {
             return {
               content: [{ type: "text", text: JSON.stringify({ success: false, error: "skill_id is required for 'patch' action." }) }],
@@ -219,14 +221,60 @@ export function registerSkillTool(pi: ExtensionAPI, store: SkillStore): void {
               details: {},
             };
           }
-          if (!content) {
+
+          const sectionKey = section.replace(/^#+\s*/, "").trim().toLowerCase();
+          let patchContent = content?.trim() ?? "";
+
+          // Prefer structured fields matching the target section so the LLM
+          // does not have to invent Markdown list formatting.
+          if (sectionKey === "procedure" && procedureSteps.length > 0) {
+            patchContent = formatOrderedList(procedureSteps);
+          } else if (sectionKey === "pitfalls" && pitfallItems.length > 0) {
+            patchContent = formatBulletList(pitfallItems, "No notable pitfalls recorded yet.");
+          } else if (sectionKey === "verification" && verificationSteps.length > 0) {
+            patchContent = formatOrderedList(verificationSteps);
+          } else if ((sectionKey === "when to use" || sectionKey === "when_to_use") && whenToUse) {
+            patchContent = whenToUse;
+          } else if (!patchContent && hasStructuredBody) {
+            // Allow a single structured field even if section name is non-standard.
+            if (procedureSteps.length > 0 && pitfallItems.length === 0 && verificationSteps.length === 0 && !whenToUse) {
+              patchContent = formatOrderedList(procedureSteps);
+            } else if (pitfallItems.length > 0 && procedureSteps.length === 0 && verificationSteps.length === 0 && !whenToUse) {
+              patchContent = formatBulletList(pitfallItems, "No notable pitfalls recorded yet.");
+            } else if (verificationSteps.length > 0 && procedureSteps.length === 0 && pitfallItems.length === 0 && !whenToUse) {
+              patchContent = formatOrderedList(verificationSteps);
+            } else if (whenToUse && procedureSteps.length === 0 && pitfallItems.length === 0 && verificationSteps.length === 0) {
+              patchContent = whenToUse;
+            } else {
+              return {
+                content: [{
+                  type: "text",
+                  text: JSON.stringify({
+                    success: false,
+                    error: "For patch, provide content or exactly one structured field matching the target section (procedure_steps, pitfalls, verification_steps, or when_to_use). Use update for multi-section rewrites.",
+                  }),
+                }],
+                details: {},
+              };
+            }
+          }
+
+          if (!patchContent) {
             return {
-              content: [{ type: "text", text: JSON.stringify({ success: false, error: "content is required for 'patch' action." }) }],
+              content: [{
+                type: "text",
+                text: JSON.stringify({
+                  success: false,
+                  error: "content or a matching structured field is required for 'patch' action. Prefer procedure_steps/pitfalls/verification_steps/when_to_use.",
+                }),
+              }],
               details: {},
             };
           }
-          result = await store.patch(skill_id, section, content);
+
+          result = await store.patch(skill_id, section, patchContent);
           break;
+        }
 
         case "update":
         case "edit": {

--- a/tests/store/skill-store.test.ts
+++ b/tests/store/skill-store.test.ts
@@ -351,6 +351,63 @@ describe("SkillStore", { concurrency: 1 }, () => {
       assert.ok(doc!.body.includes("Run the tests"));
       assert.strictEqual(doc!.version, 2);
     });
+
+    it("coerces JSON string arrays into ordered Procedure steps", async () => {
+      const store = await makeStore();
+      const created = await store.create("test", "desc", "## Procedure\n1. Old\n\n## Pitfalls\n- Keep me");
+
+      const result = await store.patch(
+        created.skillId!,
+        "Procedure",
+        JSON.stringify(["First step", "Second step"]),
+      );
+      assert.ok(result.success, `patch failed: ${result.error}`);
+
+      const doc = await store.loadSkill(created.skillId!);
+      assert.match(doc!.body, /## Procedure\n1\. First step\n2\. Second step/);
+      assert.match(doc!.body, /## Pitfalls\n- Keep me/);
+      assert.doesNotMatch(doc!.body, /\[\"First step\"/);
+    });
+
+    it("rejects JSON object patch payloads", async () => {
+      const store = await makeStore();
+      const created = await store.create("test", "desc", "## Procedure\n1. Keep");
+
+      const result = await store.patch(created.skillId!, "Procedure", '{"steps":["a"]}');
+      assert.equal(result.success, false);
+      assert.match(result.error ?? "", /JSON object/i);
+
+      const doc = await store.loadSkill(created.skillId!);
+      assert.match(doc!.body, /1\. Keep/);
+      assert.equal(doc!.version, 1);
+    });
+
+    it("rejects empty patch content", async () => {
+      const store = await makeStore();
+      const created = await store.create("test", "desc", "## Procedure\n1. Keep");
+
+      const result = await store.patch(created.skillId!, "Procedure", "   ");
+      assert.equal(result.success, false);
+      assert.match(result.error ?? "", /required for patch/i);
+      assert.equal((await store.loadSkill(created.skillId!))!.version, 1);
+    });
+
+    it("rejects patch content that injects section headers", async () => {
+      const store = await makeStore();
+      const created = await store.create("test", "desc", "## Procedure\n1. Keep\n\n## Pitfalls\n- Keep");
+
+      const result = await store.patch(
+        created.skillId!,
+        "Procedure",
+        "1. New\n\n## Pitfalls\n- Injected duplicate",
+      );
+      assert.equal(result.success, false);
+      assert.match(result.error ?? "", /section headers/i);
+
+      const doc = await store.loadSkill(created.skillId!);
+      assert.equal(doc!.version, 1);
+      assert.equal(doc!.body.match(/## Pitfalls/g)?.length, 1);
+    });
   });
 
   describe("edit()", () => {

--- a/tests/tools/skill-tool.test.ts
+++ b/tests/tools/skill-tool.test.ts
@@ -235,7 +235,7 @@ describe("registerSkillTool", () => {
     await cleanup();
   });
 
-  it("patch requires skill_id, section, content", async () => {
+  it("patch requires skill_id, section, and content or structured fields", async () => {
     let captured: any;
     const mockPi = {
       registerTool: (def: any) => { captured = def; },
@@ -252,6 +252,91 @@ describe("registerSkillTool", () => {
 
     result = await captured.execute("tc-1", { action: "patch", skill_id: "global:test", section: "Procedure" }, undefined, undefined, undefined);
     assert.strictEqual(JSON.parse(result.content[0].text).success, false);
+
+    await cleanup();
+  });
+
+  it("patch accepts structured procedure_steps for a section update", async () => {
+    let captured: any;
+    const mockPi = {
+      registerTool: (def: any) => { captured = def; },
+    } as any;
+
+    const store = await makeStore();
+    const created = await store.create(
+      "patch-me",
+      "desc",
+      "## Procedure\n1. Old way\n\n## Pitfalls\n- Keep me\n\n## Verification\n1. Still works",
+    );
+    registerSkillTool(mockPi, store);
+
+    const result = await captured.execute("tc-1", {
+      action: "patch",
+      skill_id: created.skillId,
+      section: "Procedure",
+      procedure_steps: ["Do the new first step", "Do the new second step"],
+    }, undefined, undefined, undefined);
+
+    const parsed = JSON.parse(result.content[0].text);
+    assert.strictEqual(parsed.success, true);
+
+    const doc = await store.loadSkill(created.skillId!);
+    assert.match(doc!.body, /## Procedure\n1\. Do the new first step\n2\. Do the new second step/);
+    assert.match(doc!.body, /## Pitfalls\n- Keep me/);
+    assert.match(doc!.body, /## Verification\n1\. Still works/);
+    assert.doesNotMatch(doc!.body, /Old way/);
+
+    await cleanup();
+  });
+
+  it("patch rejects JSON object content strings", async () => {
+    let captured: any;
+    const mockPi = {
+      registerTool: (def: any) => { captured = def; },
+    } as any;
+
+    const store = await makeStore();
+    const created = await store.create("patch-me", "desc", "## Procedure\n1. Keep");
+    registerSkillTool(mockPi, store);
+
+    const result = await captured.execute("tc-1", {
+      action: "patch",
+      skill_id: created.skillId,
+      section: "Procedure",
+      content: '{"steps":["bad"]}',
+    }, undefined, undefined, undefined);
+
+    const parsed = JSON.parse(result.content[0].text);
+    assert.strictEqual(parsed.success, false);
+    assert.match(parsed.error, /JSON object/i);
+    assert.equal((await store.loadSkill(created.skillId!))!.version, 1);
+
+    await cleanup();
+  });
+
+  it("patch coerces JSON array content strings into Markdown lists", async () => {
+    let captured: any;
+    const mockPi = {
+      registerTool: (def: any) => { captured = def; },
+    } as any;
+
+    const store = await makeStore();
+    const created = await store.create("patch-me", "desc", "## Pitfalls\n- old");
+    registerSkillTool(mockPi, store);
+
+    const result = await captured.execute("tc-1", {
+      action: "patch",
+      skill_id: created.skillId,
+      section: "Pitfalls",
+      content: '["Do not skip verification", "Do not wipe other sections"]',
+    }, undefined, undefined, undefined);
+
+    const parsed = JSON.parse(result.content[0].text);
+    assert.strictEqual(parsed.success, true);
+
+    const doc = await store.loadSkill(created.skillId!);
+    assert.match(doc!.body, /## Pitfalls\n- Do not skip verification\n- Do not wipe other sections/);
+    assert.doesNotMatch(doc!.body, /\[\"Do not skip verification\"/);
 
     await cleanup();
   });


### PR DESCRIPTION
## Summary
- Harden `skill_manage` `patch` so free-form LLM content cannot wipe/splice skill sections.
- Accept structured patch fields already used by create/update: `procedure_steps`, `pitfalls`, `verification_steps`, `when_to_use`.
- Coerce JSON **string arrays** into Markdown lists for list sections; reject JSON objects, empty bodies, and content that injects `##` headers.
- Match section headers exactly (case-insensitive) and keep neighboring sections intact.
- Update tool description + memory-policy prompts to prefer structured patch fields and `update` for multi-section rewrites.

## Why
Issue #107: LLM self-calls pass unstable `content` formats (`["a","b"]`, plain text, broken markdown), corrupting Procedure/Pitfalls sections (40+ real skill failures reported).

Implements the non-exclusive A+B+C approach from the issue using existing skill tool constructs (no new tools/commands).

## Issues
- Closes #107

## Test plan
- [x] `npx tsx --test tests/store/skill-store.test.ts tests/tools/skill-tool.test.ts` (53/53)
- [x] `npm run check`
- [ ] CI green on this PR