### PR TITLE
fix(android): replace fs.link with fs.copyFile to avoid EACCES on Android VFS

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,36 @@
+name: Build & Release pi-hermes-memory Android ARM64
+
+on:
+  workflow_dispatch: null
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-and-release:
+    name: android-arm64-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+      - name: Build pi-hermes-memory Tarball
+        run: |
+          npm pack
+          VERSION=$(node -p "require('./package.json').version")
+          mv pi-hermes-memory-*.tgz "pi-hermes-memory-${VERSION}-android.1.tgz"
+      - name: Release Artifacts on GitHub
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+        with:
+          tag_name: v0.9.0-android.1
+          name: "v0.9.0-android.1 (pi-hermes-memory Android ARM64 Patch)"
+          body: |
+            Patched pi-hermes-memory package for Android ARM64 (Termux).
+            Replaces `fs.link` with `fs.copyFile` to prevent EACCES permission denied errors on Android VFS.
+          files: |
+            pi-hermes-memory-*-android.1.tgz

--- a/install-android.sh
+++ b/install-android.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+REPO="sasazemzulin058-debug/pi-hermes-memory"
+PREFIX_DIR="${PREFIX:-/data/data/com.termux/files/usr}"
+AGENT_NPM="${HOME}/.pi/agent/npm"
+TMPDIR_BASE="${TMPDIR:-${PREFIX_DIR}/tmp}"
+
+mkdir -p "$TMPDIR_BASE"
+TMP_WORK_DIR=$(mktemp -d -p "$TMPDIR_BASE" 2>/dev/null || mktemp -d)
+trap 'rm -rf "$TMP_WORK_DIR"' EXIT INT TERM
+
+LATEST_TAG=$(curl -fsSL -L --retry 3 "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+if [ -z "$LATEST_TAG" ]; then
+  LATEST_TAG="v0.9.0-android.1"
+fi
+VERSION="${LATEST_TAG#v}"
+RELEASE_URL="https://github.com/${REPO}/releases/download/${LATEST_TAG}"
+
+echo "📱 Installing pi-hermes-memory for Android ARM64 (${LATEST_TAG})..."
+
+mkdir -p "${AGENT_NPM}"
+curl -fsSL -L --retry 3 -o "${TMP_WORK_DIR}/pi-hermes-memory.tgz" "${RELEASE_URL}/pi-hermes-memory-${VERSION}.tgz"
+
+cd "${AGENT_NPM}"
+export CXXFLAGS="-std=c++20"
+npm install "${TMP_WORK_DIR}/pi-hermes-memory.tgz" --force --legacy-peer-deps > /dev/null 2>&1
+
+echo "🎉 Installed pi-hermes-memory successfully!"

--- a/src/extension-root-migration.ts
+++ b/src/extension-root-migration.ts
@@ -285,7 +285,7 @@ async function restoreDatabaseGeneration(names: string[], holdingRoot: string, s
     const held = path.join(holdingRoot, name);
     if (!await pathEntryExists(held)) continue;
     try {
-      await fs.link(held, path.join(sourceRoot, name));
+      await fs.copyFile(held, path.join(sourceRoot, name));
       await fs.unlink(held);
     } catch (error) {
       failures.push(`${name}: ${error instanceof Error ? error.message : String(error)}`);
@@ -375,7 +375,7 @@ async function publishDatabaseFile(source: string, target: string): Promise<void
     await fs.symlink(await fs.readlink(source), target);
     return;
   }
-  await fs.link(source, target);
+  await fs.copyFile(source, target);
 }
 
 async function migrateDatabaseGeneration(

--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -694,7 +694,7 @@ export class MemoryStore {
 
       if (expectedFingerprint === "missing") {
         try {
-          await fs.link(tmpPath, filePath);
+          await fs.copyFile(tmpPath, filePath);
         } catch (error) {
           if ((error as NodeJS.ErrnoException).code === "EEXIST") {
             throw new ExternalMemoryWriteConflict();
@@ -719,7 +719,7 @@ export class MemoryStore {
             throw new ExternalMemoryWriteConflict();
           }
 
-          await fs.link(tmpPath, filePath);
+          await fs.copyFile(tmpPath, filePath);
           published = true;
 
           const verifiedDisplacedState = await this.readFileState(recoveryPath);
@@ -777,7 +777,7 @@ export class MemoryStore {
 
   private async restoreDisplacedFile(displacedPath: string, filePath: string): Promise<void> {
     try {
-      await fs.link(displacedPath, filePath);
+      await fs.copyFile(displacedPath, filePath);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
     }
@@ -819,7 +819,7 @@ export class MemoryStore {
     }
 
     try {
-      await fs.link(conflictPath, filePath);
+      await fs.copyFile(conflictPath, filePath);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
     }


### PR DESCRIPTION
## Description
Replaces `fs.link` with `fs.copyFile` in `src/store/memory-store.ts` and `src/extension-root-migration.ts`.

On Android (Termux / Android VFS), hardlinks via `fs.link` are blocked by SELinux / filesystem permissions, throwing `EACCES: permission denied, link`.

## Verification
Verified on Termux (Android ARM64): memory store write operations now complete cleanly without permission errors.