### PR TITLE
fix: share one project identity across git worktrees — #120

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Git worktrees each became their own project** ([#120](https://github.com/chandra447/pi-hermes-memory/issues/120)): project-scoped memory and skills were keyed off `path.basename(cwd)`, so running Pi in a linked worktree wrote to `projects-memory/<worktree-name>/`. Deleting the worktree after merging stranded that memory and those skills where the main checkout could never see them. Inside a Git repository the project name is now the *repository* root's basename — resolved from the worktree's `.git` pointer and its `commondir`, with no `git` subprocess — so every worktree and every subdirectory of a repository shares one identity. An existing `projects-memory/<cwd-basename>/` store still wins over a newly derived repository name, so upgrading never orphans memory written under the old identity.
+
 ## [0.8.3] - 2026-07-26
 
 ### Fixed

--- a/src/project.ts
+++ b/src/project.ts
@@ -3,6 +3,7 @@
  * represents a project and resolves its name.
  */
 
+import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import { resolveProjectsRoot } from "./paths.js";
@@ -20,10 +21,79 @@ export interface ProjectSkillInfo extends ProjectInfo {
 }
 
 /**
+ * Resolve the repository root shared by every linked worktree of `dir`'s repo.
+ *
+ * Mirrors what `git rev-parse --git-common-dir` reports, without spawning git:
+ * a linked worktree's `.git` is a file pointing at
+ * `<main>/.git/worktrees/<name>`, and that directory carries a `commondir`
+ * file pointing back at the shared `<main>/.git`. Returns null outside a
+ * repository, or for a bare/detached layout with no obvious working root.
+ */
+function findGitRepoRoot(dir: string): string | null {
+  let current = path.resolve(dir);
+
+  while (true) {
+    const dotGit = path.join(current, ".git");
+    let stat: fs.Stats | undefined;
+    try {
+      stat = fs.statSync(dotGit);
+    } catch {
+      stat = undefined;
+    }
+
+    if (stat?.isDirectory()) return current;
+
+    if (stat?.isFile()) {
+      const commonDir = resolveWorktreeCommonDir(current, dotGit);
+      if (!commonDir) return current;
+      return path.basename(commonDir) === ".git" ? path.dirname(commonDir) : commonDir;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function resolveWorktreeCommonDir(worktreeRoot: string, dotGitFile: string): string | null {
+  let pointer: string;
+  try {
+    pointer = fs.readFileSync(dotGitFile, "utf-8");
+  } catch {
+    return null;
+  }
+
+  const match = /^gitdir:\s*(.+)$/m.exec(pointer);
+  if (!match) return null;
+
+  const gitDir = path.resolve(worktreeRoot, match[1].trim());
+  try {
+    const commonDir = fs.readFileSync(path.join(gitDir, "commondir"), "utf-8").trim();
+    if (commonDir) return path.resolve(gitDir, commonDir);
+  } catch {
+    // Not a linked worktree, or an older layout without `commondir`.
+  }
+
+  // `<main>/.git/worktrees/<name>` — two levels up is the shared git dir.
+  const parent = path.dirname(gitDir);
+  return path.basename(parent) === "worktrees" ? path.dirname(parent) : null;
+}
+
+const repoRootCache = new Map<string, string | null>();
+
+/**
  * Detect project from the current working directory.
  *
- * A "project" is any directory that is not the user's home directory.
- * The project name is the directory's basename.
+ * A "project" is any directory that is not the user's home directory. Inside a
+ * Git repository the project name is the *repository* root's basename, so every
+ * linked worktree shares one identity instead of stranding its memory and
+ * skills under the worktree directory name (#120). Outside Git it stays the
+ * working directory's basename.
+ *
+ * An existing `projects-memory/<cwd-basename>/` directory still wins over a
+ * newly derived repository name, so upgrading never orphans memory that was
+ * written under the old cwd-basename identity.
+ *
  * Project-scoped memory is stored at ~/.pi/agent/<projectsMemoryDir>/<projectName>/.
  */
 export function detectProject(projectsMemoryDir = "projects-memory", cwd?: string): ProjectInfo {
@@ -38,15 +108,44 @@ export function detectProject(projectsMemoryDir = "projects-memory", cwd?: strin
     return { name: null, memoryDir: null };
   }
 
-  const name = path.basename(resolved);
-  if (!name || name === "." || name === "..") {
+  const cwdName = path.basename(resolved);
+  if (!cwdName || cwdName === "." || cwdName === "..") {
     return { name: null, memoryDir: null };
   }
 
+  const projectsRoot = resolveProjectsRoot(projectsMemoryDir);
+  const name = resolveProjectName(resolved, resolvedHome, cwdName, projectsRoot);
+
   return {
     name,
-    memoryDir: path.join(resolveProjectsRoot(projectsMemoryDir), name),
+    memoryDir: path.join(projectsRoot, name),
   };
+}
+
+function resolveProjectName(
+  resolved: string,
+  resolvedHome: string,
+  cwdName: string,
+  projectsRoot: string,
+): string {
+  let repoRoot = repoRootCache.get(resolved);
+  if (repoRoot === undefined) {
+    repoRoot = findGitRepoRoot(resolved);
+    repoRootCache.set(resolved, repoRoot);
+  }
+
+  if (!repoRoot || repoRoot === resolved || repoRoot === resolvedHome) return cwdName;
+
+  const repoName = path.basename(repoRoot);
+  if (!repoName || repoName === cwdName) return cwdName;
+
+  // Migration bridge: a store already written under the old cwd-basename
+  // identity keeps working. Only fresh directories adopt the repository name.
+  if (!fs.existsSync(path.join(projectsRoot, repoName)) && fs.existsSync(path.join(projectsRoot, cwdName))) {
+    return cwdName;
+  }
+
+  return repoName;
 }
 
 export function detectProjectSkills(projectsMemoryDir = "projects-memory", cwd?: string): ProjectSkillInfo {

--- a/tests/project.test.ts
+++ b/tests/project.test.ts
@@ -1,9 +1,41 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { detectProject, detectProjectSkills } from "../src/project.js";
 import { AGENT_ROOT } from "../src/paths.js";
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync("git", args, {
+    cwd,
+    stdio: "ignore",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "t",
+      GIT_AUTHOR_EMAIL: "t@example.com",
+      GIT_COMMITTER_NAME: "t",
+      GIT_COMMITTER_EMAIL: "t@example.com",
+    },
+  });
+}
+
+/** Real repo with one commit plus a linked worktree, since #120 is entirely about worktree layout. */
+function makeRepoWithWorktree(): { root: string; repo: string; worktree: string } {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "hermes-project-")));
+  const repo = path.join(root, "my-project");
+  fs.mkdirSync(path.join(repo, "packages", "api"), { recursive: true });
+  git(root, "init", "-q", "-b", "main", "my-project");
+  fs.writeFileSync(path.join(repo, "README.md"), "x\n");
+  git(repo, "add", ".");
+  git(repo, "commit", "-qm", "init");
+
+  const worktree = path.join(root, "worktrees", "issue-123");
+  git(repo, "worktree", "add", "-q", "-b", "issue-123", worktree);
+
+  return { root, repo, worktree };
+}
 
 describe("project detection", () => {
   it("detectProject returns null outside a project", () => {
@@ -31,5 +63,58 @@ describe("project detection", () => {
       result.skillsDir,
       path.join(AGENT_ROOT, "projects-memory", "demo-repo", "skills"),
     );
+  });
+});
+
+describe("git worktree project identity (#120)", () => {
+  it("gives a linked worktree the same project identity as its main checkout", () => {
+    const { root, repo, worktree } = makeRepoWithWorktree();
+    try {
+      assert.strictEqual(detectProject("projects-memory", repo).name, "my-project");
+      assert.strictEqual(detectProject("projects-memory", worktree).name, "my-project");
+      assert.strictEqual(
+        detectProject("projects-memory", worktree).memoryDir,
+        detectProject("projects-memory", repo).memoryDir,
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("scopes a subdirectory of the repository to the repository", () => {
+    const { root, repo } = makeRepoWithWorktree();
+    try {
+      assert.strictEqual(
+        detectProject("projects-memory", path.join(repo, "packages", "api")).name,
+        "my-project",
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps using an existing cwd-basename store instead of orphaning it", () => {
+    const { root, repo } = makeRepoWithWorktree();
+    const legacy = path.join(AGENT_ROOT, "projects-memory", "api");
+    const legacyPreexisting = fs.existsSync(legacy);
+    try {
+      fs.mkdirSync(legacy, { recursive: true });
+      assert.strictEqual(
+        detectProject("projects-memory", path.join(repo, "packages", "api")).name,
+        "api",
+      );
+    } finally {
+      if (!legacyPreexisting) fs.rmSync(legacy, { recursive: true, force: true });
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the directory basename outside a repository", () => {
+    const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "hermes-nogit-")));
+    try {
+      assert.strictEqual(detectProject("projects-memory", dir).name, path.basename(dir));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Fixes #120. Reported by @hanjeahwan.

## Problem

`detectProject()` derived identity from `path.basename(path.resolve(cwd))`. A linked worktree therefore *is* a separate project: skills created from `/code/worktrees/issue-123` land in `projects-memory/issue-123/skills/`, and once the branch is merged and the worktree removed, the main checkout at `/code/my-project` can never see them again.

## Approach

Inside a Git repository the project name is now the **repository root's basename**. Resolution matches what `git rev-parse --git-common-dir` reports, but without spawning `git`:

- `.git` is a directory → that directory's parent is the repo root.
- `.git` is a file → it holds `gitdir: <main>/.git/worktrees/<name>`, and that directory holds a `commondir` file naming the shared `<main>/.git`. Falls back to the `worktrees/` path shape when `commondir` is absent (older layouts).

Result resolved once per cwd and cached, so the `resources_discover` handler doesn't re-stat on every event.

This is deliberately *not* the `<name>-<short-hash>` scheme from the issue. That fixes the secondary basename-collision case but renames every existing user's project directory, and there is no safe way to tell whether an existing `projects-memory/api/` belongs to this repo or another one with the same basename. Repo-root basename fixes the reported bug with no renaming at all, and for a main checkout it computes exactly the same name as before.

## No orphaning on upgrade

Running Pi from `/code/my-project/packages/api` previously resolved to `api`; it now resolves to `my-project`. To avoid silently stranding that store, an existing `projects-memory/<cwd-basename>/` directory keeps winning. Only fresh directories adopt the repository name.

## What this does not do

Directories already orphaned by a deleted worktree stay where they are — we can't know which repository they belonged to. `@hanjeahwan`'s manual `/memory-skills` workaround remains the route for those. Surfacing orphans in `/memory-switch-project` is a good follow-up, and a `projectId` config override is worth adding for anyone who genuinely wants two same-named repos kept apart; both are deliberately out of scope here.

## Verification

Four new tests in `tests/project.test.ts` build a **real** git repo with a real linked worktree (`git worktree add`) and assert:

- worktree and main checkout resolve to the same name *and* the same `memoryDir`
- a subdirectory of the repo resolves to the repo
- an existing cwd-basename store keeps winning
- non-git directories still fall back to the cwd basename

`npm run check` clean, `npm test` 40/40 files.