### PR TITLE
fix: keep extension skills in their own directory, guard shadowed writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-07-27
+
+### Changed
+
+- **Global skills return to `~/.pi/agent/pi-hermes-memory/skills/`** ([#126](https://github.com/chandra447/pi-hermes-memory/issues/126), reported by [@kdejaeger](https://github.com/kdejaeger)): 0.9.0 moved them into Pi's own `~/.pi/agent/skills/` to eliminate a shadowing bug. That fixed the bug by deleting one of the two directories, and took a deliberate design property with it — skills this extension curates from your sessions were mixed in with skills you installed yourself, so you could no longer wipe or audit ours without picking through yours. Worse, `skill_manage delete` gained the ability to remove hand-written skills it never created. Skills are separated by who writes them again.
+- **`skill_manage delete` can no longer target Pi's global skills root.** It reaches only this extension's own global directory and the active project's. Skills you installed yourself are out of its blast radius.
+
+### Fixed
+
+- **Silent write-loss on shadowed global skill names, fixed at the source** ([#125](https://github.com/chandra447/pi-hermes-memory/issues/125)): Pi keys skills by name, first-loaded wins, and its own `~/.pi/agent/skills/` outranks anything an extension contributes via `resources_discover`. Creating a global skill under a name already present there wrote a file Pi never loads and reported success. Rather than removing one of the directories, `skill_manage` now **refuses** such a write and names both paths, so the shadowed state cannot be created in the first place. Project scope is unaffected — only the global root collides.
+
+### Upgrading
+
+If you ran 0.9.0, the skills it relocated into `~/.pi/agent/skills/` **stay there** and keep working. They are not moved back automatically: 0.9.0's migration renamed each skill and then removed its source directory without recording a manifest, and skill frontmatter carries no provenance field, so there is no reliable way to tell which skills in Pi's root came from this extension and which are yours. Moving files out of your global root on a guess would be a worse version of the mistake being corrected here. Move any you want back by hand, or open an issue and a confirmation-gated `/memory-skills reclaim` will be added.
+
 ## [0.9.0] - 2026-07-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.10.0] - 2026-07-27
+## [0.9.1] - 2026-07-27
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hermes-memory",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-tui": "^0.80.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.10.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hermes-memory",
-      "version": "0.10.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-tui": "^0.80.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "🧠 Persistent memory + 🔍 session search + 🛡️ secret scanning for Pi. Token-aware policy-only memory by default, SQLite FTS5 search, auto-consolidation, procedural skills. 693 tests. Ported from Hermes agent.",
   "type": "module",
   "main": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.10.0",
+  "version": "0.9.1",
   "description": "🧠 Persistent memory + 🔍 session search + 🛡️ secret scanning for Pi. Token-aware policy-only memory by default, SQLite FTS5 search, auto-consolidation, procedural skills. 693 tests. Ported from Hermes agent.",
   "type": "module",
   "main": "src/index.ts",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -312,7 +312,7 @@ WHEN TO CREATE A SKILL:
 - When the user teaches you a specific workflow or procedure
 
 SCOPE:
-- 'global': transferable procedures that can be reused across repositories. Written to Pi's own global skills root, ~/.pi/agent/skills/<slug>/SKILL.md — the same directory Pi loads user skills from, so a name used there is already taken.
+- 'global': transferable procedures that can be reused across repositories. Written to ~/.pi/agent/pi-hermes-memory/skills/<slug>/SKILL.md, this extension's own directory, kept separate from skills the user installed themselves. Pi also loads its own ~/.pi/agent/skills/ first, so a name already used there is rejected rather than silently shadowed.
 - 'project': procedures tied to this repo's paths, scripts, architecture, deploy flow, or conventions. Written to ~/.pi/agent/projects-memory/<project>/skills/<slug>/SKILL.md.
 
 WHEN TO UPDATE A SKILL:

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,10 +63,13 @@ export function resolveProjectSkillDiscovery(
   const detected = detectProjectSkills(projectsMemoryDir, cwd);
   skillStore.setProjectContext(detected.name, detected.skillsDir);
 
-  // Global skills live in Pi's own `~/.pi/agent/skills/`, which Pi already
-  // auto-discovers at higher precedence than anything contributed here. Only
-  // the project skills directory needs registering (#125, #126).
-  return { skillPaths: detected.skillsDir ? [detected.skillsDir] : [] };
+  // Pi auto-discovers its own `~/.pi/agent/skills/`, but this extension keeps
+  // its generated skills in a directory of its own so users can audit, wipe, or
+  // ignore them without touching skills they installed themselves (#126). Both
+  // of ours must therefore be contributed here.
+  const skillPaths = [skillStore.getGlobalSkillsDir()];
+  if (detected.skillsDir) skillPaths.push(detected.skillsDir);
+  return { skillPaths };
 }
 
 export function registerProjectSkillDiscoveryHandler(
@@ -102,13 +105,12 @@ export default function (pi: ExtensionAPI) {
   const project = detectProject(config.projectsMemoryDir);
   const projectName = project.name ?? "";
   const skillStore = new SkillStore({
-    globalSkillsDir: path.join(agentRoot, "skills"),
+    globalSkillsDir: path.join(globalDir, "skills"),
+    piGlobalSkillsDir: path.join(agentRoot, "skills"),
     projectSkillsDir: project.memoryDir ? path.join(project.memoryDir, "skills") : null,
     projectName: project.name,
     legacySkillsDir: path.join(legacyGlobalDir, "skills"),
-    legacyExtensionSkillsDir: path.join(globalDir, "skills"),
     migrationSentinelPath: path.join(globalDir, ".skills-migrated-to-extension-storage"),
-    extensionSkillsMigrationSentinelPath: path.join(globalDir, ".skills-migrated-to-pi-global"),
   });
   const dbManager = new DatabaseManager(globalDir);
   let databaseMigrationPending = shouldMigrateExtensionRoot

--- a/src/store/skill-store.ts
+++ b/src/store/skill-store.ts
@@ -23,13 +23,14 @@ import type { SkillDocument, SkillIndex, SkillResult, SkillScope } from "../type
 import { AGENT_ROOT } from "../paths.js";
 
 interface SkillStoreOptions {
+  /** Where this extension writes global skills. Never Pi's own root. */
   globalSkillsDir?: string;
+  /** Pi's global skills root, consulted read-only to refuse shadowed writes. */
+  piGlobalSkillsDir?: string;
   projectSkillsDir?: string | null;
   projectName?: string | null;
   legacySkillsDir?: string;
-  legacyExtensionSkillsDir?: string;
   migrationSentinelPath?: string;
-  extensionSkillsMigrationSentinelPath?: string;
 }
 
 interface SkillLocation {
@@ -154,29 +155,34 @@ export function normalizeSkillPatchContent(
 
 export class SkillStore {
   private globalSkillsDir: string;
+  private piGlobalSkillsDir: string;
   private projectSkillsDir: string | null;
   private projectName: string | null;
   private legacySkillsDir: string;
-  private legacyExtensionSkillsDir: string;
   private migrationSentinelPath: string;
-  private extensionSkillsMigrationSentinelPath: string;
 
   constructor(options: SkillStoreOptions = {}) {
     const agentRoot = AGENT_ROOT;
-    this.globalSkillsDir = options.globalSkillsDir ?? path.join(agentRoot, "skills");
+    this.globalSkillsDir = options.globalSkillsDir ?? path.join(agentRoot, "pi-hermes-memory", "skills");
+    this.piGlobalSkillsDir = options.piGlobalSkillsDir ?? path.join(agentRoot, "skills");
     this.projectSkillsDir = options.projectSkillsDir ?? null;
     this.projectName = options.projectName ?? null;
     this.legacySkillsDir = options.legacySkillsDir ?? path.join(agentRoot, "memory", "skills");
-    this.legacyExtensionSkillsDir = options.legacyExtensionSkillsDir
-      ?? path.join(agentRoot, "pi-hermes-memory", "skills");
     this.migrationSentinelPath = options.migrationSentinelPath
       ?? path.join(agentRoot, "pi-hermes-memory", ".skills-migrated-to-extension-storage");
-    this.extensionSkillsMigrationSentinelPath = options.extensionSkillsMigrationSentinelPath
-      ?? path.join(agentRoot, "pi-hermes-memory", ".skills-migrated-to-pi-global");
   }
 
   getGlobalSkillsDir(): string {
     return this.globalSkillsDir;
+  }
+
+  /**
+   * Pi's own global skills root. Read-only from here: we never create, patch,
+   * or delete inside it. It is consulted solely to refuse writes that Pi would
+   * silently shadow (see `findShadowingPiGlobalSkill`).
+   */
+  getPiGlobalSkillsDir(): string {
+    return this.piGlobalSkillsDir;
   }
 
   getProjectSkillsDir(): string | null {
@@ -205,7 +211,6 @@ export class SkillStore {
     // Always normalize flat markdown files under the global skills root,
     // even when a previous migration sentinel already exists.
     await this.migrateFlatMarkdownInGlobalSkillsDir(result);
-    await this.migrateExtensionSkillsToGlobalRoot(result);
 
     if (await exists(this.migrationSentinelPath)) return result;
 
@@ -316,60 +321,22 @@ export class SkillStore {
   }
 
   /**
-   * Move extension-managed global skills back into Pi's own global skills root.
+   * Is `slug` already claimed by a skill in Pi's own global root?
    *
    * Pi keys skills by name, first-loaded wins, and `~/.pi/agent/skills/` is
    * auto-discovered at higher precedence than anything an extension contributes
-   * via `resources_discover`. While global skills lived in a private directory,
-   * any name that also existed in Pi's root was permanently shadowed: the
-   * collision warning fired every session and `skill_manage` edits silently had
-   * no effect on the skill the agent actually loaded (#125, #126).
+   * via `resources_discover`. A global skill we write under a name that also
+   * exists there is never the copy Pi loads, so the write succeeds on disk and
+   * changes nothing about the agent's behaviour — silent write-loss (#125).
    *
-   * Runs on every startup until it completes with no shadowed names, since a
-   * shadowed skill can only be resolved by the user renaming one of the two.
+   * Callers refuse the write and name both paths instead, which makes the
+   * shadowed state impossible to create rather than merely reported after the
+   * fact. Returns the shadowing path, or null when the name is free.
    */
-  private async migrateExtensionSkillsToGlobalRoot(result: LegacySkillMigrationResult): Promise<void> {
-    if (path.resolve(this.legacyExtensionSkillsDir) === path.resolve(this.globalSkillsDir)) return;
-    if (await exists(this.extensionSkillsMigrationSentinelPath)) return;
-    if (!await exists(this.legacyExtensionSkillsDir)) return;
-
-    const entries = await fs.readdir(this.legacyExtensionSkillsDir, { withFileTypes: true });
-    let shadowed = 0;
-
-    for (const entry of entries) {
-      if (!entry.isDirectory() || entry.name.startsWith(".")) continue;
-
-      const sourceDir = path.join(this.legacyExtensionSkillsDir, entry.name);
-      if (!await exists(path.join(sourceDir, "SKILL.md"))) continue;
-
-      const targetDir = path.join(this.globalSkillsDir, entry.name);
-      if (await exists(path.join(targetDir, "SKILL.md"))) {
-        // Pi already loads the copy in its own root; ours was never reachable.
-        // Leave both in place rather than clobbering a skill we did not write.
-        shadowed++;
-        result.skipped++;
-        result.warnings.push(
-          `${entry.name}: already exists at ${targetDir}; the copy at ${sourceDir} was never loaded by Pi. `
-          + `Rename or delete one of them, then restart Pi.`,
-        );
-        continue;
-      }
-
-      try {
-        await fs.mkdir(path.dirname(targetDir), { recursive: true });
-        await fs.rename(sourceDir, targetDir);
-        result.migrated++;
-      } catch (error) {
-        shadowed++;
-        result.warnings.push(`${entry.name}: ${error instanceof Error ? error.message : String(error)}`);
-      }
-    }
-
-    if (shadowed === 0) {
-      await fs.mkdir(path.dirname(this.extensionSkillsMigrationSentinelPath), { recursive: true });
-      await fs.writeFile(this.extensionSkillsMigrationSentinelPath, `${new Date().toISOString()}\n`, "utf-8");
-      await fs.rm(this.legacyExtensionSkillsDir, { recursive: true, force: true });
-    }
+  private async findShadowingPiGlobalSkill(slug: string): Promise<string | null> {
+    if (path.resolve(this.piGlobalSkillsDir) === path.resolve(this.globalSkillsDir)) return null;
+    const candidate = path.join(this.piGlobalSkillsDir, slug, "SKILL.md");
+    return await exists(candidate) ? candidate : null;
   }
 
   async loadIndex(scope?: SkillScope): Promise<SkillIndex[]> {
@@ -449,6 +416,19 @@ export class SkillStore {
           error: `A near-name global skill already exists (${targetId}) but with different intent. Use a clearer differentiated name for the new skill, or patch/update the existing skill if the intent is actually the same.`,
           conflictType: "name-collision",
           similarSkillIds: collidingNameSkillIds,
+          suggestedAction: "rename",
+        };
+      }
+
+      const shadowedBy = await this.findShadowingPiGlobalSkill(slug);
+      if (shadowedBy) {
+        return {
+          success: false,
+          error: `Pi already loads a global skill named '${slug}' from ${shadowedBy}. `
+            + `Pi keys skills by name and loads its own root first, so a skill written to `
+            + `${path.join(this.globalSkillsDir, slug, "SKILL.md")} would never be the copy in effect. `
+            + `Choose a different name, or edit ${shadowedBy} directly.`,
+          conflictType: "name-collision",
           suggestedAction: "rename",
         };
       }

--- a/tests/handlers/resources-discover.test.ts
+++ b/tests/handlers/resources-discover.test.ts
@@ -29,7 +29,7 @@ describe("resources_discover skill path resolution", () => {
     const result = await handlers.resources_discover({ cwd: "/tmp/demo-repo" }, {});
     const expectedPath = path.join(AGENT_ROOT, "projects-memory", "demo-repo", "skills");
 
-    assert.deepStrictEqual(result, { skillPaths: [expectedPath] });
+    assert.deepStrictEqual(result, { skillPaths: ["/tmp/global-skills", expectedPath] });
   });
 
   it("returns project skillPaths and updates skill store context", () => {
@@ -45,7 +45,7 @@ describe("resources_discover skill path resolution", () => {
     const resource = resolveProjectSkillDiscovery(store, "projects-memory", cwd);
     const expectedPath = path.join(AGENT_ROOT, "projects-memory", "demo-repo", "skills");
 
-    assert.deepStrictEqual(resource, { skillPaths: [expectedPath] });
+    assert.deepStrictEqual(resource, { skillPaths: ["/tmp/global-skills", expectedPath] });
     assert.strictEqual(store.getProjectName(), "demo-repo");
     assert.strictEqual(store.getProjectSkillsDir(), expectedPath);
   });
@@ -61,10 +61,10 @@ describe("resources_discover skill path resolution", () => {
 
     const resource = resolveProjectSkillDiscovery(store, "projects-memory", os.homedir());
 
-    // The global root is Pi's own `~/.pi/agent/skills/`, which Pi already
-    // auto-discovers — contributing it again would make our copy of any
-    // same-named skill a permanent collision loser (#125, #126).
-    assert.deepStrictEqual(resource, { skillPaths: [] });
+    // Outside a project only the extension's own global root is contributed.
+    // It is a directory of ours, kept apart from the skills a user installed
+    // themselves, so Pi has to be told about it (#126).
+    assert.deepStrictEqual(resource, { skillPaths: ["/tmp/global-skills"] });
     assert.strictEqual(store.getProjectName(), null);
     assert.strictEqual(store.getProjectSkillsDir(), null);
   });

--- a/tests/store/skill-store.test.ts
+++ b/tests/store/skill-store.test.ts
@@ -13,19 +13,17 @@ let ROOT_DIR = "";
 let GLOBAL_SKILLS_DIR = "";
 let PROJECT_SKILLS_DIR = "";
 let LEGACY_SKILLS_DIR = "";
-let EXTENSION_SKILLS_DIR = "";
+let PI_GLOBAL_SKILLS_DIR = "";
 let MIGRATION_SENTINEL = "";
-let EXTENSION_MIGRATION_SENTINEL = "";
 
 async function makeStore(withProject = true): Promise<SkillStore> {
   return new SkillStore({
     globalSkillsDir: GLOBAL_SKILLS_DIR,
+    piGlobalSkillsDir: PI_GLOBAL_SKILLS_DIR,
     projectSkillsDir: withProject ? PROJECT_SKILLS_DIR : null,
     projectName: withProject ? "demo-project" : null,
     legacySkillsDir: LEGACY_SKILLS_DIR,
-    legacyExtensionSkillsDir: EXTENSION_SKILLS_DIR,
     migrationSentinelPath: MIGRATION_SENTINEL,
-    extensionSkillsMigrationSentinelPath: EXTENSION_MIGRATION_SENTINEL,
   });
 }
 
@@ -38,7 +36,7 @@ async function cleanSlate(): Promise<void> {
   await fs.mkdir(GLOBAL_SKILLS_DIR, { recursive: true });
   await fs.mkdir(PROJECT_SKILLS_DIR, { recursive: true });
   await fs.mkdir(LEGACY_SKILLS_DIR, { recursive: true });
-  await fs.mkdir(EXTENSION_SKILLS_DIR, { recursive: true });
+  await fs.mkdir(PI_GLOBAL_SKILLS_DIR, { recursive: true });
 }
 
 async function readFile(filePath: string): Promise<string> {
@@ -51,9 +49,8 @@ describe("SkillStore", { concurrency: 1 }, () => {
     GLOBAL_SKILLS_DIR = path.join(ROOT_DIR, "global-skills");
     PROJECT_SKILLS_DIR = path.join(ROOT_DIR, "project-skills");
     LEGACY_SKILLS_DIR = path.join(ROOT_DIR, "legacy-skills");
-    EXTENSION_SKILLS_DIR = path.join(ROOT_DIR, "extension-skills");
+    PI_GLOBAL_SKILLS_DIR = path.join(ROOT_DIR, "pi-global-skills");
     MIGRATION_SENTINEL = path.join(ROOT_DIR, ".skill-migration");
-    EXTENSION_MIGRATION_SENTINEL = path.join(ROOT_DIR, ".skill-migration-to-pi-global");
   });
 
   after(async () => {
@@ -619,46 +616,44 @@ describe("SkillStore", { concurrency: 1 }, () => {
       await fs.access(MIGRATION_SENTINEL);
     });
 
-    it("moves extension-owned global skills into Pi's global skills root", async () => {
-      const source = path.join(EXTENSION_SKILLS_DIR, "deploy-service");
-      await fs.mkdir(source, { recursive: true });
-      await fs.writeFile(path.join(source, "SKILL.md"), [
-        "---",
-        'name: "deploy-service"',
-        'display_name: "Deploy Service"',
-        'description: "Deploy the service"',
-        'version: "1"',
-        'created: "2026-01-01"',
-        'updated: "2026-01-02"',
-        "---",
-        "# Deploy",
-      ].join("\n"), "utf-8");
+  });
 
-      const result = await (await makeStore()).migrateLegacySkills();
+  describe("shadowing guard against Pi's own global skills root", () => {
+    it("writes global skills to the extension directory, never Pi's root", async () => {
+      const result = await (await makeStore()).create("deploy-service", "Deploy the service", "# Deploy", "global");
 
-      assert.strictEqual(result.migrated, 1);
+      assert.strictEqual(result.success, true);
       assert.ok((await readFile(path.join(GLOBAL_SKILLS_DIR, "deploy-service", "SKILL.md"))).includes("# Deploy"));
-      await assert.rejects(fs.access(EXTENSION_SKILLS_DIR));
-      await fs.access(EXTENSION_MIGRATION_SENTINEL);
+      // Skills the user installed themselves stay untouched by ours (#126).
+      await assert.rejects(fs.access(path.join(PI_GLOBAL_SKILLS_DIR, "deploy-service")));
     });
 
-    it("leaves a shadowed skill in place and reports it instead of clobbering Pi's copy", async () => {
-      const source = path.join(EXTENSION_SKILLS_DIR, "swarm-decompose");
-      await fs.mkdir(source, { recursive: true });
-      await fs.writeFile(path.join(source, "SKILL.md"), "---\nname: \"swarm-decompose\"\n---\n# Ours", "utf-8");
-      const existing = path.join(GLOBAL_SKILLS_DIR, "swarm-decompose");
-      await fs.mkdir(existing, { recursive: true });
-      await fs.writeFile(path.join(existing, "SKILL.md"), "---\nname: \"swarm-decompose\"\n---\n# Theirs", "utf-8");
+    it("refuses a global name Pi already loads instead of writing a shadowed copy", async () => {
+      const theirs = path.join(PI_GLOBAL_SKILLS_DIR, "swarm-decompose");
+      await fs.mkdir(theirs, { recursive: true });
+      await fs.writeFile(path.join(theirs, "SKILL.md"), "---\nname: \"swarm-decompose\"\n---\n# Theirs", "utf-8");
 
-      const result = await (await makeStore()).migrateLegacySkills();
+      const result = await (await makeStore()).create("swarm-decompose", "Decompose a swarm", "# Ours", "global");
 
-      assert.strictEqual(result.migrated, 0);
-      assert.strictEqual(result.skipped, 1);
-      assert.ok(result.warnings.some((warning) => warning.includes("swarm-decompose")));
-      assert.ok((await readFile(path.join(existing, "SKILL.md"))).includes("# Theirs"));
-      assert.ok((await readFile(path.join(source, "SKILL.md"))).includes("# Ours"));
-      // No sentinel: the user must resolve the shadowing, so this must retry.
-      await assert.rejects(fs.access(EXTENSION_MIGRATION_SENTINEL));
+      // Pi loads its own root first, so writing here would succeed on disk and
+      // change nothing about the agent's behaviour — the #125 write-loss bug.
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.conflictType, "name-collision");
+      assert.ok(result.error?.includes(path.join(theirs, "SKILL.md")));
+      await assert.rejects(fs.access(path.join(GLOBAL_SKILLS_DIR, "swarm-decompose")));
+      assert.ok((await readFile(path.join(theirs, "SKILL.md"))).includes("# Theirs"));
+    });
+
+    it("still allows a project skill to reuse a name taken in Pi's global root", async () => {
+      const theirs = path.join(PI_GLOBAL_SKILLS_DIR, "run-tests");
+      await fs.mkdir(theirs, { recursive: true });
+      await fs.writeFile(path.join(theirs, "SKILL.md"), "---\nname: \"run-tests\"\n---\n# Theirs", "utf-8");
+
+      const result = await (await makeStore()).create("run-tests", "Run this repo's tests", "# Ours", "project");
+
+      // Project skills are a different scope; only the global root collides.
+      assert.strictEqual(result.success, true);
+      assert.ok((await readFile(path.join(PROJECT_SKILLS_DIR, "run-tests", "SKILL.md"))).includes("# Ours"));
     });
   });
 


### PR DESCRIPTION
Reverts the directory move from #131 (v0.9.0) and fixes the underlying bug the way it should have been fixed. Reported by @kdejaeger on #126, within a day of 0.9.0 shipping.

## What went wrong

#125 was a real bug. Pi keys skills by name, first-loaded wins, and `~/.pi/agent/skills/` is auto-discovered at higher precedence than anything an extension contributes via `resources_discover`. A global skill written under a name already present there was never the copy Pi loaded — the write succeeded on disk, `skill_manage` reported success, and nothing changed about the agent's behaviour. Silent write-loss.

I fixed it by moving our global skills into Pi's own root, which eliminates the collision *class* by deleting one of the two directories.

**That bug never required the move.** It only fires on a name collision. And the move took a deliberate design property with it: skills this extension curates from sessions and skills the user installed themselves stopped being separable, so you could no longer wipe or audit ours without picking through yours.

The tell is in my own closing comment on #125, shipped as a footnote:

> `/memory-skills` now also lists hand-written skills in `~/.pi/agent/skills/`, and `skill_manage delete` can target them.

An expanded destructive blast radius over files we didn't create, filed under "consequences to be aware of."

## What this does

- **Global skills return to `~/.pi/agent/pi-hermes-memory/skills/`**, re-registered via `resources_discover`.
- **Write-time shadow guard** — the fix #125 should have received. `findShadowingPiGlobalSkill()` consults Pi's root **read-only**; a colliding global create is refused with an error naming both paths. The shadowed state becomes impossible to create rather than reported after the fact.
- **`skill_manage delete` is back inside our own blast radius.** `collectLocations()` no longer scans Pi's root, so this falls out of the revert rather than needing a special case.
- **`migrateExtensionSkillsToGlobalRoot()` and its sentinel are retired.**
- `SKILL_TOOL_DESCRIPTION` corrected.

Project scope is untouched throughout — only the global root collides.

## Why nothing is migrated back

Skills 0.9.0 already relocated **stay in Pi's root**. This is deliberate and it is a genuine limitation, not laziness:

- 0.9.0's migration did `fs.rename` per skill then `fs.rm`'d the source directory (`skill-store.ts:360,371` at `e69b24d`) — **no manifest**.
- Skill frontmatter carries `name`, `description`, `version`, `created`, `updated`, `display_name` (`skill-utils.ts:43-58`) — **no provenance field**.

So there is no reliable way to distinguish skills we moved from skills the user put there. Moving files out of someone's global root on a heuristic would be a worse version of the mistake being corrected. They keep working where they are; the changelog says so plainly. A confirmation-gated `/memory-skills reclaim` is the right follow-up **if anyone asks** — I'm not building it speculatively.

## README

The four references to `pi-hermes-memory/skills/` that 0.9.0 left stale (`README.md:45,230,297,567`) are correct again **without edits**. They described this design. @kdejaeger flagged the drift; the fact that the revert repairs it by itself is a reasonable signal about which design the docs were written for.

## Tests

Replaced the two migration tests with three guard tests:

- global creates land in the extension directory and leave Pi's root untouched
- a name Pi already loads is refused, error names the shadowing path, nothing is written, their file is unmodified
- project scope may still reuse a name taken in Pi's global root

`npx tsc --noEmit` clean; **all 40 test files pass**.

## Version

**0.9.1** — this restores the layout that shipped before 0.9.0 rather than introducing a new one, so it lands as a patch.

## Review

@ccacca11 — this partially reverses what you asked for, and you ranked "align paths" first in both #125 and #126. Your bug stays fixed; only the mechanism changes. If the write-time guard leaves a hole I've missed, I'd rather hear it before this ships.

Closes #126.

