### PR TITLE
feat(memory): apply consolidation plans atomically

### DIFF
--- a/src/handlers/auto-consolidate.ts
+++ b/src/handlers/auto-consolidate.ts
@@ -208,6 +208,8 @@ export async function triggerConsolidation(
           config: llmConfig,
           timeoutMs,
           signal,
+          requireAtomicShrink: true,
+          expectedTarget: toolTarget,
         },
         dbManager,
         projectName,

--- a/src/handlers/review-memory-ops.ts
+++ b/src/handlers/review-memory-ops.ts
@@ -21,6 +21,7 @@ export interface ReviewMemoryOperation {
 export interface ApplyReviewOperationsResult {
   appliedCount: number;
   skippedCount: number;
+  error?: string;
 }
 
 export interface DirectReviewResult {
@@ -36,6 +37,8 @@ export interface RunDirectMemoryCompletionOptions {
   config: Pick<MemoryConfig, "llmModelOverride" | "llmThinkingOverride">;
   timeoutMs?: number;
   signal?: AbortSignal;
+  requireAtomicShrink?: boolean;
+  expectedTarget?: ReviewMemoryOperation["target"];
 }
 
 /** Shared transport gate: review/flush/consolidation/correction all default to
@@ -263,8 +266,64 @@ export async function applyReviewOperations(
   projectStore: MemoryStore | null,
   operations: ReviewMemoryOperation[],
   _dbManager: DatabaseManager | null = null,
-  _projectName?: string | null,
+  projectName?: string | null,
+  options: {
+    requireAtomicShrink?: boolean;
+    expectedTarget?: ReviewMemoryOperation["target"];
+  } = {},
 ): Promise<ApplyReviewOperationsResult> {
+  if (options.requireAtomicShrink) {
+    if (operations.length === 0) {
+      return {
+        appliedCount: 0,
+        skippedCount: 0,
+        error: "Atomic plan requires at least one operation.",
+      };
+    }
+
+    const target = operations[0]?.target;
+    if (!target || operations.some((operation) => operation.target !== target)) {
+      return {
+        appliedCount: 0,
+        skippedCount: operations.length,
+        error: "Atomic plan must use exactly one target.",
+      };
+    }
+    if (options.expectedTarget && target !== options.expectedTarget) {
+      return {
+        appliedCount: 0,
+        skippedCount: operations.length,
+        error: `Atomic plan targeted '${target}', expected '${options.expectedTarget}'.`,
+      };
+    }
+    if (target === "project" && !projectStore) {
+      return {
+        appliedCount: 0,
+        skippedCount: operations.length,
+        error: "Project memory is unavailable.",
+      };
+    }
+
+    const activeStore = target === "project" ? projectStore! : store;
+    const memoryTarget = target === "project" ? "memory" : target;
+    const mutationOperations = operations.map((operation) => ({
+      action: operation.action,
+      content: operation.content,
+      oldText: operation.old_text,
+      category: operation.category,
+      failureReason: operation.failure_reason,
+      project: target === "failure" ? projectName ?? undefined : undefined,
+    }));
+    const result = await activeStore.applyMutationPlan(memoryTarget, mutationOperations, { requireShrink: true });
+    return result.success
+      ? { appliedCount: operations.length, skippedCount: 0 }
+      : {
+          appliedCount: 0,
+          skippedCount: operations.length,
+          error: result.error ?? "Atomic memory plan failed.",
+        };
+  }
+
   let appliedCount = 0;
   let skippedCount = 0;
 
@@ -290,6 +349,7 @@ export async function applyReviewOperations(
           result = await activeStore.addFailure(op.content, {
             category,
             failureReason: op.failure_reason,
+            project: projectName ?? undefined,
           });
           if (result.success) {
             appliedCount++;
@@ -434,14 +494,26 @@ export async function runDirectMemoryCompletion(
       return { ok: true, appliedCount: 0, fallbackReason: "empty" };
     }
 
-    const { appliedCount } = await applyReviewOperations(
+    const applied = await applyReviewOperations(
       store,
       projectStore,
       operations,
       dbManager,
       projectName,
+      {
+        requireAtomicShrink: options.requireAtomicShrink,
+        expectedTarget: options.expectedTarget,
+      },
     );
-    return { ok: true, appliedCount };
+    if (applied.error) {
+      return {
+        ok: false,
+        appliedCount: 0,
+        fallbackReason: "provider_error",
+        error: applied.error,
+      };
+    }
+    return { ok: true, appliedCount: applied.appliedCount };
   } catch (err) {
     if (controller.signal.aborted) {
       return { ok: false, appliedCount: 0, fallbackReason: "aborted" };

--- a/src/handlers/review-memory-ops.ts
+++ b/src/handlers/review-memory-ops.ts
@@ -310,7 +310,7 @@ export async function applyReviewOperations(
       action: operation.action,
       content: operation.content,
       oldText: operation.old_text,
-      category: operation.category,
+      category: target === "failure" ? operation.category ?? "failure" : operation.category,
       failureReason: operation.failure_reason,
       project: target === "failure" ? projectName ?? undefined : undefined,
     }));

--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -352,7 +352,12 @@ export class MemoryStore {
             : content;
           const scanError = scanContent(normalizedContent);
           if (scanError) return { success: false, error: scanError };
-          if (plannedEntries.some((entry) => this.decodeEntry(entry).text === normalizedContent)) {
+          const normalizedProject = operation.project?.trim() || null;
+          if (plannedEntries.some((entry) => {
+            const decoded = this.decodeEntry(entry);
+            return decoded.text === normalizedContent
+              && (target !== "failure" || decoded.project === normalizedProject);
+          })) {
             return { success: false, error: "Memory mutation plan would add a duplicate entry." };
           }
           plannedEntries.push(this.encodeEntry(normalizedContent, today, today, operation.project));

--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -25,7 +25,15 @@ import {
   MEMORY_FILE,
   USER_FILE,
 } from "../constants.js";
-import type { MemoryConfig, MemoryResult, MemorySnapshot, ConsolidationResult, MemoryCategory, MemoryOverflowStrategy } from "../types.js";
+import type {
+  MemoryConfig,
+  MemoryResult,
+  MemorySnapshot,
+  ConsolidationResult,
+  MemoryCategory,
+  MemoryMutationOperation,
+  MemoryOverflowStrategy,
+} from "../types.js";
 import { AGENT_ROOT } from "../paths.js";
 import { canonicalMarkdownIdentity, withMarkdownMutationLock } from "./markdown-mutation-lock.js";
 
@@ -314,6 +322,87 @@ export class MemoryStore {
       success: false,
       error: `Memory at ${current}/${limit} chars. Adding this entry (${contentLength} chars) would exceed the limit. Replace or remove existing entries first.`,
     };
+  }
+
+  async applyMutationPlan(
+    target: "memory" | "user" | "failure",
+    operations: MemoryMutationOperation[],
+    options: { requireShrink?: boolean } = {},
+  ): Promise<MemoryResult> {
+    return this.runTargetMutation(target, async () => {
+      await this.syncTargetFromDiskIfChanged(target);
+      if (operations.length === 0) {
+        return { success: false, error: "Memory mutation plan requires at least one operation." };
+      }
+
+      const originalEntries = [...this.entriesFor(target)];
+      let plannedEntries = [...originalEntries];
+      const today = new Date().toISOString().split("T")[0];
+
+      for (const operation of operations) {
+        if (operation.action === "add") {
+          const content = operation.content?.trim() ?? "";
+          if (!content) return { success: false, error: "Memory mutation add requires content." };
+          const normalizedContent = target === "failure" && operation.category
+            ? this.buildFailureMemoryText(content, {
+                category: operation.category,
+                failureReason: operation.failureReason,
+                project: operation.project,
+              })
+            : content;
+          const scanError = scanContent(normalizedContent);
+          if (scanError) return { success: false, error: scanError };
+          if (plannedEntries.some((entry) => this.decodeEntry(entry).text === normalizedContent)) {
+            return { success: false, error: "Memory mutation plan would add a duplicate entry." };
+          }
+          plannedEntries.push(this.encodeEntry(normalizedContent, today, today, operation.project));
+          continue;
+        }
+
+        const oldText = normalizeMemoryLookupText(operation.oldText ?? "");
+        if (!oldText) return { success: false, error: `Memory mutation ${operation.action} requires old_text.` };
+        const matches = plannedEntries.filter((entry) => this.stripMetadata(entry).includes(oldText));
+        if (matches.length === 0) return { success: false, error: `No entry matched '${oldText}'.` };
+        if (matches.length > 1 && !this.areDistinctScopedFailureCopies(target, matches)) {
+          return { success: false, error: `Multiple entries matched '${oldText}'. Be more specific.` };
+        }
+
+        if (operation.action === "remove") {
+          const matchedEntries = new Set(matches);
+          plannedEntries = plannedEntries.filter((entry) => !matchedEntries.has(entry));
+          continue;
+        }
+
+        const content = operation.content?.trim() ?? "";
+        if (!content) return { success: false, error: "Memory mutation replace requires content." };
+        const scanError = scanContent(content);
+        if (scanError) return { success: false, error: scanError };
+        const replacements = new Map(matches.map((entry) => {
+          const decoded = this.decodeEntry(entry);
+          return [entry, this.encodeEntry(content, decoded.created, today, decoded.project ?? undefined)];
+        }));
+        plannedEntries = plannedEntries.map((entry) => replacements.get(entry) ?? entry);
+      }
+
+      const originalTotal = originalEntries.join(ENTRY_DELIMITER).length;
+      const plannedTotal = plannedEntries.join(ENTRY_DELIMITER).length;
+      if (plannedTotal > this.charLimit(target)) {
+        return {
+          success: false,
+          error: `Memory mutation plan would put memory at ${plannedTotal}/${this.charLimit(target)} chars.`,
+        };
+      }
+      if (options.requireShrink && plannedTotal >= originalTotal) {
+        return {
+          success: false,
+          error: `Memory mutation plan did not shrink the target (${originalTotal} -> ${plannedTotal} chars).`,
+        };
+      }
+
+      this.setEntries(target, plannedEntries);
+      await this.saveToDisk(target);
+      return this.successResponse(target, `Applied ${operations.length} memory operations atomically.`);
+    });
   }
 
   async replace(target: "memory" | "user" | "failure", oldText: string, newContent: string): Promise<MemoryResult> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,6 +109,15 @@ export interface MemoryResult {
   matches?: string[];
 }
 
+export interface MemoryMutationOperation {
+  action: "add" | "replace" | "remove";
+  content?: string;
+  oldText?: string;
+  category?: MemoryCategory;
+  failureReason?: string;
+  project?: string;
+}
+
 export interface MemorySnapshot {
   memory: string;
   user: string;

--- a/tests/handlers/auto-consolidate.test.ts
+++ b/tests/handlers/auto-consolidate.test.ts
@@ -510,6 +510,12 @@ describe("triggerConsolidation", () => {
       assert.strictEqual(result.error, undefined);
       assert.strictEqual(directCalls.length, 1);
       assert.strictEqual(execCalls.length, 0, "subprocess must not run on successful direct consolidation");
+      const directOptions = directCalls[0]?.[3] as {
+        requireAtomicShrink?: boolean;
+        expectedTarget?: string;
+      };
+      assert.strictEqual(directOptions.requireAtomicShrink, true);
+      assert.strictEqual(directOptions.expectedTarget, "memory");
     });
 
     it("falls back to subprocess when direct transport succeeds with appliedCount 0", async () => {

--- a/tests/handlers/review-memory-ops.test.ts
+++ b/tests/handlers/review-memory-ops.test.ts
@@ -444,7 +444,7 @@ describe("applyReviewOperations", () => {
     assert.doesNotMatch(projectStore.getRawEntriesForSync("memory")[0] ?? "", /project64=/);
   });
 
-  it("preserves failure formatting and project attribution in atomic plans", async () => {
+  it("defaults failure formatting and preserves project attribution in atomic plans", async () => {
     const store = new MemoryStore({
       memoryDir: tmpDir,
       memoryCharLimit: 5000,
@@ -467,7 +467,6 @@ describe("applyReviewOperations", () => {
           action: "add",
           target: "failure",
           content: "concise lesson",
-          category: "tool-quirk",
           failure_reason: "tool used stale state",
         },
       ],
@@ -478,7 +477,7 @@ describe("applyReviewOperations", () => {
 
     assert.deepStrictEqual(result, { appliedCount: 2, skippedCount: 0 });
     assert.deepStrictEqual(store.getFailureEntries(), [
-      "[tool-quirk] concise lesson — Failed: tool used stale state",
+      "[failure] concise lesson — Failed: tool used stale state",
     ]);
     assert.match(store.getRawEntriesForSync("failure")[0] ?? "", /project64=cHJvamVjdC1h/);
   });

--- a/tests/handlers/review-memory-ops.test.ts
+++ b/tests/handlers/review-memory-ops.test.ts
@@ -13,7 +13,7 @@ import {
   runDirectMemoryCompletion,
 } from "../../src/handlers/review-memory-ops.js";
 import { DatabaseManager } from "../../src/store/db.js";
-import { reconcileMarkdownMemoryScope } from "../../src/store/sqlite-memory-store.js";
+import { getMemories, reconcileMarkdownMemoryScope } from "../../src/store/sqlite-memory-store.js";
 
 function mockModel(reasoning: boolean): Model<Api> {
   return {
@@ -285,6 +285,297 @@ describe("applyReviewOperations", () => {
 
     assert.strictEqual(result.appliedCount, 0);
     assert.strictEqual(result.skippedCount, 1);
+  });
+
+  it("rolls back the entire atomic plan when a later operation fails", async () => {
+    const store = new MemoryStore({
+      memoryDir: tmpDir,
+      memoryCharLimit: 5000,
+      userCharLimit: 5000,
+      autoConsolidate: true,
+    });
+    await store.loadFromDisk();
+    await store.add("memory", "keep this original entry");
+    const memoryPath = path.join(tmpDir, "MEMORY.md");
+    const beforeEntries = store.getMemoryEntries();
+    const beforeDisk = await fs.readFile(memoryPath, "utf8");
+
+    const result = await applyReviewOperations(
+      store,
+      null,
+      [
+        { action: "remove", target: "memory", old_text: "keep this" },
+        { action: "remove", target: "memory", old_text: "missing later entry" },
+      ],
+      null,
+      null,
+      { requireAtomicShrink: true, expectedTarget: "memory" },
+    );
+
+    assert.strictEqual(result.appliedCount, 0);
+    assert.strictEqual(result.skippedCount, 2);
+    assert.match(result.error ?? "", /No entry matched 'missing later entry'/);
+    assert.deepStrictEqual(store.getMemoryEntries(), beforeEntries);
+    assert.strictEqual(await fs.readFile(memoryPath, "utf8"), beforeDisk);
+  });
+
+  it("rejects mixed and unexpected atomic targets before mutation", async () => {
+    const store = new MemoryStore({
+      memoryDir: tmpDir,
+      memoryCharLimit: 5000,
+      userCharLimit: 5000,
+      autoConsolidate: true,
+    });
+    await store.loadFromDisk();
+    await store.add("memory", "global source entry");
+
+    const mixed = await applyReviewOperations(
+      store,
+      null,
+      [
+        { action: "remove", target: "memory", old_text: "global source" },
+        { action: "remove", target: "user", old_text: "anything" },
+      ],
+      null,
+      null,
+      { requireAtomicShrink: true, expectedTarget: "memory" },
+    );
+    const unexpected = await applyReviewOperations(
+      store,
+      null,
+      [{ action: "remove", target: "memory", old_text: "global source" }],
+      null,
+      null,
+      { requireAtomicShrink: true, expectedTarget: "user" },
+    );
+
+    assert.deepStrictEqual(
+      { appliedCount: mixed.appliedCount, skippedCount: mixed.skippedCount },
+      { appliedCount: 0, skippedCount: 2 },
+    );
+    assert.match(mixed.error ?? "", /exactly one target/);
+    assert.deepStrictEqual(
+      { appliedCount: unexpected.appliedCount, skippedCount: unexpected.skippedCount },
+      { appliedCount: 0, skippedCount: 1 },
+    );
+    assert.match(unexpected.error ?? "", /targeted 'memory', expected 'user'/);
+    assert.deepStrictEqual(store.getMemoryEntries().map((entry) => entry.replace(/\s*<!--.*$/, "")), [
+      "global source entry",
+    ]);
+  });
+
+  it("rejects an empty atomic plan and an unavailable atomic project store", async () => {
+    const store = new MemoryStore({
+      memoryDir: tmpDir,
+      memoryCharLimit: 5000,
+      userCharLimit: 5000,
+      autoConsolidate: true,
+    });
+    await store.loadFromDisk();
+
+    const empty = await applyReviewOperations(
+      store,
+      null,
+      [],
+      null,
+      "project-a",
+      { requireAtomicShrink: true, expectedTarget: "project" },
+    );
+    const unavailable = await applyReviewOperations(
+      store,
+      null,
+      [{ action: "remove", target: "project", old_text: "project source" }],
+      null,
+      "project-a",
+      { requireAtomicShrink: true, expectedTarget: "project" },
+    );
+
+    assert.deepStrictEqual(
+      { appliedCount: empty.appliedCount, skippedCount: empty.skippedCount },
+      { appliedCount: 0, skippedCount: 0 },
+    );
+    assert.match(empty.error ?? "", /requires at least one operation/i);
+    assert.deepStrictEqual(
+      { appliedCount: unavailable.appliedCount, skippedCount: unavailable.skippedCount },
+      { appliedCount: 0, skippedCount: 1 },
+    );
+    assert.match(unavailable.error ?? "", /project memory is unavailable/i);
+    assert.deepStrictEqual(store.getMemoryEntries(), []);
+  });
+
+  it("applies an atomic project plan only to the isolated project store", async () => {
+    const globalDir = path.join(tmpDir, "global");
+    const projectDir = path.join(tmpDir, "project");
+    const store = new MemoryStore({
+      memoryDir: globalDir,
+      memoryCharLimit: 5000,
+      userCharLimit: 5000,
+      autoConsolidate: true,
+    });
+    const projectStore = new MemoryStore({
+      memoryDir: projectDir,
+      memoryCharLimit: 5000,
+      userCharLimit: 5000,
+      autoConsolidate: true,
+    });
+    await Promise.all([store.loadFromDisk(), projectStore.loadFromDisk()]);
+    await store.add("memory", "global source stays intact");
+    await projectStore.add("memory", "project source has a long implementation detail");
+
+    const result = await applyReviewOperations(
+      store,
+      projectStore,
+      [
+        { action: "remove", target: "project", old_text: "project source" },
+        { action: "add", target: "project", content: "project rule" },
+      ],
+      null,
+      "project-a",
+      { requireAtomicShrink: true, expectedTarget: "project" },
+    );
+
+    assert.deepStrictEqual(result, { appliedCount: 2, skippedCount: 0 });
+    assert.deepStrictEqual(store.getMemoryEntries().map((entry) => entry.replace(/\s*<!--.*$/, "")), [
+      "global source stays intact",
+    ]);
+    assert.deepStrictEqual(projectStore.getMemoryEntries().map((entry) => entry.replace(/\s*<!--.*$/, "")), [
+      "project rule",
+    ]);
+    assert.doesNotMatch(projectStore.getRawEntriesForSync("memory")[0] ?? "", /project64=/);
+  });
+
+  it("preserves failure formatting and project attribution in atomic plans", async () => {
+    const store = new MemoryStore({
+      memoryDir: tmpDir,
+      memoryCharLimit: 5000,
+      userCharLimit: 5000,
+      failureCharLimit: 5000,
+      autoConsolidate: true,
+    });
+    await store.loadFromDisk();
+    await store.addFailure("obsolete failure detail that is intentionally long", {
+      category: "failure",
+      project: "project-a",
+    });
+
+    const result = await applyReviewOperations(
+      store,
+      null,
+      [
+        { action: "remove", target: "failure", old_text: "obsolete failure detail" },
+        {
+          action: "add",
+          target: "failure",
+          content: "concise lesson",
+          category: "tool-quirk",
+          failure_reason: "tool used stale state",
+        },
+      ],
+      null,
+      "project-a",
+      { requireAtomicShrink: true, expectedTarget: "failure" },
+    );
+
+    assert.deepStrictEqual(result, { appliedCount: 2, skippedCount: 0 });
+    assert.deepStrictEqual(store.getFailureEntries(), [
+      "[tool-quirk] concise lesson — Failed: tool used stale state",
+    ]);
+    assert.match(store.getRawEntriesForSync("failure")[0] ?? "", /project64=cHJvamVjdC1h/);
+  });
+
+  it("attributes ordinary non-atomic failures to the current project", async () => {
+    const store = new MemoryStore({
+      memoryDir: tmpDir,
+      memoryCharLimit: 5000,
+      userCharLimit: 5000,
+      failureCharLimit: 5000,
+      autoConsolidate: true,
+    });
+    await store.loadFromDisk();
+    const dbManager = new DatabaseManager(path.join(tmpDir, "db"));
+    store.setMutationObserver((target, entries) => {
+      reconcileMarkdownMemoryScope(dbManager, entries, target, target === "failure" ? "project-a" : null);
+      return null;
+    });
+
+    try {
+      const result = await applyReviewOperations(
+        store,
+        null,
+        [{
+          action: "add",
+          target: "failure",
+          content: "ordinary scoped lesson",
+          category: "correction",
+          failure_reason: "user corrected the command",
+        }],
+        dbManager,
+        "project-a",
+      );
+
+      assert.deepStrictEqual(result, { appliedCount: 1, skippedCount: 0 });
+      assert.deepStrictEqual(store.getFailureEntries(), [
+        "[correction] ordinary scoped lesson — Failed: user corrected the command",
+      ]);
+      const memories = getMemories(dbManager, { target: "failure", project: "project-a" });
+      assert.strictEqual(memories.length, 1);
+      assert.strictEqual(getMemories(dbManager, { target: "failure", project: null }).length, 0);
+      assert.strictEqual(memories[0].category, "correction");
+      assert.match(memories[0].content, /ordinary scoped lesson/);
+    } finally {
+      dbManager.close();
+    }
+  });
+
+  it("returns an actionable direct-completion error without partial atomic changes", async () => {
+    const store = new MemoryStore({
+      memoryDir: tmpDir,
+      memoryCharLimit: 5000,
+      userCharLimit: 5000,
+      autoConsolidate: true,
+    });
+    await store.loadFromDisk();
+    await store.add("memory", "keep this direct-review source");
+    const beforeEntries = store.getMemoryEntries();
+    const modelRegistry = {
+      authStorage: { reload: () => undefined },
+      getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: "test-key" }),
+      getAll: () => [mockModel(false)],
+      getAvailable: () => [mockModel(false)],
+    };
+    const complete = async () => ({
+      stopReason: "stop",
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          operations: [
+            { action: "remove", target: "memory", old_text: "keep this" },
+            { action: "remove", target: "memory", old_text: "missing later entry" },
+          ],
+        }),
+      }],
+    });
+
+    const result = await runDirectMemoryCompletion(
+      { model: mockModel(false), modelRegistry } as never,
+      store,
+      null,
+      {
+        userPrompt: "consolidate",
+        systemPrompt: "return operations",
+        config: {},
+        requireAtomicShrink: true,
+        expectedTarget: "memory",
+      },
+      null,
+      null,
+      { completeSimple: complete as never },
+    );
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.appliedCount, 0);
+    assert.match(result.error ?? "", /No entry matched 'missing later entry'/);
+    assert.deepStrictEqual(store.getMemoryEntries(), beforeEntries);
   });
 
   it("uses the in-lock mutation observer as the sole SQLite reconciliation path", async () => {

--- a/tests/store/memory-store.test.ts
+++ b/tests/store/memory-store.test.ts
@@ -924,6 +924,169 @@ describe("MemoryStore", { concurrency: 1 }, () => {
     });
   });
 
+  describe("applyMutationPlan()", () => {
+    it("applies dependent operations atomically and publishes one final observation", async () => {
+      const store = new MemoryStore(makeConfig());
+      await store.loadFromDisk();
+      await store.add("memory", `${TEST_MARKER} alpha`);
+      await store.add("memory", `${TEST_MARKER} beta`);
+
+      const observed: string[][] = [];
+      store.setMutationObserver(async (_target, entries) => {
+        observed.push(entries.map((entry) => (store as any).stripMetadata(entry)));
+        return null;
+      });
+      let consolidationCalls = 0;
+      store.setConsolidator(async () => {
+        consolidationCalls += 1;
+        return { consolidated: false };
+      });
+
+      const result = await store.applyMutationPlan("memory", [
+        { action: "replace", oldText: "alpha", content: `${TEST_MARKER} gamma` },
+        { action: "remove", oldText: "gamma" },
+        { action: "add", content: `${TEST_MARKER} delta` },
+      ]);
+
+      assert.equal(result.success, true);
+      assert.equal(result.message, "Applied 3 memory operations atomically.");
+      assert.equal(consolidationCalls, 0);
+      assert.deepEqual(observed, [[`${TEST_MARKER} beta`, `${TEST_MARKER} delta`]]);
+      const raw = await readRaw(memoryPath);
+      assert.doesNotMatch(raw, /alpha|gamma/);
+      assert.match(raw, /beta/);
+      assert.match(raw, /delta/);
+    });
+
+    it("rolls back memory and disk bytes when a late operation fails", async () => {
+      const store = new MemoryStore(makeConfig());
+      await store.loadFromDisk();
+      await store.add("memory", `${TEST_MARKER} keep one`);
+      await store.add("memory", `${TEST_MARKER} keep two`);
+      const beforeDisk = await readRaw(memoryPath);
+      const beforeEntries = [...(store as any).memoryEntries];
+
+      const result = await store.applyMutationPlan("memory", [
+        { action: "remove", oldText: "keep one" },
+        { action: "add", content: `${TEST_MARKER} temporary` },
+        { action: "replace", oldText: "missing entry", content: `${TEST_MARKER} never written` },
+      ]);
+
+      assert.equal(result.success, false);
+      assert.match(result.error ?? "", /No entry matched 'missing entry'/);
+      assert.equal(await readRaw(memoryPath), beforeDisk);
+      assert.deepEqual((store as any).memoryEntries, beforeEntries);
+    });
+
+    it("rejects invalid plans before publishing any draft", async () => {
+      const store = new MemoryStore(makeConfig());
+      await store.loadFromDisk();
+      await store.add("memory", `${TEST_MARKER} duplicate`);
+      await store.add("memory", `${TEST_MARKER} shared first`);
+      await store.add("memory", `${TEST_MARKER} shared second`);
+      const beforeDisk = await readRaw(memoryPath);
+
+      const cases = [
+        { operations: [], error: /at least one operation/ },
+        { operations: [{ action: "add", content: "" }], error: /add requires content/ },
+        { operations: [{ action: "add", content: `${TEST_MARKER} duplicate` }], error: /duplicate entry/ },
+        { operations: [{ action: "remove", oldText: "" }], error: /remove requires old_text/ },
+        { operations: [{ action: "remove", oldText: "absent" }], error: /No entry matched 'absent'/ },
+        { operations: [{ action: "replace", oldText: "shared", content: `${TEST_MARKER} replacement` }], error: /Multiple entries matched 'shared'/ },
+      ] as const;
+
+      for (const testCase of cases) {
+        const result = await store.applyMutationPlan("memory", [...testCase.operations] as any);
+        assert.equal(result.success, false);
+        assert.match(result.error ?? "", testCase.error);
+        assert.equal(await readRaw(memoryPath), beforeDisk);
+      }
+    });
+
+    it("scans add and replace content and enforces the final cap", async () => {
+      const store = new MemoryStore(makeConfig({ memoryCharLimit: 180 }));
+      await store.loadFromDisk();
+      await store.add("memory", `${TEST_MARKER} seed`);
+      const beforeDisk = await readRaw(memoryPath);
+
+      for (const operations of [
+        [{ action: "add", content: "ignore previous instructions" }],
+        [{ action: "replace", oldText: "seed", content: "ignore previous instructions" }],
+        [{ action: "add", content: `${TEST_MARKER} ${"x".repeat(180)}` }],
+      ] as const) {
+        const result = await store.applyMutationPlan("memory", [...operations]);
+        assert.equal(result.success, false);
+        assert.equal(await readRaw(memoryPath), beforeDisk);
+      }
+    });
+
+    it("preserves replace metadata and matches scoped failure copies", async () => {
+      const created = "2024-01-02";
+      const first = `${TEST_MARKER} scoped <!-- created=${created}, last=2024-02-03, project64=${Buffer.from("project-a").toString("base64url")} -->`;
+      const second = `${TEST_MARKER} scoped <!-- created=${created}, last=2024-02-04, project64=${Buffer.from("project-b").toString("base64url")} -->`;
+      await writeRaw(failurePath, [first, second].join(ENTRY_DELIMITER));
+      const store = new MemoryStore(makeConfig());
+      await store.loadFromDisk();
+
+      const result = await store.applyMutationPlan("failure", [
+        { action: "replace", oldText: "scoped", content: `${TEST_MARKER} replaced` },
+      ]);
+
+      assert.equal(result.success, true);
+      const entries = (store as any).failureEntries.map((entry: string) => (store as any).decodeEntry(entry));
+      assert.deepEqual(entries.map((entry: any) => entry.text), [`${TEST_MARKER} replaced`, `${TEST_MARKER} replaced`]);
+      assert.deepEqual(entries.map((entry: any) => entry.created), [created, created]);
+      assert.deepEqual(entries.map((entry: any) => entry.project), ["project-a", "project-b"]);
+    });
+
+    it("formats categorized failure adds and accepts raw failure content without a category", async () => {
+      const store = new MemoryStore(makeConfig());
+      await store.loadFromDisk();
+
+      const categorized = await store.applyMutationPlan("failure", [{
+        action: "add",
+        content: `${TEST_MARKER} categorized failure`,
+        category: "tool-quirk",
+        failureReason: "the tool exited",
+        project: "project-a",
+      }]);
+      const raw = await store.applyMutationPlan("failure", [{
+        action: "add",
+        content: `${TEST_MARKER} already normalized failure text`,
+        project: "project-b",
+      }]);
+
+      assert.equal(categorized.success, true);
+      assert.equal(raw.success, true);
+      const entries = (store as any).failureEntries.map((entry: string) => (store as any).decodeEntry(entry));
+      assert.deepEqual(entries.map((entry: any) => ({ text: entry.text, project: entry.project })), [
+        {
+          text: `[tool-quirk] ${TEST_MARKER} categorized failure — Failed: the tool exited`,
+          project: "project-a",
+        },
+        { text: `${TEST_MARKER} already normalized failure text`, project: "project-b" },
+      ]);
+    });
+
+    it("requires a strictly smaller final plan", async () => {
+      const store = new MemoryStore(makeConfig());
+      await store.loadFromDisk();
+      await store.add("memory", `${TEST_MARKER} same size`);
+      const beforeDisk = await readRaw(memoryPath);
+
+      for (const content of [`${TEST_MARKER} same form`, `${TEST_MARKER} this replacement is larger`]) {
+        const result = await store.applyMutationPlan(
+          "memory",
+          [{ action: "replace", oldText: "same size", content }],
+          { requireShrink: true },
+        );
+        assert.equal(result.success, false);
+        assert.match(result.error ?? "", /did not shrink/);
+        assert.equal(await readRaw(memoryPath), beforeDisk);
+      }
+    });
+  });
+
   describe("external file changes", () => {
     async function replaceOnDiskSameSize(from: string, to: string): Promise<void> {
       assert.equal(Buffer.byteLength(from), Buffer.byteLength(to));

--- a/tests/store/memory-store.test.ts
+++ b/tests/store/memory-store.test.ts
@@ -1039,32 +1039,46 @@ describe("MemoryStore", { concurrency: 1 }, () => {
       assert.deepEqual(entries.map((entry: any) => entry.project), ["project-a", "project-b"]);
     });
 
-    it("formats categorized failure adds and accepts raw failure content without a category", async () => {
+    it("formats failure adds and deduplicates them within project scope", async () => {
       const store = new MemoryStore(makeConfig());
       await store.loadFromDisk();
 
-      const categorized = await store.applyMutationPlan("failure", [{
+      const first = await store.applyMutationPlan("failure", [{
         action: "add",
         content: `${TEST_MARKER} categorized failure`,
         category: "tool-quirk",
         failureReason: "the tool exited",
         project: "project-a",
       }]);
-      const raw = await store.applyMutationPlan("failure", [{
+      const secondProject = await store.applyMutationPlan("failure", [{
         action: "add",
-        content: `${TEST_MARKER} already normalized failure text`,
+        content: `${TEST_MARKER} categorized failure`,
+        category: "tool-quirk",
+        failureReason: "the tool exited",
         project: "project-b",
       }]);
+      const duplicate = await store.applyMutationPlan("failure", [{
+        action: "add",
+        content: `${TEST_MARKER} categorized failure`,
+        category: "tool-quirk",
+        failureReason: "the tool exited",
+        project: "project-a",
+      }]);
 
-      assert.equal(categorized.success, true);
-      assert.equal(raw.success, true);
+      assert.equal(first.success, true);
+      assert.equal(secondProject.success, true);
+      assert.equal(duplicate.success, false);
+      assert.match(duplicate.error ?? "", /duplicate entry/);
       const entries = (store as any).failureEntries.map((entry: string) => (store as any).decodeEntry(entry));
       assert.deepEqual(entries.map((entry: any) => ({ text: entry.text, project: entry.project })), [
         {
           text: `[tool-quirk] ${TEST_MARKER} categorized failure — Failed: the tool exited`,
           project: "project-a",
         },
-        { text: `${TEST_MARKER} already normalized failure text`, project: "project-b" },
+        {
+          text: `[tool-quirk] ${TEST_MARKER} categorized failure — Failed: the tool exited`,
+          project: "project-b",
+        },
       ]);
     });
 


### PR DESCRIPTION
## Summary

- add `MemoryStore.applyMutationPlan()` for single-target, all-or-nothing memory mutations under the existing cross-process Markdown mutation boundary
- apply direct consolidation operation batches with one atomic plan, rejecting empty, mixed-target, unexpected-target, invalid, over-limit, and non-shrinking plans without publishing partial changes
- preserve failure-memory category, reason, and project attribution, including same-text failures scoped to different projects
- keep the current direct-to-subprocess fallback, provider-auth refresh, notifications, session flush behavior, SQLite reconciliation, and minimum SDK unchanged

## Why this PR was narrowed

The original version of this PR bundled provider-auth refresh, transport-policy changes, dependency updates, and atomic consolidation work. Provider auth was subsequently fixed upstream by #146 using `authStorage.reload()`, and #149 established the actual minimum SDK and minimum-version CI.

This rewrite retains only the independently useful portion identified in review: atomic mutation plans. It also fixes the review finding that `operation.project` was accepted by the store but never populated by `applyReviewOperations`, silently dropping project attribution from failure-memory additions.

## Behavior

### Store primitive

`applyMutationPlan(target, operations, { requireShrink? })`:

- runs within the existing `runTargetMutation()` lock and external-write retry machinery
- synchronizes the target from disk before planning
- evaluates all operations sequentially against a draft, so later operations can use earlier draft results
- scans both add and replacement content
- rejects empty content/lookup text, duplicate additions, missing or ambiguous matches, final over-capacity state, and non-shrinking plans when required
- preserves creation/project metadata on replacement
- formats failure additions with category/reason and stores project attribution
- allows the same failure text in distinct project scopes while rejecting duplicates within one scope
- publishes only after the complete plan validates, using one final `setEntries()`/`saveToDisk()` path
- does not recursively invoke the auto-consolidator

### Consolidation bridge

For explicit atomic consolidation:

- every operation must use one logical target
- the target must match the caller's expected target
- project plans write only to `projectStore`; unavailable project storage rejects the complete plan
- the complete operation array is passed to `applyMutationPlan()` once with strict shrink enforcement
- success applies the entire plan; failure applies none of it
- failure additions without an explicit category default to `failure`, matching ordinary non-atomic behavior

Direct auto-consolidation now requests this atomic/shrinking contract. A failed, empty, or rejected direct result still follows the existing subprocess fallback; this PR does not change transport policy.

## Explicit non-goals

This rewrite does **not** include the old PR's:

- provider-runtime or auth implementation; #146 is retained unchanged
- removal of direct-to-subprocess fallback
- background-review notification changes
- session-flush error propagation changes
- SDK, dependency, peer-floor, or lockfile changes
- command, README, or extension-index changes

## Verification

- focused store/review/consolidation tests: **133/133 passed**
- long-`TMPDIR` focused run: **133/133 passed**
- post-review store/review tests: **99/99 passed**
- `npm run check`: passed
- `npm run check:min-sdk`: passed against Pi SDK **0.80.1**
- `npm test`: all **42 test files passed**
- `npm pack --dry-run`: passed
- `git diff --check`: clean
- intentional mutation checks confirmed strict-shrink and project-attribution regressions are detected
- independent code review: approved
- final merge gate: approved
