### PR TITLE
chore: release v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2026-07-21
+
+### Fixed
+
+- **Silent memory data loss after external `MEMORY.md` edits** ([#112](https://github.com/chandra447/pi-hermes-memory/issues/112), [#113](https://github.com/chandra447/pi-hermes-memory/pull/113)): manual truncate/`cp` races could return `success: true` with stale usage while the live Markdown file was empty and the SQLite search mirror was wiped. Mutations now treat disk as source of truth, refresh usage/entry counts from disk, retry post-publish fingerprint mismatches, and always reconcile SQLite via the existing mutation observer (including failed writes). Exhausted external-write conflicts point at `/memory-sync-markdown`.
+- **Immediate `database is locked` under concurrent Pi writers** ([#110](https://github.com/chandra447/pi-hermes-memory/pull/110), [#113](https://github.com/chandra447/pi-hermes-memory/pull/113)): `DatabaseManager` now sets `PRAGMA busy_timeout = 5000` so short overlapping writers serialize instead of failing immediately.
+- **Homebrew Pi `better-sqlite3` ABI mismatch** ([#111](https://github.com/chandra447/pi-hermes-memory/issues/111), [#114](https://github.com/chandra447/pi-hermes-memory/pull/114)): when the native addon was compiled for a different Node ABI than the runtime hosting Pi, load failures are detected, one automatic `npm rebuild better-sqlite3` is attempted against the current Node, and remaining failures return a clear recovery path (including brew/npm guidance).
+- **`skill_manage` patch content format corruption** ([#107](https://github.com/chandra447/pi-hermes-memory/issues/107), [#115](https://github.com/chandra447/pi-hermes-memory/pull/115)): free-form LLM patch payloads (JSON arrays/objects, empty bodies, injected `##` headers) could wipe or splice skill sections. Patch now accepts structured section fields (`procedure_steps` / `pitfalls` / `verification_steps` / `when_to_use`), coerces JSON string arrays into Markdown lists, and rejects unsafe payloads. Prompts steer structured patch and prefer `update` for multi-section rewrites.
+
 ## [0.8.1] - 2026-07-14
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hermes-memory",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-tui": "^0.80.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "🧠 Persistent memory + 🔍 session search + 🛡️ secret scanning for Pi. Token-aware policy-only memory by default, SQLite FTS5 search, auto-consolidation, procedural skills. 693 tests. Ported from Hermes agent.",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary
- Bump package version **0.8.1 → 0.8.2**
- Changelog entries for:
  - #112 / #113 disk-authoritative memory mutations + SQLite busy_timeout (#110)
  - #111 / #114 better-sqlite3 ABI recovery for brew Pi
  - #107 / #115 skill_manage patch content hardening

## Publish plan
1. Merge this PR
2. `npm publish` from clean `main` at 0.8.2
3. Create GitHub release `v0.8.2` after npm publish succeeds

## Test plan
- [x] version fields in `package.json` + `package-lock.json` are `0.8.2`
- [ ] CI green