### PR TITLE
fix: retry natural-language queries when raw FTS5 parse fails

### DIFF
--- a/src/store/fts-query.ts
+++ b/src/store/fts-query.ts
@@ -63,6 +63,37 @@ export function buildFallbackFts5Query(query: string): string | null {
     .join(' OR ');
 }
 
+function quoteTerms(terms: string[], separator: string): string {
+  return terms.map((term) => `"${term.replace(/"/g, '""')}"`).join(separator);
+}
+
+/**
+ * Normalize a query as natural language even when it contains uppercase
+ * operator words. Queries like "DO NOT USE FIND /" are passed through as raw
+ * FTS5 syntax by normalizeFts5Query; when that raw form fails to parse, this
+ * produces the quoted-term form to retry with.
+ */
+export function normalizeNaturalLanguageFts5Query(query: string): string {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) return '';
+
+  return quoteTerms(collectNaturalLanguageTerms(trimmed), ' ');
+}
+
+/**
+ * Build the broader OR fallback for the same recovery path, ignoring
+ * operator detection.
+ */
+export function buildNaturalLanguageFallbackQuery(query: string): string | null {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) return null;
+
+  const terms = collectNaturalLanguageTerms(trimmed);
+  if (terms.length <= 1) return null;
+
+  return quoteTerms(terms, ' OR ');
+}
+
 export function isFts5QueryError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   const msg = err.message.toLowerCase();

--- a/src/store/session-search.ts
+++ b/src/store/session-search.ts
@@ -1,5 +1,12 @@
 import { DatabaseManager } from './db.js';
-import { buildFallbackFts5Query, hasExplicitFts5Operator, isFts5QueryError, normalizeFts5Query } from './fts-query.js';
+import {
+  buildFallbackFts5Query,
+  buildNaturalLanguageFallbackQuery,
+  hasExplicitFts5Operator,
+  isFts5QueryError,
+  normalizeFts5Query,
+  normalizeNaturalLanguageFts5Query,
+} from './fts-query.js';
 
 /**
  * Search result from session history.
@@ -93,6 +100,8 @@ export function searchSessions(
   const db = dbManager.getDb();
   const { limit = 10, project, role, since } = options;
 
+  let ftsParseError = false;
+
   const executeSearch = (match: SearchMatch): SessionSearchResult[] => {
     const conditions: string[] = [];
     const params: unknown[] = [];
@@ -160,6 +169,7 @@ export function searchSessions(
       return mapRows(rows);
     } catch (err) {
       if (match.type === 'fts' && isFts5QueryError(err)) {
+        ftsParseError = true;
         return [];
       }
       throw err;
@@ -178,7 +188,28 @@ export function searchSessions(
 
   const explicitOperatorQuery = hasExplicitFts5Operator(query);
   if (explicitOperatorQuery) {
-    return exactResults;
+    // Same recovery as searchMemories: only when the raw operator query fails
+    // to parse do we retry it as natural language; valid operator queries that
+    // match nothing keep their exact semantics.
+    if (!ftsParseError) {
+      return exactResults;
+    }
+    const nlQuery = normalizeNaturalLanguageFts5Query(query);
+    if (nlQuery.length > 0 && nlQuery !== normalizedQuery) {
+      const nlResults = executeSearch({ type: 'fts', query: nlQuery });
+      if (nlResults.length > 0) {
+        return nlResults;
+      }
+      const nlFallback = buildNaturalLanguageFallbackQuery(query);
+      if (nlFallback && nlFallback !== nlQuery) {
+        const nlFallbackResults = executeSearch({ type: 'fts', query: nlFallback });
+        if (nlFallbackResults.length > 0) {
+          return nlFallbackResults;
+        }
+      }
+    }
+    const likeTerms = collectLikeTerms(query);
+    return executeSearch({ type: 'like', terms: likeTerms });
   }
 
   const fallbackQuery = buildFallbackFts5Query(query);

--- a/src/store/sqlite-memory-store.ts
+++ b/src/store/sqlite-memory-store.ts
@@ -1,5 +1,11 @@
 import { DatabaseManager } from './db.js';
-import { buildFallbackFts5Query, isFts5QueryError, normalizeFts5Query } from './fts-query.js';
+import {
+  buildFallbackFts5Query,
+  buildNaturalLanguageFallbackQuery,
+  isFts5QueryError,
+  normalizeFts5Query,
+  normalizeNaturalLanguageFts5Query,
+} from './fts-query.js';
 import { normalizeMemoryLookupText } from './memory-lookup.js';
 import type { MemoryCategory } from '../types.js';
 
@@ -697,6 +703,8 @@ export function searchMemories(
     return [];
   }
 
+  let ftsParseError = false;
+
   const runSearch = (matchQuery: string): SqliteMemoryEntry[] => {
     const conditions: string[] = [];
     const params: unknown[] = [];
@@ -750,6 +758,7 @@ export function searchMemories(
       return rows.map(mapRow);
     } catch (err) {
       if (isFts5QueryError(err)) {
+        ftsParseError = true;
         return [];
       }
       throw err;
@@ -759,6 +768,26 @@ export function searchMemories(
   const exactResults = runSearch(normalizedQuery);
   if (exactResults.length > 0) {
     return exactResults;
+  }
+
+  // A query with uppercase operator words (e.g. "DO NOT USE FIND /") passes
+  // through as raw FTS5 syntax; when that fails to parse, retry it as natural
+  // language instead of silently returning nothing. Valid operator queries
+  // that legitimately match nothing keep their exact semantics.
+  if (ftsParseError) {
+    const nlQuery = normalizeNaturalLanguageFts5Query(query);
+    if (nlQuery.length === 0 || nlQuery === normalizedQuery) {
+      return [];
+    }
+    const nlResults = runSearch(nlQuery);
+    if (nlResults.length > 0) {
+      return nlResults;
+    }
+    const nlFallback = buildNaturalLanguageFallbackQuery(query);
+    if (nlFallback && nlFallback !== nlQuery) {
+      return runSearch(nlFallback);
+    }
+    return nlResults;
   }
 
   const fallbackQuery = buildFallbackFts5Query(query);

--- a/tests/store/session-search.test.ts
+++ b/tests/store/session-search.test.ts
@@ -136,6 +136,17 @@ describe('session-search', () => {
       assert.ok(results.every((r) => r.content.includes('memory search')));
     });
 
+    it('should recover natural-language queries with uppercase operator words and punctuation', () => {
+      indexSession(dbManager, createTestSession({ id: 'recovery-session', messages: [
+        { id: 'recovery-session-msg-1', role: 'assistant', content: 'Never search whole filesystem from root. Do not run find /.', timestamp: '2026-05-03T00:01:00Z' },
+      ] }));
+
+      const results = searchSessions(dbManager, 'DO NOT USE FIND /');
+
+      assert.ok(results.length > 0);
+      assert.ok(results.some((r) => r.content.includes('find')));
+    });
+
     it('should preserve valid operator queries', () => {
       indexSession(dbManager, createTestSession());
 

--- a/tests/store/sqlite-memory-store.test.ts
+++ b/tests/store/sqlite-memory-store.test.ts
@@ -377,6 +377,15 @@ describe('sqlite-memory-store', () => {
       assert.ok(results.every((r) => r.content.includes('memory search')));
     });
 
+    it('should recover natural-language queries with uppercase operator words and punctuation', () => {
+      addMemory(dbManager, 'Never search whole filesystem from root. Do not run find /.', 'user');
+
+      const results = searchMemories(dbManager, 'DO NOT USE FIND /', { target: 'user' });
+
+      assert.ok(results.length > 0);
+      assert.ok(results.some((r) => r.content.includes('find')));
+    });
+
     it('should preserve valid operator queries', () => {
       const results = searchMemories(dbManager, 'pnpm OR AEST');
       assert.ok(results.length >= 2);


### PR DESCRIPTION
Fixes #122

## Problem

`memory_search` (and session search) silently return nothing for natural-language queries containing uppercase operator words plus punctuation, e.g. `DO NOT USE FIND /`:

1. `hasExplicitFts5Operator` sees uppercase `NOT` and classifies the query as raw FTS5 syntax, passing it through unquoted.
2. The bare `/` makes FTS5 raise a parse error.
3. The error is converted to an empty result, and the natural-language fallback is skipped because the query is 'explicit operator', so the user gets "No memories found" even when matching memory exists.

The same query in lowercase succeeds, which makes the behavior surprising.

## Fix

Both search paths now track FTS5 parse errors and recover by retrying the query as natural language:

- `fts-query.ts`: add `normalizeNaturalLanguageFts5Query` / `buildNaturalLanguageFallbackQuery`, which normalize a query as natural language regardless of operator detection.
- `sqlite-memory-store.ts` `searchMemories`: when the raw operator query fails to parse, retry with quoted terms (implicit AND), then the broader OR fallback.
- `session-search.ts` `searchSessions`: same recovery, ending with the existing LIKE fallback.

**Valid** operator queries that legitimately match nothing keep their exact semantics — recovery only triggers on a parse error, so `foo NOT bar` returning empty still returns empty.

## Testing

- Regression tests in both test files: store `Never search whole filesystem from root. Do not run find /.`, query `DO NOT USE FIND /`, assert it is found (exercises both the AND retry and the OR fallback).
- `npx tsc --noEmit` clean.
- `tests/run-all.sh`: all 39 test files pass.

Note: this touches the same area as #118 (BM25 ranking); whichever lands second will need a trivial rebase — happy to do that on my side.