### PR TITLE
fix: poll for consolidation lock on contention; GC dead-pid lock rows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1214,6 +1214,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1231,6 +1234,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1248,6 +1254,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1265,6 +1274,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1282,6 +1294,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/handlers/auto-consolidate.ts
+++ b/src/handlers/auto-consolidate.ts
@@ -38,6 +38,12 @@ type ConsolidationLlmConfig = Pick<MemoryConfig, "llmModelOverride" | "llmThinki
 
 const CONSOLIDATION_LOCK_STALE_GRACE_MS = 30000;
 const CONSOLIDATION_LOCK_ENV = "PI_HERMES_CONSOLIDATION_LOCK_DIR";
+// How long to keep polling for a contended consolidation lock before giving up.
+// Mirrors acquireMarkdownMutationLock: transient contention (another session
+// mid-consolidation) should become a short delay, not an immediate hard
+// failure of the memory write that triggered auto-consolidation.
+const CONSOLIDATION_LOCK_CONTENTION_WAIT_MS = 30000;
+const CONSOLIDATION_LOCK_POLL_MS = 100;
 
 interface ConsolidationLock {
   release: () => Promise<void>;
@@ -67,10 +73,21 @@ async function tryAcquireConsolidationLock(
   const root = consolidationLockRoot();
   await fs.mkdir(root, { recursive: true });
   const coordinator = AtomicLockCoordinator.shared(path.join(root, "locks.sqlite"));
-  const lease = coordinator.tryAcquire(
-    consolidationLockKey(target, toolTarget, storageIdentity),
-    { staleMs: Math.max(timeoutMs, 0) + CONSOLIDATION_LOCK_STALE_GRACE_MS },
-  );
+  const staleMs = Math.max(timeoutMs, 0) + CONSOLIDATION_LOCK_STALE_GRACE_MS;
+  const key = consolidationLockKey(target, toolTarget, storageIdentity);
+
+  // Contention is normally transient (another session is mid-consolidation or
+  // a hung holder is about to cross staleMs). Poll with a bounded deadline
+  // instead of failing the caller on the first collision; a hard failure here
+  // cascades into every memory write that exceeds capacity (memory-store.ts
+  // addWithConsolidation), blocking writes for all sessions while the lock is
+  // held.
+  const deadline = Date.now() + Math.min(CONSOLIDATION_LOCK_CONTENTION_WAIT_MS, staleMs);
+  let lease = coordinator.tryAcquire(key, { staleMs });
+  while (!lease && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, CONSOLIDATION_LOCK_POLL_MS));
+    lease = coordinator.tryAcquire(key, { staleMs });
+  }
   return lease ? { release: async () => lease.release() } : null;
 }
 

--- a/src/store/atomic-lock-coordinator.ts
+++ b/src/store/atomic-lock-coordinator.ts
@@ -96,11 +96,17 @@ const RELEASE_ATTEMPTS = 3;
 const pendingReleases = new Map<string, () => void>();
 const sharedCoordinators = new Map<string, AtomicLockCoordinator>();
 
+// Opportunistic GC tuning: how old (ms) a row must be before a dead-pid row
+// qualifies for deletion, and how often each coordinator may sweep.
+const DEAD_LOCK_SWEEP_GRACE_MS = 30000;
+const DEAD_LOCK_SWEEP_INTERVAL_MS = 60000;
+
 export class AtomicLockCoordinator {
   private readonly pid: number;
   private readonly incarnation: string | null;
   private readonly probeIncarnation: (pid: number) => string | null;
   private cachedDb: DatabaseLike | null = null;
+  private lastSweepMs = 0;
 
   constructor(private readonly dbPath: string, options: AtomicLockCoordinatorOptions = {}) {
     this.pid = options.pid ?? process.pid;
@@ -116,6 +122,7 @@ export class AtomicLockCoordinator {
     const token = randomUUID();
     const now = Date.now();
     const db = this.open();
+    this.sweepDeadLocks(db, now);
     let acquired = false;
 
     db.exec('BEGIN IMMEDIATE');
@@ -215,6 +222,34 @@ export class AtomicLockCoordinator {
     const prefix = `${path.resolve(this.dbPath)}\0${key}\0`;
     for (const [pendingKey, release] of [...pendingReleases.entries()]) {
       if (pendingKey.startsWith(prefix)) release();
+    }
+  }
+
+  /**
+   * Best-effort GC for lock rows whose holder process has exited. Without
+   * this, rows are only reaped when another session with the same lock key
+   * attempts acquisition — orphaned storage identities (dead sessions,
+   * abandoned projects) leak rows forever. A dead pid can never release its
+   * lease, so deletion is always safe; the grace period only guards against
+   * pid-reuse races (a new process reusing a recycled pid).
+   */
+  private sweepDeadLocks(db: DatabaseLike, now: number): void {
+    if (now - this.lastSweepMs < DEAD_LOCK_SWEEP_INTERVAL_MS) return;
+    this.lastSweepMs = now;
+    try {
+      const rows = db.prepare('SELECT lock_key, pid, acquired_at FROM locks').all() as Array<{
+        lock_key: string;
+        pid: number;
+        acquired_at: number;
+      }>;
+      for (const row of rows) {
+        if (!Number.isSafeInteger(row.pid) || row.pid <= 0) continue;
+        if (processIsAlive(row.pid)) continue;
+        if (now - row.acquired_at < DEAD_LOCK_SWEEP_GRACE_MS) continue;
+        db.prepare('DELETE FROM locks WHERE lock_key = ? AND pid = ?').run(row.lock_key, row.pid);
+      }
+    } catch {
+      // GC is best-effort; never fail an acquisition because of it.
     }
   }
 


### PR DESCRIPTION
# Consolidation lock contention hard-fails memory writes; hung consolidator blocks all sessions; dead-pid locks never GC'd

**pi-hermes-memory 0.9.2 / pi-coding-agent 0.83.0 / macOS / node 25**

## Summary

When a memory consolidation lock is held (by any session, on any target), **every** memory write that exceeds capacity fails hard with `Consolidation already in progress for target '<t>'`. The consolidation lock acquisition fails immediately on first contention, unlike the store's *mutation* locks which poll with a deadline. A hung-but-alive consolidator therefore blocks memory writes **for all sessions** for the full `staleMs` window (~210 s), and the failure is cascaded into the user-visible memory-write error.

## Deterministic repro

1. Simulate a hung-but-alive consolidator by inserting a lock row with a live pid and a fresh timestamp (key = `sha256(<abs path of MEMORY.md>)`, verified against the running store):
```sql
INSERT INTO locks (lock_key, token, pid, incarnation, acquired_at)
VALUES ('memory:memory:a074fd587d019f90a6a079b64ac7ce323ca396e06b5f8ca740c6027fcfc66784',
        'repro', 69955, NULL, strftime('%s','now')*1000);
```
(`pid 69955` is a live process → liveness check passes → not stealable; fresh `acquired_at` → not past `staleMs` → not stealable. This is exactly the state a hung/slow consolidator leaves behind.)

2. Trigger any capacity-exceeding memory add:
```
pi -p "Use your memory tool to save this exact short text to memory (target: memory, content: HELLO-REPRO-12345). Reply with the tool's result message."
```

3. Actual output:
```
⚠️ Auto-consolidation failed for 'memory': Consolidation already in progress for target 'memory'. Skipping duplicate subprocess.
{"success":false,"error":"Memory at 4991/5000 chars. Adding this entry (17 chars) would exceed the limit. Replace or remove existing entries first. Auto-consolidation attempted but failed: Consolidation already in progress for target 'memory'. Skipping duplicate subprocess."}
```

Observed in production: the same warning + write-failure loop repeatedly during context compaction with two concurrent pi sessions.

## Root cause

- `handlers/auto-consolidate.ts` — `tryAcquireConsolidationLock` returns `null` on the **first** contention; `triggerConsolidation` converts that into an immediate hard failure (`Consolidation already in progress ... Skipping duplicate subprocess.`) with no wait/retry.
- **Contrast:** `store/markdown-mutation-lock.ts` (`acquireMarkdownMutationLock`) polls with `MUTATION_WAIT_MS` deadline for the *mutation* locks — so the codebase already has the correct pattern for transient contention; consolidation just doesn't use it.
- `store/atomic-lock-coordinator.ts` — `staleMs = timeoutMs + 30_000` (default 210 s). A live pid is not stealable until stale; the consolidator child has `timeoutMs` 180 s **plus** `retryWithoutOverrides` (another 180 s) = up to 6 min of lock holding, longer than `staleMs` → the lock can be stolen mid-run (fencing), or (worse) the child hangs and blocks every session for 210 s.
- `store/memory-store.ts` (`addWithConsolidation`, ~line 239) — the auto-consolidation failure is merged into the memory-write error string, so a lock-contention hiccup becomes a visible memory-tool failure mid-task.

## Secondary issue: dead-pid lock rows are never GC'd

A `pi -p "/memory-consolidate"` invocation left `user:user:0fb97a…` in the lock table **after its process (pid 85036) had exited**. Rows are only reaped when another session with the *same storage identity* attempts acquisition; orphaned identities leak rows forever (harmless until that identity returns, then a spurious wait/failure).

## Suggested fix (I have a patch ready — PR to follow)

1. **Poll with deadline** in `tryAcquireConsolidationLock` (mirror `acquireMarkdownMutationLock`): wait up to `min(staleMs, ~30 s)` before giving up, so transient contention becomes a brief delay instead of a hard failure.
2. **Opportunistic dead-pid GC** in `AtomicLockCoordinator`: on each `tryAcquire`, delete rows whose pid is dead (with a small grace to avoid racing a live holder's insert).
3. (Optional) When contention is detected, return a *deferred* success for the memory write path so capacity errors don't cascade into tool failures.