### PR TITLE
fix: give auto-consolidation a viable timeout and surface its failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2026-07-30
+
+### Fixed
+
+- **Auto-consolidation no longer dies on a timeout the manual path never had** ([#136](https://github.com/chandra447/pi-hermes-memory/issues/136), reported by [@jasonrr](https://github.com/jasonrr)): `consolidationTimeoutMs` defaulted to 60s, but `/memory-consolidate` quietly floored itself at 180s while the over-capacity auto path passed the raw 60s straight to a `pi -p` child. A consolidation pays child-process boot plus a full LLM turn, so on stock defaults the auto path was killed mid-run every time — 100% failure on slower models or near-full memory, while manual runs of the same memory succeeded. The default is now **180000** and both paths use the configured value verbatim; the manual floor that hid the mismatch is gone. A configured value below the default is still honored, but `loadConfig` warns at startup that it is likely to be killed mid-run.
+- **Auto-consolidation failures are surfaced instead of swallowed** ([#135](https://github.com/chandra447/pi-hermes-memory/issues/135), reported by [@jasonrr](https://github.com/jasonrr)): `triggerConsolidation` returns a specific reason for every failure mode — lock contention, spawn failure, non-zero exit, timeout kill — and `MemoryStore` discarded all of it in a bare `catch {}`, returning the unchanged `Memory at N/M chars...` capacity error. Every mode looked identical to a memory that was simply full, and the auto path was undiagnosable from outside. The reason is now appended to the tool result (`... Auto-consolidation attempted but failed: <reason>`) and logged once per failure. A consolidation that ran successfully but freed no space is reported distinctly (`Auto-consolidation ran but did not free enough space.`), as is a reload failure after a successful consolidation.
+
 ## [0.9.1] - 2026-07-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ Create `~/.pi/agent/hermes-memory-config.json`:
   "failureInjectionEnabled": true,
   "failureInjectionMaxAgeDays": 7,
   "failureInjectionMaxEntries": 5,
-  "consolidationTimeoutMs": 60000,
+  "consolidationTimeoutMs": 180000,
   "flushOnCompact": true,
   "flushOnShutdown": true,
   "flushMinTurns": 6,
@@ -508,7 +508,7 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 | `reviewTransport` | `direct` | LLM transport for background review, session flush, correction save, and manual consolidation: `direct` uses in-process `completeSimple()` with subprocess fallback; `subprocess` forces legacy `pi -p` only |
 | `memoryOverflowStrategy` | `auto-consolidate` | Behavior when MEMORY.md, USER.md, failures.md, or project-scoped memory reaches its character limit: `auto-consolidate` runs the existing consolidation flow; `reject` returns an error; `fifo-evict` rotates older entries in file order until the new entry fits |
 | `autoConsolidate` | `true` | Legacy alias for `memoryOverflowStrategy` when `memoryOverflowStrategy` is not set (`true` = `auto-consolidate`, `false` = `reject`) |
-| `consolidationTimeoutMs` | `60000` | Maximum time in milliseconds for auto-consolidation to complete |
+| `consolidationTimeoutMs` | `180000` | Maximum time in milliseconds for a consolidation run (auto and `/memory-consolidate` alike). Configured values are used verbatim; a consolidation pays child-process boot plus a full LLM turn, so values below the default are frequently killed mid-run and log a warning at startup |
 | `correctionDetection` | `true` | Detect user corrections and save immediately |
 | `correctionStrongPatterns` | unset | Optional case-insensitive regex sources replacing strong correction patterns; omitted preserves defaults, invalid entries are ignored |
 | `correctionWeakPatterns` | unset | Optional case-insensitive regex sources replacing weak correction patterns; omitted preserves defaults, invalid entries are ignored |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hermes-memory",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-tui": "^0.80.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.9.1",
-  "description": "🧠 Persistent memory + 🔍 session search + 🛡️ secret scanning for Pi. Token-aware policy-only memory by default, SQLite FTS5 search, auto-consolidation, procedural skills. 693 tests. Ported from Hermes agent.",
+  "version": "0.9.2",
+  "description": "🧠 Persistent memory + 🔍 session search + 🛡️ secret scanning for Pi. Token-aware policy-only memory by default, SQLite FTS5 search, auto-consolidation, procedural skills. 732 tests. Ported from Hermes agent.",
   "type": "module",
   "main": "src/index.ts",
   "files": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -115,7 +115,15 @@ export function loadConfig(configPath = DEFAULT_CONFIG_PATH): MemoryConfig {
       if (isStringArray(parsed.correctionWeakPatterns)) config.correctionWeakPatterns = parsed.correctionWeakPatterns;
       if (isStringArray(parsed.correctionNegativePatterns)) config.correctionNegativePatterns = parsed.correctionNegativePatterns;
       if (isStringArray(parsed.correctionDirectiveWords)) config.correctionDirectiveWords = parsed.correctionDirectiveWords;
-      if (typeof parsed.consolidationTimeoutMs === "number") config.consolidationTimeoutMs = parsed.consolidationTimeoutMs;
+      if (typeof parsed.consolidationTimeoutMs === "number") {
+        config.consolidationTimeoutMs = parsed.consolidationTimeoutMs;
+        if (parsed.consolidationTimeoutMs < DEFAULT_CONSOLIDATION_TIMEOUT_MS) {
+          console.warn(
+            `⚠️ consolidationTimeoutMs is set to ${parsed.consolidationTimeoutMs}ms, below the ${DEFAULT_CONSOLIDATION_TIMEOUT_MS}ms default.`
+            + " Consolidation spawns a child agent turn and is routinely killed mid-run at lower values.",
+          );
+        }
+      }
       if (typeof parsed.failureInjectionEnabled === "boolean") config.failureInjectionEnabled = parsed.failureInjectionEnabled;
       if (typeof parsed.failureInjectionMaxAgeDays === "number") config.failureInjectionMaxAgeDays = parsed.failureInjectionMaxAgeDays;
       if (typeof parsed.failureInjectionMaxEntries === "number") config.failureInjectionMaxEntries = parsed.failureInjectionMaxEntries;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,7 +22,13 @@ export const DEFAULT_FLUSH_MIN_TURNS = 6;
 export const DEFAULT_NUDGE_TOOL_CALLS = 15;
 export const DEFAULT_REVIEW_RECENT_MESSAGES = 0;
 export const DEFAULT_FLUSH_RECENT_MESSAGES = 0;
-export const DEFAULT_CONSOLIDATION_TIMEOUT_MS = 60000;
+/**
+ * A consolidation run pays child-process boot plus a full LLM turn, which
+ * routinely exceeds 60s — at the old 60s default the auto path was killed
+ * mid-run on every attempt (#136). Configured values are honored verbatim,
+ * including lower ones; `loadConfig` warns when a value below this is set.
+ */
+export const DEFAULT_CONSOLIDATION_TIMEOUT_MS = 180000;
 export const DEFAULT_FAILURE_INJECTION_MAX_AGE_DAYS = 7;
 export const DEFAULT_FAILURE_INJECTION_MAX_ENTRIES = 5;
 

--- a/src/handlers/auto-consolidate.ts
+++ b/src/handlers/auto-consolidate.ts
@@ -20,7 +20,12 @@ import { createHash } from "node:crypto";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { MemoryStore } from "../store/memory-store.js";
 import { DatabaseManager } from "../store/db.js";
-import { CONSOLIDATION_PROMPT, DIRECT_CONSOLIDATION_SYSTEM_PROMPT, ENTRY_DELIMITER } from "../constants.js";
+import {
+  CONSOLIDATION_PROMPT,
+  DEFAULT_CONSOLIDATION_TIMEOUT_MS,
+  DIRECT_CONSOLIDATION_SYSTEM_PROMPT,
+  ENTRY_DELIMITER,
+} from "../constants.js";
 import type { ConsolidationResult, MemoryConfig } from "../types.js";
 import { AGENT_ROOT } from "../paths.js";
 import { execChildPrompt } from "./pi-child-process.js";
@@ -90,7 +95,7 @@ function describeConsolidationFailure(
   const terminated = result.killed || result.code === 124 || result.code === 143;
 
   if (terminated) {
-    return `Consolidation subprocess was terminated (likely timeout or cancellation). Timeout: ${timeoutMs}ms. Consider increasing consolidationTimeoutMs if this is a manual run.`;
+    return `Consolidation subprocess was terminated (likely timeout or cancellation). Timeout: ${timeoutMs}ms. Raise consolidationTimeoutMs if consolidation legitimately needs longer.`;
   }
 
   return `Consolidation process exited with code ${result.code}: ${stderr?.slice(0, 200) || "unknown error"}`;
@@ -101,7 +106,7 @@ export async function triggerConsolidation(
   store: MemoryStore,
   target: MemoryTarget,
   signal?: AbortSignal,
-  timeoutMs: number = 60000,
+  timeoutMs: number = DEFAULT_CONSOLIDATION_TIMEOUT_MS,
   toolTarget: ToolMemoryTarget = target,
   llmConfig: ConsolidationLlmConfig = {},
   directCtx: Pick<ExtensionContext, "model" | "modelRegistry"> | null = null,
@@ -196,7 +201,7 @@ export async function triggerConsolidation(
 export function registerConsolidateCommand(
   pi: ExtensionAPI,
   store: MemoryStore,
-  timeoutMs: number = 60000,
+  timeoutMs: number = DEFAULT_CONSOLIDATION_TIMEOUT_MS,
   projectStore: MemoryStore | null = null,
   projectName?: string | null,
   llmConfig: ConsolidationLlmConfig = {},
@@ -206,7 +211,6 @@ export function registerConsolidateCommand(
   pi.registerCommand("memory-consolidate", {
     description: "Manually trigger memory consolidation to free up space",
     handler: async (_args, ctx) => {
-      const manualTimeoutMs = Math.max(timeoutMs, 180000);
       const results: string[] = [];
       const targets: Array<{
         label: string;
@@ -260,7 +264,7 @@ export function registerConsolidateCommand(
           item.store,
           item.target,
           ctx.signal,
-          manualTimeoutMs,
+          timeoutMs,
           item.toolTarget,
           llmConfig,
           ctx,

--- a/src/index.ts
+++ b/src/index.ts
@@ -216,14 +216,34 @@ export default function (pi: ExtensionAPI) {
   setupSessionFlush(pi, store, projectStore, config, dbManager, projectName);
 
   // ── 7. Setup auto-consolidation (inject consolidator into stores) ──
-  store.setConsolidator(async (target, signal) => {
-    return triggerConsolidation(pi, store, target, signal, config.consolidationTimeoutMs, target, config);
-  });
+  // A failed auto-consolidation is otherwise invisible outside the tool result,
+  // so log the reason for whoever is watching the session (#135).
+  const runAutoConsolidation = async (
+    target: "memory" | "user" | "failure",
+    targetStore: MemoryStore,
+    toolTarget: "memory" | "user" | "failure" | "project",
+    signal?: AbortSignal,
+  ) => {
+    const result = await triggerConsolidation(
+      pi,
+      targetStore,
+      target,
+      signal,
+      config.consolidationTimeoutMs,
+      toolTarget,
+      config,
+    );
+    if (!result.consolidated) {
+      console.warn(`⚠️ Auto-consolidation failed for '${toolTarget}': ${result.error ?? "no reason reported"}`);
+    }
+    return result;
+  };
+
+  store.setConsolidator((target, signal) => runAutoConsolidation(target, store, target, signal));
   if (projectStore) {
-    projectStore.setConsolidator(async (target, signal) => {
-      const toolTarget = target === "memory" ? "project" : target;
-      return triggerConsolidation(pi, projectStore, target, signal, config.consolidationTimeoutMs, toolTarget, config);
-    });
+    projectStore.setConsolidator((target, signal) =>
+      runAutoConsolidation(target, projectStore, target === "memory" ? "project" : target, signal),
+    );
   }
   registerConsolidateCommand(pi, store, config.consolidationTimeoutMs, projectStore, projectName, config, dbManager);
 

--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -243,15 +243,26 @@ export class MemoryStore {
       return result;
     }
 
-    try {
-      const consolidation = await this.consolidator(target, signal);
-      if (consolidation.consolidated) {
-        await this.loadFromDisk();
-        return this.addWithConsolidation(target, content, signal, retriesLeft - 1, addedMessage, project);
-      }
-    } catch {
+    // Every failure mode (lock contention, spawn failure, non-zero exit, timeout
+    // kill) used to be swallowed here and present identically to a plain capacity
+    // error, making the auto path impossible to diagnose from outside (#135).
+    const consolidation = await this.consolidator(target, signal).catch(
+      (err): ConsolidationResult => ({ consolidated: false, error: `consolidator threw ${String(err).slice(0, 200)}` }),
+    );
+    if (!consolidation.consolidated) {
+      const reason = consolidation.error || "no reason reported";
+      return { ...result, error: `${result.error} Auto-consolidation attempted but failed: ${reason}` };
     }
-    return result;
+
+    try {
+      await this.loadFromDisk();
+    } catch (err) {
+      return { ...result, error: `${result.error} Auto-consolidation succeeded but reloading memory failed: ${String(err).slice(0, 200)}` };
+    }
+
+    const retried = await this.addWithConsolidation(target, content, signal, retriesLeft - 1, addedMessage, project);
+    if (retried.success || !retried.error?.startsWith("Memory at ")) return retried;
+    return { ...retried, error: `${retried.error} Auto-consolidation ran but did not free enough space.` };
   }
 
   private async fifoEvictAndAdd(

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,7 +80,7 @@ export interface MemoryConfig {
   failureInjectionMaxEntries: number;
   /** Tool calls before triggering background review (in addition to turn count). Default: 15 */
   nudgeToolCalls: number;
-  /** Maximum time in milliseconds for auto-consolidation to complete. Default: 60000 */
+  /** Maximum time in milliseconds for a consolidation run, auto or manual. Default: 180000 */
   consolidationTimeoutMs: number;
 }
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -30,6 +30,7 @@ describe("loadConfig", () => {
     assert.strictEqual(config.flushRecentMessages, 0);
     assert.strictEqual(config.memoryOverflowStrategy, "auto-consolidate");
     assert.strictEqual(config.autoConsolidate, true);
+    assert.strictEqual(config.consolidationTimeoutMs, 180000);
     assert.strictEqual(config.failureInjectionEnabled, true);
     assert.strictEqual(config.failureInjectionMaxAgeDays, 7);
     assert.strictEqual(config.failureInjectionMaxEntries, 5);
@@ -37,6 +38,30 @@ describe("loadConfig", () => {
     assert.deepStrictEqual(config.sessionSearch, { variant: "legacy" });
     assert.strictEqual(config.llmModelOverride, undefined);
     assert.strictEqual(config.llmThinkingOverride, undefined);
+  });
+
+  it("honors a configured consolidationTimeoutMs, warning only when it is below the default", () => {
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (message?: unknown) => { warnings.push(String(message)); };
+
+    try {
+      fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({ consolidationTimeoutMs: 300000 }));
+      assert.strictEqual(loadConfig(TEST_CONFIG_PATH).consolidationTimeoutMs, 300000);
+      assert.deepStrictEqual(warnings, [], "a value above the default should not warn");
+
+      fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({ consolidationTimeoutMs: 60000 }));
+      assert.strictEqual(
+        loadConfig(TEST_CONFIG_PATH).consolidationTimeoutMs,
+        60000,
+        "a lower configured value must be honored, not clamped",
+      );
+      assert.strictEqual(warnings.length, 1, "a sub-default value should warn once");
+      assert.match(warnings[0], /60000ms.*below the 180000ms default/);
+    } finally {
+      console.warn = originalWarn;
+    }
   });
 
   it("overrides defaults when config file exists", () => {

--- a/tests/handlers/auto-consolidate.test.ts
+++ b/tests/handlers/auto-consolidate.test.ts
@@ -12,7 +12,7 @@ import { registerConsolidateCommand, triggerConsolidation } from "../../src/hand
 import { resolveWatchedChildPiInvocation } from "../../src/handlers/pi-child-process.js";
 import { MemoryStore } from "../../src/store/memory-store.js";
 import { AtomicLockCoordinator } from "../../src/store/atomic-lock-coordinator.js";
-import { ENTRY_DELIMITER } from "../../src/constants.js";
+import { DEFAULT_CONSOLIDATION_TIMEOUT_MS, ENTRY_DELIMITER } from "../../src/constants.js";
 
 // ─── Mock infrastructure ───
 
@@ -98,6 +98,27 @@ const mockStore = {
 
 async function settle(ms = 10) {
   await new Promise((r) => setTimeout(r, ms));
+}
+
+type ManualCommandHandler = (args: unknown, ctx: unknown) => Promise<void>;
+
+async function runManualConsolidate(timeoutMs?: number): Promise<void> {
+  let handler: ManualCommandHandler | undefined;
+  const pi = {
+    on: () => {},
+    exec: async (...args: unknown[]) => {
+      execCalls.push(captureExecArgs(args as Parameters<typeof captureExecArgs>[0]));
+      return { code: 0, stdout: "Done", stderr: "" };
+    },
+    registerTool: () => {},
+    registerCommand: (_name: string, command: { handler: ManualCommandHandler }) => {
+      handler = command.handler;
+    },
+  } as unknown as Parameters<typeof registerConsolidateCommand>[0];
+
+  registerConsolidateCommand(pi, mockStore, timeoutMs);
+  assert.ok(handler, "command handler should be registered");
+  await handler({}, { signal: undefined, ui: { notify: () => {} } });
 }
 
 // ─── Tests ───
@@ -543,30 +564,22 @@ describe("registerConsolidateCommand", () => {
     assert.ok(finalNotification.includes("project:demo-project: ✅ consolidated"), "final notification should include project result");
   });
 
-  it("uses a longer timeout floor for the manual consolidate command", async () => {
-    let handler: any;
+  it("passes the configured timeout through to the manual consolidate child", async () => {
+    await runManualConsolidate(240000);
 
-    const pi = {
-      on: () => {},
-      exec: async (...args: any[]) => {
-        execCalls.push(captureExecArgs(args));
-        return { code: 0, stdout: "Done", stderr: "" };
-      },
-      registerTool: () => {},
-      registerCommand: (_name: string, command: any) => {
-        handler = command.handler;
-      },
-    } as any;
-
-    registerConsolidateCommand(pi, mockStore, 60000);
-    await handler({}, {
-      signal: undefined,
-      ui: { notify: () => {} },
-    });
-
+    assert.ok(execCalls.length > 0, "manual consolidation should spawn children");
     for (const call of execCalls) {
-      assert.strictEqual(call[1][1], "180000");
-      assert.strictEqual(call[2]?.timeout, 185000);
+      assert.strictEqual(call[1][1], "240000");
+      assert.strictEqual(call[2]?.timeout, 245000);
+    }
+  });
+
+  it("defaults the manual consolidate command to the shared consolidation timeout", async () => {
+    await runManualConsolidate();
+
+    assert.ok(execCalls.length > 0, "manual consolidation should spawn children");
+    for (const call of execCalls) {
+      assert.strictEqual(call[1][1], String(DEFAULT_CONSOLIDATION_TIMEOUT_MS));
     }
   });
 
@@ -761,5 +774,80 @@ describe("MemoryStore auto-consolidation integration", () => {
     const result = await store.add("memory", "x".repeat(60));
     assert.ok(!result.success, "should return error");
     assert.ok(result.error!.includes("exceed"), "should mention exceeding limit");
+  });
+
+  async function storeWithConsolidator(
+    dirName: string,
+    consolidator: () => Promise<{ consolidated: boolean; error?: string }>,
+  ): Promise<MemoryStore> {
+    const store = new MemoryStore({
+      memoryCharLimit: 120,
+      userCharLimit: 120,
+      nudgeInterval: 10,
+      reviewEnabled: false,
+      flushOnCompact: false,
+      flushOnShutdown: false,
+      flushMinTurns: 6,
+      autoConsolidate: true,
+      correctionDetection: false,
+      nudgeToolCalls: 15,
+      memoryDir: path.join(MEMORY_DIR, dirName),
+    });
+    store.setConsolidator(consolidator);
+    await store.loadFromDisk();
+    await store.add("memory", "a".repeat(60));
+    return store;
+  }
+
+  it("add() surfaces the reason a failed auto-consolidation reported", async () => {
+    const store = await storeWithConsolidator("reason", async () => ({
+      consolidated: false,
+      error: "Consolidation subprocess was terminated (likely timeout or cancellation). Timeout: 180000ms.",
+    }));
+
+    const result = await store.add("memory", "b".repeat(20));
+
+    assert.ok(!result.success, "over-capacity add should still fail");
+    assert.ok(result.error!.startsWith("Memory at "), "original capacity error must be preserved");
+    assert.ok(
+      result.error!.includes("Auto-consolidation attempted but failed: Consolidation subprocess was terminated"),
+      `expected the consolidation reason to be appended, got: ${result.error}`,
+    );
+  });
+
+  it("add() reports a reasonless consolidation failure instead of staying silent", async () => {
+    const store = await storeWithConsolidator("reasonless", async () => ({ consolidated: false }));
+
+    const result = await store.add("memory", "b".repeat(20));
+
+    assert.ok(result.error!.includes("Auto-consolidation attempted but failed: no reason reported"), result.error);
+  });
+
+  it("add() surfaces a consolidator that throws", async () => {
+    const store = await storeWithConsolidator("throws", async () => {
+      throw new Error("spawn ENOENT");
+    });
+
+    const result = await store.add("memory", "b".repeat(20));
+
+    assert.ok(!result.success, "a thrown consolidator must not surface as success");
+    assert.ok(result.error!.includes("consolidator threw"), result.error);
+    assert.ok(result.error!.includes("spawn ENOENT"), result.error);
+  });
+
+  it("add() distinguishes a consolidation that ran but freed nothing", async () => {
+    const store = await storeWithConsolidator("no-space", async () => ({ consolidated: true }));
+
+    const result = await store.add("memory", "b".repeat(20));
+
+    assert.ok(!result.success, "add should still fail when nothing was freed");
+    assert.ok(
+      result.error!.includes("Auto-consolidation ran but did not free enough space."),
+      result.error,
+    );
+    assert.ok(
+      !result.error!.includes("attempted but failed"),
+      "a successful-but-ineffective consolidation is not a consolidation failure",
+    );
   });
 });


### PR DESCRIPTION
Fixes #135, fixes #136 — both reported by @jasonrr. Same root cause from two angles: the auto over-capacity consolidation path was under-budgeted *and* unobservable, so on stock defaults it failed 100% of the time while looking like it never ran.

## #136 — the auto path was systematically killed

`consolidationTimeoutMs` defaulted to **60s**, and the two paths disagreed about it:

- `/memory-consolidate` quietly floored itself: `Math.max(timeoutMs, 180000)`.
- The auto path passed raw `config.consolidationTimeoutMs` to `triggerConsolidation`, which for `MemoryStore` is always the subprocess path.

A consolidation pays child-process boot plus a full LLM turn. At 60s the child was killed mid-run every time, while a manual consolidation of the same memory succeeded — exactly what the reporter measured (tool result returning at 60.08s).

**Change:** `DEFAULT_CONSOLIDATION_TIMEOUT_MS` is now `180000`, and both paths use the configured value **verbatim** — the manual floor is gone, so the two paths can no longer drift apart. Per maintainer direction, config is honored rather than clamped: a configured value below the default still applies, but `loadConfig` warns once at startup that it is likely to be killed mid-run.

## #135 — every failure mode looked like a full memory

`triggerConsolidation` returns a specific reason for each failure (lock contention, spawn failure, non-zero exit, timeout kill via `describeConsolidationFailure`). `MemoryStore.addWithConsolidation` threw all of it away:

```ts
try {
  const consolidation = await this.consolidator(target, signal);
  if (consolidation.consolidated) { /* reload + retry */ }
} catch {
}
return result;  // original "Memory at ..." error, unchanged
```

**Change:** the reason is appended to the returned error and logged once where the consolidator is wired:

```
Memory at 105/120 chars. Adding this entry (30 chars) would exceed the limit.
Replace or remove existing entries first. Auto-consolidation attempted but failed:
Consolidation subprocess was terminated (likely timeout or cancellation).
Timeout: 180000ms. Raise consolidationTimeoutMs if consolidation legitimately needs longer.
```

Three states that previously collapsed into one message are now distinct:

| State | Reported as |
|---|---|
| Consolidation failed | `Auto-consolidation attempted but failed: <reason>` |
| Failed with no reason | `... failed: no reason reported` |
| Consolidator threw | `... failed: consolidator threw <err>` |
| Succeeded, freed nothing | `Auto-consolidation ran but did not free enough space.` |
| Succeeded, reload failed | `Auto-consolidation succeeded but reloading memory failed: <err>` |

The `catch` around the consolidator is now narrow, so a reload or retry failure is attributed correctly instead of being mislabelled as a consolidation failure.

## Files

- `src/constants.ts` — default 60000 → 180000, with the reasoning inline
- `src/config.ts` — warn when a configured value is below the default
- `src/handlers/auto-consolidate.ts` — drop the manual `Math.max` floor; default params from the constant; reword the termination message now that both paths share one budget
- `src/store/memory-store.ts` — propagate the consolidation reason; narrow the `catch`
- `src/index.ts` — one `runAutoConsolidation` wrapper for both stores that logs a failed auto-consolidation
- `README.md`, `src/types.ts` — document the new default and the honored-verbatim behavior

## Verification

- Full suite: **732 tests, 0 failures**, `tsc --noEmit` clean.
- New tests: configured timeout reaches the child verbatim (240000 → `240000`); manual command defaults to the shared constant; config honors a sub-default value and warns exactly once; the four consolidation-outcome messages above.
- Updated `uses a longer timeout floor for the manual consolidate command` → now asserts the configured value passes through unchanged, since the floor it guarded is intentionally removed.
- Smoke test through a real `MemoryStore` + real `triggerConsolidation` with a `pi.exec` that simulates the timeout kill: child watchdog receives `180000`, the warning is logged, and the tool result carries the reason (output quoted above).

## Not in scope

Letting the auto path use the in-process direct transport (issue #136's alternative suggestion) — `MemoryStore` has no runtime context, and plumbing one in is a bigger change than the timeout mismatch these issues are about. With a 180s budget the subprocess path has ample headroom.
