### PR TITLE
feat(ui): add expandable tool result views

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-tui": "^0.80.2",
-        "better-sqlite3": "^12.9.0"
+        "better-sqlite3": "^12.9.0",
+        "strip-ansi": "7.2.0"
       },
       "devDependencies": {
         "@earendil-works/pi-ai": "^0.80.2",
@@ -3269,6 +3270,18 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -4109,6 +4122,21 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   },
   "dependencies": {
     "@earendil-works/pi-tui": "^0.80.2",
-    "better-sqlite3": "^12.9.0"
+    "better-sqlite3": "^12.9.0",
+    "strip-ansi": "7.2.0"
   }
 }

--- a/src/tools/memory-search-tool.ts
+++ b/src/tools/memory-search-tool.ts
@@ -4,6 +4,8 @@ import { StringEnum } from "@earendil-works/pi-ai";
 import { DatabaseManager } from '../store/db.js';
 import { searchMemories, getMemoryStats } from '../store/sqlite-memory-store.js';
 import type { MemoryCategory } from '../types.js';
+import { createSharedToolResultRenderer } from './shared-output-view.js';
+import { searchResultView } from './tool-result-views.js';
 
 interface SearchResult {
   success: boolean;
@@ -31,6 +33,7 @@ Returns matching memory entries with project context and dates.`,
       'Use memory_search to find project-specific memories or user preferences.',
       'Use memory_search with category filter to find specific types of memories (failure, correction, insight, etc.).',
     ],
+    renderResult: createSharedToolResultRenderer(searchResultView),
     parameters: Type.Object({
       query: Type.String({ description: 'Search query. Use natural language or specific terms.' }),
       project: Type.Optional(Type.String({ description: 'Filter by project name. Pass null for global memories only.' })),

--- a/src/tools/memory-tool.ts
+++ b/src/tools/memory-tool.ts
@@ -20,6 +20,8 @@ import {
 } from "../store/sqlite-memory-store.js";
 import { MEMORY_TOOL_DESCRIPTION } from "../constants.js";
 import type { MemoryCategory, MemoryResult } from "../types.js";
+import { createSharedToolResultRenderer } from "./shared-output-view.js";
+import { memoryResultView } from "./tool-result-views.js";
 
 function appendSyncWarning(result: MemoryResult, warning: string): MemoryResult {
   const warnings = [...(((result as any).warnings ?? []) as string[]), warning];
@@ -241,6 +243,7 @@ export function registerMemoryTool(
       "Do NOT use memory for temporary task state, TODO items, or session progress — only for durable, cross-session facts.",
       "Use target='failure' with category to save what didn't work (failures, corrections, insights).",
     ],
+    renderResult: createSharedToolResultRenderer(memoryResultView),
     parameters: Type.Object({
       action: StringEnum(["add", "replace", "remove"] as const),
       target: StringEnum(["memory", "user", "project", "failure"] as const),

--- a/src/tools/session-search-tool.ts
+++ b/src/tools/session-search-tool.ts
@@ -8,6 +8,8 @@ import { searchSessionAnchors } from '../store/session-anchor-search.js';
 import type { SessionAnchorRange, SessionAnchorSearchResult } from '../store/session-anchor-search.js';
 import type { SessionSearchConfig } from '../types.js';
 import { AGENT_ROOT } from '../paths.js';
+import { createSharedToolResultRenderer } from './shared-output-view.js';
+import { searchResultView } from './tool-result-views.js';
 
 interface SearchResult {
   success: boolean;
@@ -90,6 +92,7 @@ exclude:
       'Request source anchors, not summaries or previews.',
       'Use all for required terms, any for alternatives, and exclude for terms that must not appear in a returned range.',
     ],
+    renderResult: createSharedToolResultRenderer(searchResultView),
     parameters: Type.Object({
       markdown: Type.String({ description: 'Markdown request with optional from/to/cwd/limit fields and all/any/exclude lists.' }),
     }),
@@ -157,6 +160,7 @@ Returns bounded conversation snippets with session dates and project context. La
       'Use session_search when the user asks about previous discussions or past work.',
       'Use session_search when you need context from earlier sessions.',
     ],
+    renderResult: createSharedToolResultRenderer(searchResultView),
     parameters: Type.Object({
       query: Type.String({ description: 'Search query. Use natural language or specific terms.' }),
       project: Type.Optional(Type.String({ description: 'Filter by project name (optional).' })),

--- a/src/tools/shared-output-view.ts
+++ b/src/tools/shared-output-view.ts
@@ -103,7 +103,14 @@ function renderView(
   theme: SharedOutputTheme | undefined,
   background: ToolCardBackground,
 ): Component {
-  if (options.expanded) return new Text(view.expandedText || view.summary, 0, 0);
+  if (options.expanded) {
+    return new Text(
+      view.expandedText || view.summary,
+      0,
+      0,
+      (line) => restoreBackground(line, background, theme),
+    );
+  }
 
   return {
     render(width: number): string[] {
@@ -127,20 +134,6 @@ function renderView(
     },
     invalidate(): void {},
   };
-}
-
-export function renderSharedToolResult(
-  result: unknown,
-  options: ToolRenderResultOptions,
-  theme?: SharedOutputTheme,
-): Component {
-  const view = normalizeSharedOutputView(result);
-  const background: ToolCardBackground = options.isPartial
-    ? "toolPendingBg"
-    : view.status === "failure"
-      ? "toolErrorBg"
-      : "toolSuccessBg";
-  return renderView(view, options, theme, background);
 }
 
 export function createSharedToolResultRenderer(

--- a/src/tools/shared-output-view.ts
+++ b/src/tools/shared-output-view.ts
@@ -1,4 +1,5 @@
 import { keyHint, type ToolRenderResultOptions } from "@earendil-works/pi-coding-agent";
+import stripAnsi from "strip-ansi";
 import {
   Text,
   sliceByColumn,
@@ -38,6 +39,12 @@ function textBlocks(content: unknown): string[] {
   });
 }
 
+function sanitizeDisplayText(text: string): string {
+  return stripAnsi(text).replace(/[\p{Cc}\p{Cs}\uFFF9-\uFFFB]/gu, (character) =>
+    character === "\n" || character === "\t" ? character : ""
+  );
+}
+
 function firstLine(text: string): string {
   return text.split(/\r?\n/).find((line) => line.trim())?.trim() ?? "";
 }
@@ -52,12 +59,13 @@ function reason(details: Record<string, unknown> | null): string {
 export function normalizeSharedOutputView(input: unknown): SharedOutputView {
   const result = record(input);
   const details = record(result?.details);
-  const expandedText = textBlocks(result?.content).join("\n");
+  const expandedText = sanitizeDisplayText(textBlocks(result?.content).join("\n"));
+  const detailsReason = sanitizeDisplayText(reason(details));
   const failure = result?.isError === true || details?.success === false || details?.isError === true;
   const status: SharedStatus = failure ? "failure" : expandedText.trim() ? "success" : "empty";
   const summary = failure
-    ? reason(details) || firstLine(expandedText) || "Error"
-    : firstLine(expandedText) || reason(details) || "No output";
+    ? detailsReason || firstLine(expandedText) || "Error"
+    : firstLine(expandedText) || detailsReason || "No output";
   return { summary, expandedText, status };
 }
 
@@ -146,10 +154,15 @@ export function createSharedToolResultRenderer(
     context?: { isError?: boolean },
   ): Component => {
     const adapted = adapt(result);
-    const view = context?.isError ? { ...adapted, status: "failure" as const } : adapted;
+    const displayView = {
+      ...adapted,
+      summary: sanitizeDisplayText(adapted.summary),
+      expandedText: sanitizeDisplayText(adapted.expandedText),
+    };
+    const view = context?.isError ? { ...displayView, status: "failure" as const } : displayView;
     const background: ToolCardBackground = options.isPartial
       ? "toolPendingBg"
-      : view.status === "failure"
+      : context?.isError
         ? "toolErrorBg"
         : "toolSuccessBg";
     return renderView(view, options, theme, background);

--- a/src/tools/shared-output-view.ts
+++ b/src/tools/shared-output-view.ts
@@ -1,0 +1,164 @@
+import { keyHint, type ToolRenderResultOptions } from "@earendil-works/pi-coding-agent";
+import {
+  Text,
+  sliceByColumn,
+  truncateToWidth,
+  visibleWidth,
+  type Component,
+} from "@earendil-works/pi-tui";
+
+export type SharedStatus = "success" | "failure" | "empty";
+
+export interface SharedOutputView {
+  summary: string;
+  expandedText: string;
+  status: SharedStatus;
+}
+
+interface SharedOutputTheme {
+  fg?: (color: any, text: string) => string;
+  getBgAnsi?: (color: any) => string;
+}
+
+type ToolCardBackground = "toolPendingBg" | "toolSuccessBg" | "toolErrorBg";
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function textBlocks(content: unknown): string[] {
+  if (!Array.isArray(content)) return [];
+  return content.flatMap((item) => {
+    const block = record(item);
+    return block?.type === "text" && typeof block.text === "string"
+      ? [block.text]
+      : [];
+  });
+}
+
+function firstLine(text: string): string {
+  return text.split(/\r?\n/).find((line) => line.trim())?.trim() ?? "";
+}
+
+function reason(details: Record<string, unknown> | null): string {
+  for (const value of [details?.error, details?.message, details?.reason]) {
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return "";
+}
+
+export function normalizeSharedOutputView(input: unknown): SharedOutputView {
+  const result = record(input);
+  const details = record(result?.details);
+  const expandedText = textBlocks(result?.content).join("\n");
+  const failure = result?.isError === true || details?.success === false || details?.isError === true;
+  const status: SharedStatus = failure ? "failure" : expandedText.trim() ? "success" : "empty";
+  const summary = failure
+    ? reason(details) || firstLine(expandedText) || "Error"
+    : firstLine(expandedText) || reason(details) || "No output";
+  return { summary, expandedText, status };
+}
+
+function themed(
+  theme: SharedOutputTheme | undefined,
+  status: SharedStatus,
+  partial: boolean,
+  text: string,
+): string {
+  if (typeof theme?.fg !== "function") return text;
+  const color = partial ? "warning" : status === "failure" ? "error" : status === "empty" ? "muted" : "toolOutput";
+  return theme.fg(color, text);
+}
+
+function restoreBackground(
+  text: string,
+  background: ToolCardBackground,
+  theme: SharedOutputTheme | undefined,
+): string {
+  if (typeof theme?.getBgAnsi !== "function") return text;
+  const backgroundAnsi = theme.getBgAnsi(background);
+  return text.replace(/\x1b\[[0-?]*[ -/]*m/g, `$&${backgroundAnsi}`);
+}
+
+function compactSummary(summary: string, width: number, preserveTail: boolean): string {
+  if (visibleWidth(summary) <= width) return summary;
+  if (!preserveTail || width < 13) return truncateToWidth(summary, width, "…");
+
+  const tailWidth = Math.max(6, Math.floor(width / 2));
+  const headWidth = Math.max(3, width - tailWidth - 1);
+  const fullWidth = visibleWidth(summary);
+  return `${sliceByColumn(summary, 0, headWidth, true)}…${sliceByColumn(
+    summary,
+    Math.max(0, fullWidth - tailWidth),
+    tailWidth,
+    true,
+  )}`;
+}
+
+function renderView(
+  view: SharedOutputView,
+  options: ToolRenderResultOptions,
+  theme: SharedOutputTheme | undefined,
+  background: ToolCardBackground,
+): Component {
+  if (options.expanded) return new Text(view.expandedText || view.summary, 0, 0);
+
+  return {
+    render(width: number): string[] {
+      const availableWidth = Math.max(1, width);
+      const partialPrefix = options.isPartial && !/progress|partial|in progress|处理中/i.test(view.summary)
+        ? "In progress: "
+        : "";
+      const fullSummary = `${partialPrefix}${view.summary}`;
+      const hasHiddenText = view.expandedText.trim() !== view.summary.trim();
+      const hint = hasHiddenText ? ` (${keyHint("app.tools.expand", "to expand")})` : "";
+      const hintWidth = visibleWidth(hint);
+      const visibleHint = hintWidth < availableWidth ? hint : "";
+      const summaryWidth = Math.max(1, availableWidth - visibleWidth(visibleHint));
+      const summary = compactSummary(
+        fullSummary,
+        summaryWidth,
+        view.status === "failure" || /warning/i.test(fullSummary),
+      );
+      const line = themed(theme, view.status, options.isPartial, `${summary}${visibleHint}`);
+      return [restoreBackground(line, background, theme)];
+    },
+    invalidate(): void {},
+  };
+}
+
+export function renderSharedToolResult(
+  result: unknown,
+  options: ToolRenderResultOptions,
+  theme?: SharedOutputTheme,
+): Component {
+  const view = normalizeSharedOutputView(result);
+  const background: ToolCardBackground = options.isPartial
+    ? "toolPendingBg"
+    : view.status === "failure"
+      ? "toolErrorBg"
+      : "toolSuccessBg";
+  return renderView(view, options, theme, background);
+}
+
+export function createSharedToolResultRenderer(
+  adapt: (result: unknown) => SharedOutputView = normalizeSharedOutputView,
+) {
+  return (
+    result: unknown,
+    options: ToolRenderResultOptions,
+    theme: SharedOutputTheme,
+    context?: { isError?: boolean },
+  ): Component => {
+    const adapted = adapt(result);
+    const view = context?.isError ? { ...adapted, status: "failure" as const } : adapted;
+    const background: ToolCardBackground = options.isPartial
+      ? "toolPendingBg"
+      : view.status === "failure"
+        ? "toolErrorBg"
+        : "toolSuccessBg";
+    return renderView(view, options, theme, background);
+  };
+}

--- a/src/tools/skill-tool.ts
+++ b/src/tools/skill-tool.ts
@@ -8,6 +8,8 @@ import { Type } from "typebox";
 import { StringEnum } from "@earendil-works/pi-ai";
 import { SkillStore } from "../store/skill-store.js";
 import { SKILL_TOOL_DESCRIPTION } from "../constants.js";
+import { createSharedToolResultRenderer } from "./shared-output-view.js";
+import { skillResultView } from "./tool-result-views.js";
 
 function normalizeTextList(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
@@ -103,6 +105,7 @@ export function registerSkillTool(pi: ExtensionAPI, store: SkillStore): void {
       "Use 'view' before patching or updating when you need to inspect an existing skill.",
       "Do NOT use skills for temporary task state — only for durable, reusable procedures.",
     ],
+    renderResult: createSharedToolResultRenderer(skillResultView),
     parameters: SKILL_TOOL_PARAMETERS,
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const skillParams = params as {

--- a/src/tools/tool-result-views.ts
+++ b/src/tools/tool-result-views.ts
@@ -1,0 +1,96 @@
+import type { SharedOutputView } from "./shared-output-view.js";
+import { normalizeSharedOutputView } from "./shared-output-view.js";
+
+function record(value: unknown): Record<string, any> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, any>
+    : null;
+}
+
+function resultData(result: unknown): Record<string, any> | null {
+  const resultRecord = record(result);
+  const details = record(resultRecord?.details);
+  if (details && Object.keys(details).length > 0) return details;
+
+  const content = resultRecord?.content;
+  if (!Array.isArray(content) || content.length !== 1) return null;
+  const text = record(content[0])?.text;
+  if (typeof text !== "string" || !text.trimStart().startsWith("{")) return null;
+  try {
+    return record(JSON.parse(text));
+  } catch {
+    return null;
+  }
+}
+
+function firstText(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+function warningText(data: Record<string, any>): string | null {
+  const warnings = Array.isArray(data.warnings)
+    ? data.warnings.filter((value: unknown) => typeof value === "string" && value.trim())
+    : [];
+  return firstText(data.warning, ...warnings);
+}
+
+export function memoryResultView(result: unknown): SharedOutputView {
+  const base = normalizeSharedOutputView(result);
+  const data = resultData(result);
+  if (!data) return base;
+
+  if (data.success === false || (data.success !== true && firstText(data.error))) {
+    const failureReason = firstText(data.error, data.message);
+    return { ...base, status: "failure", summary: failureReason ? `Error · ${failureReason}` : "Error" };
+  }
+  if (data.success !== true) return base;
+
+  const primaryMessage = (firstText(data.message) ?? "").split(/\s*\bWarning:/)[0].trim();
+  const evicted = typeof data.evicted_count === "number"
+    ? data.evicted_count
+    : Array.isArray(data.evicted_entries)
+      ? data.evicted_entries.length
+      : 0;
+  const outcome = /^Entry added\.$/.test(primaryMessage) || /^Failure memory saved:/.test(primaryMessage) || evicted > 0
+    ? "Saved"
+    : /^Entry replaced\.$/.test(primaryMessage)
+      ? "Replaced"
+      : /^Entry removed\.$/.test(primaryMessage)
+        ? "Removed"
+        : /^Entry already exists/.test(primaryMessage)
+          ? "Unchanged"
+          : "Updated";
+  const parts = [outcome];
+  if (typeof data.target === "string" && data.target.trim()) parts.push(`target: ${data.target.trim()}`);
+  if (typeof data.category === "string" && data.category.trim()) parts.push(`category: ${data.category.trim()}`);
+  if (evicted > 0) parts.push(`evicted: ${evicted}`);
+  if (typeof data.entry_count === "number") parts.push(`${data.entry_count} ${data.entry_count === 1 ? "entry" : "entries"}`);
+  if (typeof data.usage === "string" && data.usage.trim()) parts.push(data.usage.trim());
+  const warning = warningText(data);
+  if (warning) parts.push(`Warning: ${warning}`);
+  return { ...base, status: "success", summary: parts.join(" · ") };
+}
+
+export function searchResultView(result: unknown): SharedOutputView {
+  const base = normalizeSharedOutputView(result);
+  const data = resultData(result);
+  if (!data || data.success === false) return base;
+  if (typeof data.count === "number") {
+    return { ...base, summary: data.count === 1 ? "Found 1 result" : `Found ${data.count} results` };
+  }
+  return base;
+}
+
+export function skillResultView(result: unknown): SharedOutputView {
+  const base = normalizeSharedOutputView(result);
+  const data = resultData(result);
+  if (!data || data.success === false) return base;
+  if (Array.isArray(data.skills)) return { ...base, summary: `Skills: ${data.skills.length} available` };
+
+  const name = firstText(data.displayName, data.name, data.skillId, data.skill_id);
+  if (name) return { ...base, summary: `Skill: ${name}` };
+  return { ...base, summary: firstText(data.message) ?? "Skill updated" };
+}

--- a/src/tools/tool-result-views.ts
+++ b/src/tools/tool-result-views.ts
@@ -87,7 +87,11 @@ export function searchResultView(result: unknown): SharedOutputView {
 export function skillResultView(result: unknown): SharedOutputView {
   const base = normalizeSharedOutputView(result);
   const data = resultData(result);
-  if (!data || data.success === false) return base;
+  if (!data) return base;
+  if (data.success === false) {
+    const failureReason = firstText(data.error, data.message);
+    return { ...base, status: "failure", summary: failureReason ? `Error · ${failureReason}` : "Error" };
+  }
   if (Array.isArray(data.skills)) return { ...base, summary: `Skills: ${data.skills.length} available` };
 
   const name = firstText(data.displayName, data.name, data.skillId, data.skill_id);

--- a/src/tools/tool-result-views.ts
+++ b/src/tools/tool-result-views.ts
@@ -65,7 +65,12 @@ export function memoryResultView(result: unknown): SharedOutputView {
           : "Updated";
   const parts = [outcome];
   if (typeof data.target === "string" && data.target.trim()) parts.push(`target: ${data.target.trim()}`);
-  if (typeof data.category === "string" && data.category.trim()) parts.push(`category: ${data.category.trim()}`);
+  const category = typeof data.category === "string" && data.category.trim()
+    ? data.category.trim()
+    : data.target === "failure"
+      ? primaryMessage.match(/^Failure memory saved:\s*(\S+)/i)?.[1] ?? null
+      : null;
+  if (category) parts.push(`category: ${category}`);
   if (evicted > 0) parts.push(`evicted: ${evicted}`);
   if (typeof data.entry_count === "number") parts.push(`${data.entry_count} ${data.entry_count === 1 ? "entry" : "entries"}`);
   if (typeof data.usage === "string" && data.usage.trim()) parts.push(data.usage.trim());

--- a/tests/tools/shared-output-view.test.ts
+++ b/tests/tools/shared-output-view.test.ts
@@ -4,7 +4,6 @@ import { initTheme } from "@earendil-works/pi-coding-agent";
 import { Box, visibleWidth, type Component } from "@earendil-works/pi-tui";
 import {
   createSharedToolResultRenderer,
-  renderSharedToolResult,
   type SharedOutputView,
 } from "../../src/tools/shared-output-view.js";
 import {
@@ -34,6 +33,22 @@ function result(text: string, details: Record<string, unknown> = { success: true
   return { content: [{ type: "text", text }], details };
 }
 
+function renderToolResult(
+  toolResult: ReturnType<typeof result>,
+  expanded: boolean,
+  width = 120,
+): string {
+  return renderPlain(
+    createSharedToolResultRenderer()(
+      toolResult,
+      { expanded, isPartial: false },
+      fakeTheme(),
+      { isError: false },
+    ),
+    width,
+  );
+}
+
 function renderView(view: SharedOutputView, expanded: boolean, width = 120): string {
   return renderPlain(
     createSharedToolResultRenderer(() => view)(
@@ -46,6 +61,25 @@ function renderView(view: SharedOutputView, expanded: boolean, width = 120): str
   );
 }
 
+function assertRowKeepsBackground(row: string): void {
+  let backgroundActive = false;
+  for (let index = 0; index < row.length;) {
+    const sgr = row.slice(index).match(/^\x1b\[([0-9;]*)m/);
+    if (sgr) {
+      const parameters = sgr[1];
+      if (parameters === "" || parameters === "0" || parameters === "49") {
+        backgroundActive = false;
+      } else if (parameters.split(";")[0] === "48") {
+        backgroundActive = true;
+      }
+      index += sgr[0].length;
+      continue;
+    }
+    assert.equal(backgroundActive, true, `background cleared before ${JSON.stringify(row.slice(index))}`);
+    index += 1;
+  }
+}
+
 describe("shared tool-result view", () => {
   it("collapses to one concise line and expands to the full bounded result", () => {
     const toolResult = result("Found 2 memories matching auth:\n\nfirst\nsecond", {
@@ -53,17 +87,13 @@ describe("shared tool-result view", () => {
       count: 2,
     });
 
-    const collapsed = renderPlain(
-      renderSharedToolResult(toolResult, { expanded: false, isPartial: false }, fakeTheme()),
-    );
+    const collapsed = renderToolResult(toolResult, false);
     assert.equal(collapsed.split("\n").length, 1);
     assert.match(collapsed, /Found 2 memories matching auth/);
     assert.doesNotMatch(collapsed, /second/);
     assert.match(collapsed, /expand/);
 
-    const expanded = renderPlain(
-      renderSharedToolResult(toolResult, { expanded: true, isPartial: false }, fakeTheme()),
-    );
+    const expanded = renderToolResult(toolResult, true);
     assert.equal(expanded, toolResult.content[0].text);
   });
 
@@ -74,45 +104,35 @@ describe("shared tool-result view", () => {
     });
     const before = structuredClone(toolResult);
 
-    renderPlain(renderSharedToolResult(toolResult, { expanded: false, isPartial: false }, fakeTheme()));
-    renderPlain(renderSharedToolResult(toolResult, { expanded: true, isPartial: false }, fakeTheme()));
+    renderToolResult(toolResult, false);
+    renderToolResult(toolResult, true);
 
     assert.deepEqual(toolResult, before);
   });
 
-  it("keeps failure reasons and warning-bearing success reasons in NO_COLOR", () => {
-    const previous = process.env.NO_COLOR;
-    process.env.NO_COLOR = "1";
-    try {
-      const failure = renderPlain(
-        renderSharedToolResult(
-          result("query is required", { success: false, message: "query is required" }),
-          { expanded: false, isPartial: false },
-          fakeTheme(),
-        ),
-      );
-      assert.match(failure, /query is required/);
+  it("keeps textual failure and warning reasons in collapsed output", () => {
+    const failure = renderToolResult(
+      result("query is required", { success: false, message: "query is required" }),
+      false,
+    );
+    assert.match(failure, /query is required/);
 
-      const warningView = memoryResultView(result(JSON.stringify({
-        success: true,
-        message: "Entry added. Warning: SQLite mirror unavailable",
-        warning: "SQLite mirror unavailable",
-        warnings: ["SQLite mirror unavailable"],
-        target: "memory",
-        entry_count: 1,
-      }), {
-        success: true,
-        message: "Entry added. Warning: SQLite mirror unavailable",
-        warning: "SQLite mirror unavailable",
-        warnings: ["SQLite mirror unavailable"],
-        target: "memory",
-        entry_count: 1,
-      }));
-      assert.match(renderView(warningView, false), /SQLite mirror unavailable/);
-    } finally {
-      if (previous === undefined) delete process.env.NO_COLOR;
-      else process.env.NO_COLOR = previous;
-    }
+    const warningView = memoryResultView(result(JSON.stringify({
+      success: true,
+      message: "Entry added. Warning: SQLite mirror unavailable",
+      warning: "SQLite mirror unavailable",
+      warnings: ["SQLite mirror unavailable"],
+      target: "memory",
+      entry_count: 1,
+    }), {
+      success: true,
+      message: "Entry added. Warning: SQLite mirror unavailable",
+      warning: "SQLite mirror unavailable",
+      warnings: ["SQLite mirror unavailable"],
+      target: "memory",
+      entry_count: 1,
+    }));
+    assert.match(renderView(warningView, false), /SQLite mirror unavailable/);
   });
 
   it("fits ANSI, CJK, and partial rows while preserving the outer tool-card background", () => {
@@ -135,22 +155,33 @@ describe("shared tool-result view", () => {
     assert.equal(visibleWidth(rows[1]), width);
     assert.match(stripAnsi(rows[1]), /处理中|In progress/);
 
-    let backgroundActive = false;
-    for (let index = 0; index < rows[1].length;) {
-      const sgr = rows[1].slice(index).match(/^\x1b\[([0-9;]*)m/);
-      if (sgr) {
-        const parameters = sgr[1];
-        if (parameters === "" || parameters === "0" || parameters === "49") {
-          backgroundActive = false;
-        } else if (parameters.split(";")[0] === "48") {
-          backgroundActive = true;
-        }
-        index += sgr[0].length;
-        continue;
-      }
-      assert.equal(backgroundActive, true);
-      index += 1;
+    assertRowKeepsBackground(rows[1]);
+  });
+
+  it("keeps the tool-card background across expanded Text rows with ANSI resets and CJK wrapping", () => {
+    const width = 18;
+    const backgroundOpen = "\x1b[48;2;40;50;40m";
+    const ansiTheme = {
+      fg: (_color: string, text: string): string => text,
+      getBgAnsi: (_color: string): string => backgroundOpen,
+    } as any;
+    const expandedText = "第一行 世界世界世界\x1b[0m继续\n第二行 \x1b[49m背景保留";
+    const box = new Box(1, 1, (text: string) => `${backgroundOpen}${text}\x1b[49m`);
+    box.addChild(createSharedToolResultRenderer()(
+      result(expandedText),
+      { expanded: true, isPartial: false },
+      ansiTheme,
+      { isError: false },
+    ));
+
+    const rows = box.render(width);
+    assert.ok(rows.length > 4);
+    for (const row of rows) {
+      assert.equal(visibleWidth(row), width);
+      assertRowKeepsBackground(row);
     }
+    const expandedRows = rows.slice(1, -1).map((row) => stripAnsi(row).trim());
+    assert.deepEqual(expandedRows, ["第一行 世界世界", "世界继续", "第二行 背景保留"]);
   });
 });
 
@@ -179,5 +210,24 @@ describe("tool-specific summaries", () => {
     const skill = skillResultView(result(skillText, JSON.parse(skillText)));
     assert.match(skill.summary, /deploy/i);
     assert.equal(skill.expandedText, skillText);
+  });
+
+  it("renders a real skill-tool JSON failure as an actionable failure", () => {
+    const error = "Skill 'global:missing' not found.";
+    const skillText = JSON.stringify({ success: false, error });
+    const toolResult = result(skillText, {});
+    const skill = skillResultView(toolResult);
+
+    assert.equal(skill.status, "failure");
+    assert.equal(skill.summary, `Error · ${error}`);
+    assert.equal(skill.expandedText, skillText);
+    assert.match(renderPlain(
+      createSharedToolResultRenderer(skillResultView)(
+        toolResult,
+        { expanded: false, isPartial: false },
+        fakeTheme(),
+        { isError: false },
+      ),
+    ), new RegExp(error.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   });
 });

--- a/tests/tools/shared-output-view.test.ts
+++ b/tests/tools/shared-output-view.test.ts
@@ -1,0 +1,180 @@
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+import { Box, visibleWidth, type Component } from "@earendil-works/pi-tui";
+import {
+  createSharedToolResultRenderer,
+  renderSharedToolResult,
+  type SharedOutputView,
+} from "../../src/tools/shared-output-view.js";
+import {
+  memoryResultView,
+  searchResultView,
+  skillResultView,
+} from "../../src/tools/tool-result-views.js";
+
+function fakeTheme() {
+  return {
+    fg: (_color: string, text: string): string => text,
+    getBgAnsi: (_color: string): string => "",
+  } as any;
+}
+
+function stripAnsi(text: string): string {
+  return text.replace(/\x1b\[[0-?]*[ -/]*m/g, "");
+}
+
+function renderPlain(component: Component, width = 120): string {
+  return component.render(width).map(stripAnsi).join("\n");
+}
+
+function result(text: string, details: Record<string, unknown> = { success: true }) {
+  return { content: [{ type: "text", text }], details };
+}
+
+function renderView(view: SharedOutputView, expanded: boolean, width = 120): string {
+  return renderPlain(
+    createSharedToolResultRenderer(() => view)(
+      result(view.expandedText),
+      { expanded, isPartial: false },
+      fakeTheme(),
+      { isError: false },
+    ),
+    width,
+  );
+}
+
+describe("shared tool-result view", () => {
+  it("collapses to one concise line and expands to the full bounded result", () => {
+    const toolResult = result("Found 2 memories matching auth:\n\nfirst\nsecond", {
+      success: true,
+      count: 2,
+    });
+
+    const collapsed = renderPlain(
+      renderSharedToolResult(toolResult, { expanded: false }, fakeTheme()),
+    );
+    assert.equal(collapsed.split("\n").length, 1);
+    assert.match(collapsed, /Found 2 memories matching auth/);
+    assert.doesNotMatch(collapsed, /second/);
+    assert.match(collapsed, /expand/);
+
+    const expanded = renderPlain(
+      renderSharedToolResult(toolResult, { expanded: true }, fakeTheme()),
+    );
+    assert.equal(expanded, toolResult.content[0].text);
+  });
+
+  it("does not mutate model-visible content or details", () => {
+    const toolResult = result("immutable\nfull output", {
+      success: true,
+      nested: { keep: true },
+    });
+    const before = structuredClone(toolResult);
+
+    renderPlain(renderSharedToolResult(toolResult, { expanded: false }, fakeTheme()));
+    renderPlain(renderSharedToolResult(toolResult, { expanded: true }, fakeTheme()));
+
+    assert.deepEqual(toolResult, before);
+  });
+
+  it("keeps failure reasons and warning-bearing success reasons in NO_COLOR", () => {
+    const previous = process.env.NO_COLOR;
+    process.env.NO_COLOR = "1";
+    try {
+      const failure = renderPlain(
+        renderSharedToolResult(
+          result("query is required", { success: false, message: "query is required" }),
+          { expanded: false },
+          fakeTheme(),
+        ),
+      );
+      assert.match(failure, /query is required/);
+
+      const warningView = memoryResultView(result(JSON.stringify({
+        success: true,
+        message: "Entry added. Warning: SQLite mirror unavailable",
+        warning: "SQLite mirror unavailable",
+        warnings: ["SQLite mirror unavailable"],
+        target: "memory",
+        entry_count: 1,
+      }), {
+        success: true,
+        message: "Entry added. Warning: SQLite mirror unavailable",
+        warning: "SQLite mirror unavailable",
+        warnings: ["SQLite mirror unavailable"],
+        target: "memory",
+        entry_count: 1,
+      }));
+      assert.match(renderView(warningView, false), /SQLite mirror unavailable/);
+    } finally {
+      if (previous === undefined) delete process.env.NO_COLOR;
+      else process.env.NO_COLOR = previous;
+    }
+  });
+
+  it("fits ANSI, CJK, and partial rows while preserving the outer tool-card background", () => {
+    const width = 34;
+    const backgroundOpen = "\x1b[48;2;40;50;40m";
+    const ansiTheme = {
+      fg: (_color: string, text: string): string => `\x1b[38;2;145;148;145m${text}\x1b[39m`,
+      getBgAnsi: (_color: string): string => backgroundOpen,
+    } as any;
+    const box = new Box(1, 1, (text: string) => `${backgroundOpen}${text}\x1b[49m`);
+    box.addChild(createSharedToolResultRenderer()(
+      result("处理中 世界世界世界世界 \x1b[1mvery long partial output\x1b[0m"),
+      { expanded: false, isPartial: true },
+      ansiTheme,
+      { isError: false },
+    ));
+
+    const rows = box.render(width);
+    assert.equal(rows.length, 3);
+    assert.equal(visibleWidth(rows[1]), width);
+    assert.match(stripAnsi(rows[1]), /处理中|In progress/);
+
+    let backgroundActive = false;
+    for (let index = 0; index < rows[1].length;) {
+      const sgr = rows[1].slice(index).match(/^\x1b\[([0-9;]*)m/);
+      if (sgr) {
+        const parameters = sgr[1];
+        if (parameters === "" || parameters === "0" || parameters === "49") {
+          backgroundActive = false;
+        } else if (parameters.split(";")[0] === "48") {
+          backgroundActive = true;
+        }
+        index += sgr[0].length;
+        continue;
+      }
+      assert.equal(backgroundActive, true);
+      index += 1;
+    }
+  });
+});
+
+describe("tool-specific summaries", () => {
+  it("summarizes memory, search/session, and skill results without changing expanded text", () => {
+    const memoryText = JSON.stringify({
+      success: true,
+      message: "Entry added.",
+      target: "failure",
+      category: "tool-quirk",
+      entry_count: 2,
+      usage: "120 / 5,000 chars",
+    });
+    const memory = memoryResultView(result(memoryText, JSON.parse(memoryText)));
+    assert.match(memory.summary, /Saved/);
+    assert.match(memory.summary, /target: failure/);
+    assert.match(memory.summary, /category: tool-quirk/);
+    assert.equal(memory.expandedText, memoryText);
+
+    const searchText = "Found 3 memories matching auth:\n\nfirst\nsecond\nthird";
+    const search = searchResultView(result(searchText, { success: true, count: 3 }));
+    assert.match(search.summary, /3/);
+    assert.equal(search.expandedText, searchText);
+
+    const skillText = JSON.stringify({ success: true, skillId: "global:deploy", name: "deploy" });
+    const skill = skillResultView(result(skillText, JSON.parse(skillText)));
+    assert.match(skill.summary, /deploy/i);
+    assert.equal(skill.expandedText, skillText);
+  });
+});

--- a/tests/tools/shared-output-view.test.ts
+++ b/tests/tools/shared-output-view.test.ts
@@ -97,6 +97,53 @@ describe("shared tool-result view", () => {
     assert.equal(expanded, toolResult.content[0].text);
   });
 
+  it("sanitizes only the rendered copy of hostile tool text and failure details", () => {
+    const hostileText = [
+      "safe 世界 \x1b]52;c;YXR0YWNr\x07 after OSC",
+      "styled \x1b[31mred\x1b[0m moved \x1b[2J after CSI",
+      "private \x1bPdanger\x1b\\ after DCS",
+      "linked \x1b]8;;https://evil.example\x1b\\label\x1b]8;;\x1b\\ after ST",
+      "carriage\rreturn binary\x00\x08\x7f end",
+    ].join("\n");
+    const hostileReason = "query \x1b]52;c;YXR0YWNr\x07 is required\x00";
+    const toolResult = result(hostileText, {
+      success: false,
+      message: hostileReason,
+      nested: { keep: true },
+    });
+    const before = structuredClone(toolResult);
+
+    const collapsed = renderToolResult(toolResult, false);
+    const expanded = renderToolResult(toolResult, true);
+
+    for (const rendered of [collapsed, expanded]) {
+      assert.doesNotMatch(rendered, /\x1b|\x07|\x00|\x08|\x7f|\r/);
+    }
+    assert.match(collapsed, /query .* is required/);
+    assert.match(expanded, /safe 世界/);
+    assert.match(expanded, /styled red moved  after CSI/);
+    assert.match(expanded, /private danger\\ after DCS/);
+    assert.match(expanded, /linked label after ST/);
+    assert.match(expanded, /carriagereturn binary end/);
+    assert.deepEqual(toolResult, before);
+
+    const adapterResult = result("safe", {
+      success: true,
+      message: "Entry added.",
+      target: "memory\x1b[2J",
+      usage: "1 entry\x00",
+    });
+    const adapterBefore = structuredClone(adapterResult);
+    const adapterRendered = renderPlain(createSharedToolResultRenderer(memoryResultView)(
+      adapterResult,
+      { expanded: false, isPartial: false },
+      fakeTheme(),
+      { isError: false },
+    ));
+    assert.doesNotMatch(adapterRendered, /\x1b|\x00/);
+    assert.deepEqual(adapterResult, adapterBefore);
+  });
+
   it("does not mutate model-visible content or details", () => {
     const toolResult = result("immutable\nfull output", {
       success: true,
@@ -158,7 +205,7 @@ describe("shared tool-result view", () => {
     assertRowKeepsBackground(rows[1]);
   });
 
-  it("keeps the tool-card background across expanded Text rows with ANSI resets and CJK wrapping", () => {
+  it("keeps the tool-card background after sanitizing expanded ANSI and CJK text", () => {
     const width = 18;
     const backgroundOpen = "\x1b[48;2;40;50;40m";
     const ansiTheme = {
@@ -182,6 +229,50 @@ describe("shared tool-result view", () => {
     }
     const expandedRows = rows.slice(1, -1).map((row) => stripAnsi(row).trim());
     assert.deepEqual(expandedRows, ["第一行 世界世界", "世界继续", "第二行 背景保留"]);
+  });
+
+  it("uses Pi shell state for the card background and logical status for foreground", () => {
+    const scenarios = [
+      { partial: true, isError: false, success: false, background: "toolPendingBg", foreground: "warning" },
+      { partial: false, isError: true, success: true, background: "toolErrorBg", foreground: "error" },
+      { partial: false, isError: false, success: true, background: "toolSuccessBg", foreground: "toolOutput" },
+      { partial: false, isError: false, success: false, background: "toolSuccessBg", foreground: "error" },
+    ] as const;
+
+    for (const scenario of scenarios) {
+      const backgrounds: string[] = [];
+      const foregrounds: string[] = [];
+      const theme = {
+        fg: (color: string, text: string): string => {
+          foregrounds.push(color);
+          return text;
+        },
+        getBgAnsi: (color: string): string => {
+          backgrounds.push(color);
+          return "";
+        },
+      } as any;
+      const message = scenario.success ? "done" : "query is required";
+      const toolResult = result(message, { success: scenario.success, message });
+
+      const renderer = createSharedToolResultRenderer();
+      const rendered = renderPlain(renderer(
+        toolResult,
+        { expanded: false, isPartial: scenario.partial },
+        theme,
+        { isError: scenario.isError },
+      ));
+      renderPlain(renderer(
+        toolResult,
+        { expanded: true, isPartial: scenario.partial },
+        theme,
+        { isError: scenario.isError },
+      ));
+
+      assert.deepEqual(backgrounds, [scenario.background, scenario.background]);
+      assert.deepEqual(foregrounds, [scenario.foreground]);
+      if (!scenario.success) assert.match(rendered, /query is required/);
+    }
   });
 });
 

--- a/tests/tools/shared-output-view.test.ts
+++ b/tests/tools/shared-output-view.test.ts
@@ -230,4 +230,42 @@ describe("tool-specific summaries", () => {
       ),
     ), new RegExp(error.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   });
+
+  it("summarizes successful failure memory from the real producer result shape", () => {
+    // MemoryResult has no category field; producers encode it only in message.
+    const details = {
+      success: true,
+      target: "failure",
+      message: "Failure memory saved: tool-quirk",
+      entry_count: 16,
+      usage: "92% — 9271/10000 chars",
+    };
+    const fullText = JSON.stringify(details);
+    const toolResult = result(fullText, details);
+    const before = structuredClone(toolResult);
+    const view = memoryResultView(toolResult);
+
+    assert.equal(view.status, "success");
+    assert.equal(
+      view.summary,
+      "Saved · target: failure · category: tool-quirk · 16 entries · 92% — 9271/10000 chars",
+    );
+    assert.doesNotMatch(view.summary, /^failure:/);
+    assert.equal(view.expandedText, fullText);
+    assert.deepEqual(toolResult, before);
+
+    const collapsed = renderPlain(
+      createSharedToolResultRenderer(memoryResultView)(
+        toolResult,
+        { expanded: false, isPartial: false },
+        fakeTheme(),
+        { isError: false },
+      ),
+    );
+    assert.match(
+      collapsed,
+      /Saved · target: failure · category: tool-quirk · 16 entries · 92% — 9271\/10000 chars/,
+    );
+    assert.doesNotMatch(collapsed, /^failure:/);
+  });
 });

--- a/tests/tools/shared-output-view.test.ts
+++ b/tests/tools/shared-output-view.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "node:test";
 import * as assert from "node:assert/strict";
+import { initTheme } from "@earendil-works/pi-coding-agent";
 import { Box, visibleWidth, type Component } from "@earendil-works/pi-tui";
 import {
   createSharedToolResultRenderer,
@@ -11,6 +12,8 @@ import {
   searchResultView,
   skillResultView,
 } from "../../src/tools/tool-result-views.js";
+
+initTheme();
 
 function fakeTheme() {
   return {
@@ -24,7 +27,7 @@ function stripAnsi(text: string): string {
 }
 
 function renderPlain(component: Component, width = 120): string {
-  return component.render(width).map(stripAnsi).join("\n");
+  return component.render(width).map((row) => stripAnsi(row).trimEnd()).join("\n");
 }
 
 function result(text: string, details: Record<string, unknown> = { success: true }) {
@@ -51,7 +54,7 @@ describe("shared tool-result view", () => {
     });
 
     const collapsed = renderPlain(
-      renderSharedToolResult(toolResult, { expanded: false }, fakeTheme()),
+      renderSharedToolResult(toolResult, { expanded: false, isPartial: false }, fakeTheme()),
     );
     assert.equal(collapsed.split("\n").length, 1);
     assert.match(collapsed, /Found 2 memories matching auth/);
@@ -59,7 +62,7 @@ describe("shared tool-result view", () => {
     assert.match(collapsed, /expand/);
 
     const expanded = renderPlain(
-      renderSharedToolResult(toolResult, { expanded: true }, fakeTheme()),
+      renderSharedToolResult(toolResult, { expanded: true, isPartial: false }, fakeTheme()),
     );
     assert.equal(expanded, toolResult.content[0].text);
   });
@@ -71,8 +74,8 @@ describe("shared tool-result view", () => {
     });
     const before = structuredClone(toolResult);
 
-    renderPlain(renderSharedToolResult(toolResult, { expanded: false }, fakeTheme()));
-    renderPlain(renderSharedToolResult(toolResult, { expanded: true }, fakeTheme()));
+    renderPlain(renderSharedToolResult(toolResult, { expanded: false, isPartial: false }, fakeTheme()));
+    renderPlain(renderSharedToolResult(toolResult, { expanded: true, isPartial: false }, fakeTheme()));
 
     assert.deepEqual(toolResult, before);
   });
@@ -84,7 +87,7 @@ describe("shared tool-result view", () => {
       const failure = renderPlain(
         renderSharedToolResult(
           result("query is required", { success: false, message: "query is required" }),
-          { expanded: false },
+          { expanded: false, isPartial: false },
           fakeTheme(),
         ),
       );

--- a/tests/tools/tool-result-renderer-wiring.test.ts
+++ b/tests/tools/tool-result-renderer-wiring.test.ts
@@ -1,0 +1,40 @@
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+import { registerMemoryTool } from "../../src/tools/memory-tool.js";
+import { registerMemorySearchTool } from "../../src/tools/memory-search-tool.js";
+import { registerSessionSearchTool } from "../../src/tools/session-search-tool.js";
+import { registerSkillTool } from "../../src/tools/skill-tool.js";
+
+function capture(register: (pi: any) => void): any {
+  let definition: any;
+  register({ registerTool(value: any) { definition = value; } });
+  return definition;
+}
+
+describe("tool result renderer wiring", () => {
+  it("registers renderResult on memory and memory_search", () => {
+    const memory = capture((pi) => registerMemoryTool(pi, {} as any, null));
+    const memorySearch = capture((pi) => registerMemorySearchTool(pi, {} as any));
+
+    assert.equal(typeof memory.renderResult, "function");
+    assert.equal(typeof memorySearch.renderResult, "function");
+  });
+
+  it("registers renderResult on both session_search variants", () => {
+    const legacy = capture((pi) => registerSessionSearchTool(pi, {} as any));
+    const anchors = capture((pi) => registerSessionSearchTool(
+      pi,
+      {} as any,
+      { variant: "anchors" },
+      { sessionsDir: "/path-independent-sessions" },
+    ));
+
+    assert.equal(typeof legacy.renderResult, "function");
+    assert.equal(typeof anchors.renderResult, "function");
+  });
+
+  it("registers renderResult on skill_manage", () => {
+    const skill = capture((pi) => registerSkillTool(pi, {} as any));
+    assert.equal(typeof skill.renderResult, "function");
+  });
+});


### PR DESCRIPTION
## Summary

- add one shared collapsed/expanded TUI result view for the four logical Hermes tools: `memory`, `memory_search`, both `session_search` variants, and `skill_manage`
- follow Pi's existing global tool-output expansion state (`app.tools.expand`; Ctrl-O by default) without registering a shortcut or owning extension-local expansion state
- keep the collapsed view to one actionable line while expanded mode shows the complete already-bounded tool result
- sanitize only the display copy before it reaches the terminal while preserving model-visible `content` and `details` exactly

## Motivation

Without custom `renderResult` functions, Pi's generic fallback can print complete custom-tool results even when global tool output is collapsed. Search and full-document results can therefore dominate the transcript.

A custom renderer also replaces Pi's generic display boundary. This implementation therefore strips terminal control sequences from its display-only copy before deriving summaries or creating TUI `Text`; the original tool result remains unchanged for the model and extension logic.

This PR remains limited to tool-result presentation. Slash-command reports keep their existing notification/UI behavior. The change does not add custom transcript entries, alter command handlers, raise the minimum Pi SDK, or change source-level output safety limits.

## Behavior

- **Collapsed:** one width-safe summary line with Pi's configured expansion key hint
- **Expanded:** the complete safe display copy of the text already returned by the tool, still subject to each tool's existing source-level limits
- **Terminal safety:** OSC, CSI/SGR styling, carriage returns, and binary controls cannot reach rendered rows; `strip-ansi` is applied only in the renderer
- **Failures:** actionable reasons remain visible through error foreground text
- **Shell state:** pending/error/success card background restoration follows Pi's actual partial and `context.isError` state, not application-level `details.success`
- **Warning-bearing successes:** warning text remains visible instead of being hidden behind a generic success label
- **Failure memories:** successful saves render as `Saved · target: failure · category: …`, avoiding a misleading `failure:` prefix

Tool-specific summaries cover memory actions and targets, search/session counts, and skill outcomes. Structured skill failures such as `{ "success": false, "error": "..." }` are rendered as failures rather than successful JSON output.

## Compatibility and scope

- keeps the existing project minimum Pi SDK (`>=0.80.1`)
- uses public `renderResult`, `ToolRenderContext.isError`, `keyHint("app.tools.expand", ...)`, and TUI APIs available at that floor
- adds the pinned runtime dependency `strip-ansi@7.2.0` because Pi's internal fallback sanitizer is not exported from the public package API in any release through `0.83.0`
- no slash-command or command-handler changes
- no `appendEntry` / `registerEntryRenderer` usage
- no extension factory/index wiring changes
- no model-context, persistence, or tool execution changes

## Verification

- focused renderer and wiring tests: **13/13 passed**
- `npm run check`: passed
- `npm run check:min-sdk`: passed against Pi SDK **0.80.1**
- `npm test`: all **44 test files passed**
- production dependency audit: **0 vulnerabilities**
- `npm pack --dry-run`: passed
- `git diff --check`: clean
- independent review: **approved**, no remaining findings
