### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.0] - 2026-07-26
+
+### Changed
+
+- **Global skills moved to `~/.pi/agent/skills/`.** `skill_manage` with `scope: "global"` previously wrote to a private `~/.pi/agent/pi-hermes-memory/skills/`. Existing global skills are relocated automatically on first run. Because that directory is Pi's own user-skills root, `/memory-skills` now also lists skills you wrote by hand or that another tool installed there. See the #125/#126 entry below for why the private directory could not stay.
+- **Project identity follows the Git repository, not the working directory name.** Running Pi from a linked worktree or a subdirectory of a repository now resolves to the repository's project scope. Directories that already exist under the old cwd-basename identity keep being used, so nothing is orphaned on upgrade.
 
 ### Fixed
 
 - **Git worktrees each became their own project** ([#120](https://github.com/chandra447/pi-hermes-memory/issues/120)): project-scoped memory and skills were keyed off `path.basename(cwd)`, so running Pi in a linked worktree wrote to `projects-memory/<worktree-name>/`. Deleting the worktree after merging stranded that memory and those skills where the main checkout could never see them. Inside a Git repository the project name is now the *repository* root's basename — resolved from the worktree's `.git` pointer and its `commondir`, with no `git` subprocess — so every worktree and every subdirectory of a repository shares one identity. An existing `projects-memory/<cwd-basename>/` store still wins over a newly derived repository name, so upgrading never orphans memory written under the old identity.
 - **Global skills were permanently shadowed by Pi's own skills root** ([#125](https://github.com/chandra447/pi-hermes-memory/issues/125), [#126](https://github.com/chandra447/pi-hermes-memory/issues/126)): `skill_manage` with `scope: "global"` wrote to `~/.pi/agent/pi-hermes-memory/skills/`, which the extension then contributed as an extra scan root. Pi keys skills by name, first-loaded wins, and its own `~/.pi/agent/skills/` is auto-discovered at higher precedence — so any name present in both places produced a collision warning every session **and** silently ignored our copy, making `skill_manage` edits a no-op against the skill the agent actually loaded. Global skills now live in `~/.pi/agent/skills/` alongside every other user skill, and only the project skills directory is contributed via `resources_discover`. Existing skills are moved out of the private directory on first run; a name that already exists in Pi's root is left untouched and reported rather than clobbered. `SKILL_TOOL_DESCRIPTION` now states the on-disk path for each scope.
+
 ### Performance
 
 - **Session start no longer churns SQLite connections** ([#124](https://github.com/chandra447/pi-hermes-memory/pull/124), thanks [@Fraguinha](https://github.com/Fraguinha)): `AtomicLockCoordinator` opened and closed a fresh connection for every `tryAcquire`/`isCurrentOwner`/`release` — each open running PRAGMA setup plus `CREATE TABLE IF NOT EXISTS`, each close triggering a WAL checkpoint — and `syncMarkdownMemoriesToSqlite` constructed a new coordinator per file. On a 2.5 MB `sessions.db` this accounted for **16.7s of better-sqlite3 CPU per `/new` or `/resume`, now 3.7s**. Connections are cached per coordinator and coordinators are shared per database path, so every lock site (markdown mutations, consolidation, corruption recovery, legacy-root migration) reuses one connection instead of leaking one per call.
 
 ## [0.8.3] - 2026-07-26
+
+> Tagged but never published to npm; its fixes ship in 0.9.0.
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hermes-memory",
-      "version": "0.8.3",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-tui": "^0.80.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "🧠 Persistent memory + 🔍 session search + 🛡️ secret scanning for Pi. Token-aware policy-only memory by default, SQLite FTS5 search, auto-consolidation, procedural skills. 693 tests. Ported from Hermes agent.",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
Rolls up everything merged since 0.8.2. Minor bump rather than patch: global skills change on-disk location and project identity changes derivation, both with automatic migration but both user-visible.

0.8.3 was tagged but never reached npm (the publish workflow has no credentials), so its two fixes ship here.

| Item | |
|---|---|
| #117 | compiled Pi could not load the extension at all |
| #122 | memory_search silently missed uppercase-connector queries |
| #120 | git worktrees each became their own project |
| #125 / #126 | global skills permanently shadowed by Pi own skills root |
| #124 | 16.7s -> 3.7s better-sqlite3 CPU per /new and /resume |

Verified: npm run check clean, npm test 40/40 files.