### PR TITLE
fix: load extension under compiled Pi (Bun) — #117

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3] - 2026-07-26
+
+### Fixed
+
+- **Compiled Pi failed to load the extension at all** ([#117](https://github.com/chandra447/pi-hermes-memory/issues/117)): `src/extension-root-migration.ts` resolved `better-sqlite3` at module scope, and `src/index.ts` imports it during extension load. Compiled Pi runs on Bun, whose resolver cannot find `better-sqlite3` (nor its transitive `bindings`) from an on-disk extension file, so every session started with `Failed to load extension: ResolveMessage: Cannot find package 'better-sqlite3'` and the whole extension was dead. The legacy-root migration now resolves SQLite lazily and routes through `bun:sqlite` under Bun, matching what `db.ts` and `atomic-lock-coordinator.ts` already did. Those two also defer their native load out of module scope, so an ABI mismatch now surfaces as an actionable in-session error (the recovery guidance added in 0.8.2) instead of a fatal extension-load failure.
+
 ## [0.8.2] - 2026-07-21
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hermes-memory",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-tui": "^0.80.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "🧠 Persistent memory + 🔍 session search + 🛡️ secret scanning for Pi. Token-aware policy-only memory by default, SQLite FTS5 search, auto-consolidation, procedural skills. 693 tests. Ported from Hermes agent.",
   "type": "module",
   "main": "src/index.ts",

--- a/src/extension-root-migration.ts
+++ b/src/extension-root-migration.ts
@@ -4,7 +4,8 @@ import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { AtomicLockCoordinator, type AtomicLockLease } from "./store/atomic-lock-coordinator.js";
 import { canonicalStoragePathSync } from "./store/canonical-storage-path.js";
-import { loadBetterSqlite3 } from "./store/sqlite-native.js";
+import { createRequire } from "node:module";
+import { isBunRuntime, loadBetterSqlite3 } from "./store/sqlite-native.js";
 
 type MigrationDatabase = {
   exec: (sql: string) => void;
@@ -22,7 +23,94 @@ type MigrationDatabaseCtor = new (
   options?: { readonly?: boolean; fileMustExist?: boolean; timeout?: number },
 ) => MigrationDatabase;
 
-const Database = loadBetterSqlite3() as MigrationDatabaseCtor;
+type BunDatabaseInstance = {
+  exec: (sql: string) => void;
+  prepare: (sql: string) => { get: (...args: unknown[]) => unknown; run: (...args: unknown[]) => unknown };
+  close: () => void;
+};
+
+/**
+ * bun:sqlite shim covering the slice of the better-sqlite3 API this migration
+ * uses. Compiled Pi cannot resolve better-sqlite3 at all, so under Bun this is
+ * the only way the legacy-root migration can touch sessions.db.
+ */
+function createBunMigrationDatabaseCtor(): MigrationDatabaseCtor {
+  const require = createRequire(import.meta.url);
+  const bunSqlite = require("bun:sqlite") as {
+    Database: new (
+      dbPath: string,
+      options?: { readonly?: boolean; readwrite?: boolean; create?: boolean },
+    ) => BunDatabaseInstance;
+  };
+
+  return class BunMigrationDatabase implements MigrationDatabase {
+    private readonly db: BunDatabaseInstance;
+
+    constructor(
+      dbPath: string,
+      options: { readonly?: boolean; fileMustExist?: boolean; timeout?: number } = {},
+    ) {
+      const readonly = options.readonly === true;
+      this.db = new bunSqlite.Database(dbPath, {
+        readonly,
+        readwrite: !readonly,
+        create: !readonly && options.fileMustExist !== true,
+      });
+      if (typeof options.timeout === "number") {
+        this.db.exec(`PRAGMA busy_timeout = ${Math.max(0, Math.trunc(options.timeout))}`);
+      }
+    }
+
+    exec(sql: string): void {
+      this.db.exec(sql);
+    }
+
+    prepare(sql: string): { get: (...args: unknown[]) => unknown; run: (...args: unknown[]) => unknown } {
+      return this.db.prepare(sql);
+    }
+
+    close(): void {
+      this.db.close();
+    }
+
+    pragma(query: string, options?: { simple?: boolean }): unknown {
+      if (query.includes("=")) {
+        this.db.exec(`PRAGMA ${query}`);
+        return undefined;
+      }
+      const row = this.db.prepare(`PRAGMA ${query}`).get();
+      if (typeof row !== "object" || row === null) return options?.simple ? row : [];
+      return options?.simple ? Object.values(row)[0] : [row];
+    }
+
+    /**
+     * bun:sqlite exposes no online backup API. `VACUUM INTO` writes an
+     * equivalent consistent snapshot under a read transaction, but has no
+     * incremental callback, so the heartbeat only fires either side of it.
+     */
+    async backup(destination: string, options?: { progress?: () => void }): Promise<void> {
+      options?.progress?.();
+      this.db.prepare("VACUUM INTO ?").run(destination);
+      options?.progress?.();
+    }
+  };
+}
+
+let cachedDatabaseCtor: MigrationDatabaseCtor | null = null;
+
+/**
+ * Resolved on first use, never at import time: this module is pulled in by
+ * src/index.ts at extension load, and a module-scope native load turns any
+ * SQLite resolve/ABI failure into "Failed to load extension" (issue #117).
+ */
+function getDatabaseCtor(): MigrationDatabaseCtor {
+  if (!cachedDatabaseCtor) {
+    cachedDatabaseCtor = isBunRuntime()
+      ? createBunMigrationDatabaseCtor()
+      : (loadBetterSqlite3() as MigrationDatabaseCtor);
+  }
+  return cachedDatabaseCtor;
+}
 const DATABASE_FILES = ["sessions.db", "sessions.db-wal", "sessions.db-shm"] as const;
 const DATABASE_MIGRATION_PENDING_FILE = ".sessions-db-migration-pending";
 
@@ -102,6 +190,7 @@ async function stageDatabaseSnapshot(
   staged: string,
   onProgress?: () => void,
 ): Promise<void> {
+  const Database = getDatabaseCtor();
   const sourceDb = new Database(source, { readonly: true, fileMustExist: true });
   try {
     await sourceDb.backup(staged, {
@@ -390,7 +479,7 @@ async function migrateDatabaseGeneration(
     const staged = path.join(stagingDir, "sessions.db");
     const sourceState = await fs.lstat(source);
     try {
-      writeLock = new Database(source, { fileMustExist: true, timeout: 0 });
+      writeLock = new (getDatabaseCtor())(source, { fileMustExist: true, timeout: 0 });
       writeLock.pragma("busy_timeout = 0");
       writeLock.exec("BEGIN IMMEDIATE");
     } catch (error) {
@@ -448,7 +537,15 @@ async function migrateDatabaseGeneration(
       published.set(target, await fileIdentity(target));
     }
 
-    if (writeLock) writeLock.exec("COMMIT");
+    if (writeLock) {
+      // Every generation file has already been moved out of legacyRoot, so this
+      // transaction can no longer guard anything and its database no longer
+      // exists at this path. bun:sqlite reports SQLITE_IOERR here where
+      // better-sqlite3 succeeds; either way a failed cleanup COMMIT must not
+      // roll back an otherwise completed migration.
+      // The connection is closed in `finally` either way.
+      try { writeLock.exec("COMMIT"); } catch {}
+    }
     result.moved += generationNames.length;
   } catch (error) {
     for (const [target, identity] of [...published.entries()].reverse()) {

--- a/src/store/atomic-lock-coordinator.ts
+++ b/src/store/atomic-lock-coordinator.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { createRequire } from 'node:module';
 import { spawnSync } from 'node:child_process';
-import { loadBetterSqlite3 } from './sqlite-native.js';
+import { isBunRuntime, loadBetterSqlite3 } from './sqlite-native.js';
 
 type StatementLike = {
   run: (...args: unknown[]) => unknown;
@@ -34,16 +34,24 @@ export interface AtomicLockCoordinatorOptions {
   probeIncarnation?: (pid: number) => string | null;
 }
 
-function loadDatabaseCtor(): DatabaseCtor {
-  const require = createRequire(import.meta.url);
-  if (typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined') {
-    const bunSqlite = require('bun:sqlite') as { Database: DatabaseCtor };
-    return bunSqlite.Database;
-  }
-  return loadBetterSqlite3({ requireImpl: require }) as DatabaseCtor;
-}
+let cachedDatabaseCtor: DatabaseCtor | null = null;
 
-const Database = loadDatabaseCtor();
+/**
+ * Resolved on first use, never at import time — see the same note in db.ts.
+ * Compiled Pi cannot resolve better-sqlite3 at all, so Bun must take bun:sqlite.
+ */
+function getDatabaseCtor(): DatabaseCtor {
+  if (!cachedDatabaseCtor) {
+    const require = createRequire(import.meta.url);
+    if (isBunRuntime()) {
+      const bunSqlite = require('bun:sqlite') as { Database: DatabaseCtor };
+      cachedDatabaseCtor = bunSqlite.Database;
+    } else {
+      cachedDatabaseCtor = loadBetterSqlite3({ requireImpl: require }) as DatabaseCtor;
+    }
+  }
+  return cachedDatabaseCtor;
+}
 
 function processIsAlive(pid: number): boolean {
   try {
@@ -220,7 +228,7 @@ export class AtomicLockCoordinator {
   private open(): DatabaseLike {
     fs.mkdirSync(path.dirname(this.dbPath), { recursive: true });
     const existed = fs.existsSync(this.dbPath);
-    const db = new Database(this.dbPath);
+    const db = new (getDatabaseCtor())(this.dbPath);
     try {
       db.exec(`
         PRAGMA busy_timeout = 5000;

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -4,7 +4,7 @@ import { createRequire } from 'node:module';
 import { SCHEMA_SQL } from './schema.js';
 import { AtomicLockCoordinator } from './atomic-lock-coordinator.js';
 import { canonicalStoragePathSync } from './canonical-storage-path.js';
-import { loadBetterSqlite3 } from './sqlite-native.js';
+import { isBunRuntime, loadBetterSqlite3 } from './sqlite-native.js';
 
 type StatementLike = {
   run: (...args: any[]) => any;
@@ -120,18 +120,22 @@ function createBunCompatDatabaseCtor(require: NodeRequire): DatabaseCtor {
   };
 }
 
-function loadDatabaseCtor(): DatabaseCtor {
-  const require = createRequire(import.meta.url);
-  const isBunRuntime = typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined';
+let cachedDatabaseCtor: DatabaseCtor | null = null;
 
-  if (isBunRuntime) {
-    return createBunCompatDatabaseCtor(require);
+/**
+ * Resolved on first use, never at import time. A module-scope native load turns
+ * any SQLite resolve/ABI failure into "Failed to load extension", which hides
+ * the actionable rebuild message and bricks the whole extension (issue #117).
+ */
+function getDatabaseCtor(): DatabaseCtor {
+  if (!cachedDatabaseCtor) {
+    const require = createRequire(import.meta.url);
+    cachedDatabaseCtor = isBunRuntime()
+      ? createBunCompatDatabaseCtor(require)
+      : (loadBetterSqlite3({ requireImpl: require }) as DatabaseCtor);
   }
-
-  return loadBetterSqlite3({ requireImpl: require }) as DatabaseCtor;
+  return cachedDatabaseCtor;
 }
-
-const Database = loadDatabaseCtor();
 
 export class DatabaseManager {
   private db: DatabaseLike | null = null;
@@ -270,7 +274,7 @@ export class DatabaseManager {
 
   private openUnchecked(): DatabaseLike {
     const existed = this.hasExistingMainDatabaseFile();
-    const db = new Database(this.dbPath);
+    const db = new (getDatabaseCtor())(this.dbPath);
     let ok = false;
 
     try {
@@ -434,7 +438,7 @@ export class DatabaseManager {
     if (!this.hasExistingMainDatabaseFile()) return false;
     let db: DatabaseLike | null = null;
     try {
-      db = new Database(this.dbPath);
+      db = new (getDatabaseCtor())(this.dbPath);
       this.assertIntegrityOk(db, 'quick_check', 'while joining corruption recovery');
       return true;
     } catch {
@@ -546,6 +550,7 @@ export class DatabaseManager {
     let rebuildOk = false;
 
     try {
+      const Database = getDatabaseCtor();
       source = new Database(this.dbPath);
       target = new Database(tempPath);
       target.exec('PRAGMA journal_mode = DELETE');

--- a/src/store/sqlite-native.ts
+++ b/src/store/sqlite-native.ts
@@ -44,6 +44,18 @@ export class BetterSqlite3LoadError extends Error {
 const ABI_MISMATCH_RE =
   /NODE_MODULE_VERSION|was compiled against a different Node\.js version|ERR_DLOPEN_FAILED/i;
 
+/**
+ * True when running under Bun (including the compiled Pi binary).
+ *
+ * Compiled Pi cannot resolve `better-sqlite3` — neither the bare specifier nor
+ * the package's own transitive `require("bindings")` resolve from an on-disk
+ * extension file, so every code path that needs SQLite must route through
+ * `bun:sqlite` instead of loading the native module.
+ */
+export function isBunRuntime(): boolean {
+  return "Bun" in globalThis;
+}
+
 export function isNativeModuleAbiMismatch(error: unknown): boolean {
   if (!error) return false;
   const message = error instanceof Error ? error.message : String(error);

--- a/tests/store/sqlite-lazy-load.test.ts
+++ b/tests/store/sqlite-lazy-load.test.ts
@@ -1,0 +1,78 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const srcRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../src");
+
+const POISON_REQUIRE = [
+  'import Module from "node:module";',
+  'import path from "node:path";',
+  "const original = Module.prototype.require;",
+  "Module.prototype.require = function (id: string) {",
+  '  if (id === "better-sqlite3") {',
+  "    throw Object.assign(new Error(\"Cannot find package 'better-sqlite3'\"), { code: \"MODULE_NOT_FOUND\" });",
+  "  }",
+  "  return original.apply(this, arguments as never);",
+  "};",
+].join("\n");
+
+/**
+ * Run `body` in a child process where `require("better-sqlite3")` always fails,
+ * standing in for compiled Pi, whose Bun resolver cannot find the package from
+ * an on-disk extension file.
+ */
+function runWithoutBetterSqlite3(body: string): { status: number | null; output: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-lazy-sqlite-"));
+  try {
+    const child = path.join(dir, "probe.mts");
+    fs.writeFileSync(child, `${POISON_REQUIRE}\n${body}\n`);
+    const result = spawnSync(process.execPath, ["--import", "tsx", child], { encoding: "utf-8" });
+    return { status: result.status, output: `${result.stdout ?? ""}${result.stderr ?? ""}` };
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Regression guard for issue #117: a module-scope native load turned an
+ * unresolvable better-sqlite3 into "Failed to load extension", bricking the
+ * extension for every compiled-Pi user instead of failing at the point of use.
+ */
+describe("SQLite native loading is deferred past extension load", () => {
+  it("imports the extension-load module graph without resolving better-sqlite3", () => {
+    // Dynamic import: the specifiers are absolute paths built at runtime so the
+    // poisoned require hook is installed before the graph is evaluated.
+    const body = [
+      `for (const specifier of ${JSON.stringify([
+        path.join(srcRoot, "extension-root-migration.ts"),
+        path.join(srcRoot, "store/db.ts"),
+        path.join(srcRoot, "store/atomic-lock-coordinator.ts"),
+      ])}) {`,
+      "  await import(specifier);",
+      "}",
+      'console.log("IMPORTED_OK");',
+    ].join("\n");
+
+    const { status, output } = runWithoutBetterSqlite3(body);
+    assert.match(output, /IMPORTED_OK/);
+    assert.equal(status, 0);
+  });
+
+  it("still fails loudly when SQLite is actually used", () => {
+    const body = [
+      `const { AtomicLockCoordinator } = await import(${JSON.stringify(path.join(srcRoot, "store/atomic-lock-coordinator.ts"))});`,
+      'const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-lazy-sqlite-use-"));',
+      'new AtomicLockCoordinator(path.join(dir, "locks.sqlite")).tryAcquire("k", { staleMs: 1000 });',
+    ].join("\n");
+
+    const { status, output } = runWithoutBetterSqlite3(
+      `import fs from "node:fs";\nimport os from "node:os";\n${body}`,
+    );
+    assert.notEqual(status, 0);
+    assert.match(output, /better-sqlite3/);
+  });
+});


### PR DESCRIPTION
Fixes #117. Reported by @atimofeev, confirmed by @sanderpoks.

## Root cause

`src/index.ts` imports `src/extension-root-migration.ts` at module scope, and that module did an **unconditional module-scope** native load:

```ts
const Database = loadBetterSqlite3() as MigrationDatabaseCtor;
```

Compiled Pi runs on Bun. Reproduced locally against the installed `0.8.2` with a `bun build --compile` host that dynamically imports the extension the way Pi does:

```
src/extension-root-migration.ts -> FAILED: ResolveMessage: Cannot find package 'better-sqlite3'
                                   from '.../pi-hermes-memory/src/store/sqlite-native.ts'
src/store/sqlite-native.ts      -> LOADED OK
```

Exactly the reported error. `db.ts` and `atomic-lock-coordinator.ts` were already Bun-aware (`bun:sqlite`), so `extension-root-migration.ts` was the only module reaching for the native addon on Bun — introduced in v0.8.0 as a static `import Database from "better-sqlite3"`, which is why 0.7.22 is unaffected.

### Why the suggested absolute-path fallback isn't the fix

The workaround in the issue makes the *first* resolve succeed, but better-sqlite3's own internals then fail the same way:

```
ABS: ok, ctor? function
ABS: fail ResolveMessage: Cannot find package 'bindings' from '.../better-sqlite3/lib/database.js'
```

Under compiled Pi, better-sqlite3 is unusable end-to-end. The correct answer is option 1 from the issue: never route through it on Bun.

## Changes

- `extension-root-migration.ts` resolves its `Database` ctor **on first use**, and uses a `bun:sqlite` shim under Bun — `VACUUM INTO` for the snapshot (no online-backup API in `bun:sqlite`), prepared `PRAGMA` for `integrity_check`, `readwrite`/`create` flag mapping for `readonly`/`fileMustExist`.
- `db.ts` and `atomic-lock-coordinator.ts` also defer their native load out of module scope. An ABI mismatch (#111) now surfaces as an actionable in-session error carrying the 0.8.2 rebuild guidance, instead of a fatal `Failed to load extension`.
- The post-move cleanup `COMMIT` on the legacy write lock is best-effort. By that point every generation file has been moved out of the legacy root, so the transaction guards nothing; `bun:sqlite` returns `SQLITE_IOERR` there where better-sqlite3 succeeds, and a failed cleanup must not roll back a completed migration.

## Verification

- Load, under a compiled Bun binary dynamically importing the patched source:
  ```
  src/extension-root-migration.ts      -> LOADED OK
  src/store/db.ts                      -> LOADED OK
  src/store/atomic-lock-coordinator.ts -> LOADED OK
  ```
- Functional legacy-root migration under the same compiled binary: `moved: 2`, `criticalFailures: 0`, `integrity_check: ok`, rows intact, `MEMORY.md` moved, legacy root removed, second run a clean no-op.
- New regression test `tests/store/sqlite-lazy-load.test.ts` imports the extension-load module graph with `require("better-sqlite3")` poisoned to throw. It fails on `main` and passes here, and a second case asserts the failure still surfaces loudly at point of use.
- `npm run check` clean, `npm test` 40/40 files.