### PR TITLE
fix: wait out consolidation lock contention and GC dead lock rows (#144)

### DIFF
--- a/src/handlers/auto-consolidate.ts
+++ b/src/handlers/auto-consolidate.ts
@@ -36,11 +36,30 @@ type MemoryTarget = "memory" | "user" | "failure";
 type ToolMemoryTarget = MemoryTarget | "project";
 type ConsolidationLlmConfig = Pick<MemoryConfig, "llmModelOverride" | "llmThinkingOverride" | "reviewTransport">;
 
-const CONSOLIDATION_LOCK_STALE_GRACE_MS = 30000;
+// staleMs is deliberately decoupled from the consolidation timeout. The holder
+// beats every CONSOLIDATION_LOCK_HEARTBEAT_MS while its child runs, so a
+// legitimately slow consolidation (up to 2x timeoutMs once retryWithoutOverrides
+// fires) never loses its lease, while a holder that stops making progress is
+// reclaimable after seconds instead of after its worst-case runtime (#144).
+const CONSOLIDATION_LOCK_STALE_MS = 45_000;
+const CONSOLIDATION_LOCK_HEARTBEAT_MS = 10_000;
+// Contention is usually transient. Poll for the lock the way
+// acquireMarkdownMutationLock does instead of hard-failing the memory write
+// that triggered auto-consolidation on the very first collision.
+const CONSOLIDATION_LOCK_WAIT_MS = 5_000;
+const CONSOLIDATION_LOCK_POLL_MS = 50;
 const CONSOLIDATION_LOCK_ENV = "PI_HERMES_CONSOLIDATION_LOCK_DIR";
+const CONSOLIDATION_LOCK_WAIT_ENV = "PI_HERMES_CONSOLIDATION_LOCK_WAIT_MS";
 
 interface ConsolidationLock {
   release: () => Promise<void>;
+}
+
+interface ConsolidationLockAttempt {
+  lock: ConsolidationLock | null;
+  /** True when the lock was held by someone else on the first attempt. */
+  contended: boolean;
+  waitedMs: number;
 }
 
 function consolidationLockRoot(): string {
@@ -57,21 +76,60 @@ function consolidationLockKey(target: MemoryTarget, toolTarget: ToolMemoryTarget
   return `${sanitizeLockPart(toolTarget)}:${sanitizeLockPart(target)}:${storageHash}`;
 }
 
-async function tryAcquireConsolidationLock(
+function consolidationLockWaitMs(): number {
+  const configured = Number(process.env[CONSOLIDATION_LOCK_WAIT_ENV]);
+  return Number.isFinite(configured) && configured >= 0 ? configured : CONSOLIDATION_LOCK_WAIT_MS;
+}
+
+async function acquireConsolidationLock(
   store: MemoryStore,
   target: MemoryTarget,
   toolTarget: ToolMemoryTarget,
-  timeoutMs: number,
-): Promise<ConsolidationLock | null> {
+): Promise<ConsolidationLockAttempt> {
   const storageIdentity = await store.getStorageIdentity(target);
   const root = consolidationLockRoot();
   await fs.mkdir(root, { recursive: true });
   const coordinator = AtomicLockCoordinator.shared(path.join(root, "locks.sqlite"));
-  const lease = coordinator.tryAcquire(
-    consolidationLockKey(target, toolTarget, storageIdentity),
-    { staleMs: Math.max(timeoutMs, 0) + CONSOLIDATION_LOCK_STALE_GRACE_MS },
-  );
-  return lease ? { release: async () => lease.release() } : null;
+  const key = consolidationLockKey(target, toolTarget, storageIdentity);
+  const lockOptions = { staleMs: CONSOLIDATION_LOCK_STALE_MS };
+
+  const startedAt = Date.now();
+  let lease = coordinator.tryAcquire(key, lockOptions);
+  const contended = !lease;
+  if (contended) {
+    const deadline = startedAt + consolidationLockWaitMs();
+    while (!lease && Date.now() < deadline) {
+      // Same shape as acquireMarkdownMutationLock; Promise.withResolvers would
+      // need an ES2024 lib this project does not target.
+      await new Promise((resolve) => setTimeout(resolve, CONSOLIDATION_LOCK_POLL_MS));
+      lease = coordinator.tryAcquire(key, lockOptions);
+    }
+  }
+
+  const waitedMs = Date.now() - startedAt;
+  if (!lease) return { lock: null, contended, waitedMs };
+
+  const held = lease;
+  const heartbeat = setInterval(() => {
+    try {
+      held.renew();
+    } catch {
+      // A missed beat only moves the lease closer to staleMs; the next beat
+      // recovers, and a permanently broken lock DB should not crash the run.
+    }
+  }, CONSOLIDATION_LOCK_HEARTBEAT_MS);
+  heartbeat.unref?.();
+
+  return {
+    lock: {
+      release: async () => {
+        clearInterval(heartbeat);
+        held.release();
+      },
+    },
+    contended,
+    waitedMs,
+  };
 }
 
 function entriesForTarget(store: MemoryStore, target: MemoryTarget): string[] {
@@ -99,6 +157,21 @@ function describeConsolidationFailure(
   }
 
   return `Consolidation process exited with code ${result.code}: ${stderr?.slice(0, 200) || "unknown error"}`;
+}
+
+function buildConsolidationPrompt(
+  target: MemoryTarget,
+  toolTarget: ToolMemoryTarget,
+  entries: string[],
+): string {
+  return [
+    CONSOLIDATION_PROMPT,
+    "",
+    `--- Current ${labelForTarget(target, toolTarget)} Entries ---`,
+    entries.join(ENTRY_DELIMITER) || "(empty)",
+    "",
+    `Use the memory tool to consolidate. Target: '${toolTarget}'`,
+  ].join("\n");
 }
 
 export async function triggerConsolidation(
@@ -150,27 +223,42 @@ export async function triggerConsolidation(
     }
   }
 
-  const prompt = [
-    CONSOLIDATION_PROMPT,
-    "",
-    `--- Current ${labelForTarget(target, toolTarget)} Entries ---`,
-    currentContent || "(empty)",
-    "",
-    `Use the memory tool to consolidate. Target: '${toolTarget}'`,
-  ].join("\n");
-
   let lock: ConsolidationLock | null = null;
 
   try {
-    lock = await tryAcquireConsolidationLock(store, target, toolTarget, timeoutMs);
+    const attempt = await acquireConsolidationLock(store, target, toolTarget);
+    lock = attempt.lock;
     if (!lock) {
+      // Not a failure: the work is already running in another session. Say so
+      // plainly so the memory-write path can ask for a retry instead of
+      // reporting a broken consolidation mid-task (#144).
       return {
         consolidated: false,
-        error: `Consolidation already in progress for target '${toolTarget}'. Skipping duplicate subprocess.`,
+        deferred: true,
+        error: `Consolidation already in progress for target '${toolTarget}' in another session`
+          + ` (waited ${attempt.waitedMs}ms). Nothing was consolidated here — retry shortly.`,
       };
     }
 
-    const result = await execChildPrompt(pi, prompt, llmConfig, {
+    let promptEntries = entries;
+    if (attempt.contended) {
+      // We queued behind another session's consolidation and it has now
+      // finished. If it already freed space, running a second LLM pass here
+      // costs a child turn and over-compresses memory for nothing — hand the
+      // caller a reload-and-retry instead.
+      try {
+        await store.loadFromDisk();
+        const refreshed = entriesForTarget(store, target);
+        if (refreshed.join(ENTRY_DELIMITER).length < currentContent.length) {
+          return { consolidated: true };
+        }
+        promptEntries = refreshed;
+      } catch {
+        // Reload failed — consolidate the entries we already read instead.
+      }
+    }
+
+    const result = await execChildPrompt(pi, buildConsolidationPrompt(target, toolTarget, promptEntries), llmConfig, {
       signal,
       timeoutMs,
       retryWithoutOverrides: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -233,7 +233,9 @@ export default function (pi: ExtensionAPI) {
       toolTarget,
       config,
     );
-    if (!result.consolidated) {
+    if (result.deferred) {
+      console.info(`⏳ Auto-consolidation for '${toolTarget}' deferred: ${result.error ?? "another session holds the consolidation lock"}`);
+    } else if (!result.consolidated) {
       console.warn(`⚠️ Auto-consolidation failed for '${toolTarget}': ${result.error ?? "no reason reported"}`);
     }
     return result;

--- a/src/store/atomic-lock-coordinator.ts
+++ b/src/store/atomic-lock-coordinator.ts
@@ -26,6 +26,12 @@ export interface AtomicLockOptions {
 export interface AtomicLockLease {
   token: string;
   release: () => void;
+  /**
+   * Refresh the lease timestamp so a long-running-but-healthy holder is never
+   * mistaken for a wedged one. Returns false once the lease has been taken
+   * over, which is the holder's signal that it no longer owns the resource.
+   */
+  renew: () => boolean;
 }
 
 export interface AtomicLockCoordinatorOptions {
@@ -93,6 +99,12 @@ function probeProcessIncarnation(pid: number): string | null {
 
 const currentProcessIncarnation = probeProcessIncarnation(process.pid);
 const RELEASE_ATTEMPTS = 3;
+// Opportunistic dead-row GC: a row must be older than the grace period before
+// a dead pid makes it collectable (guards against a pid we cannot observe, and
+// against racing a holder that has just inserted its row), and each coordinator
+// sweeps at most once per interval so acquisition stays cheap.
+const DEAD_LOCK_SWEEP_GRACE_MS = 60_000;
+const DEAD_LOCK_SWEEP_INTERVAL_MS = 60_000;
 const pendingReleases = new Map<string, () => void>();
 const sharedCoordinators = new Map<string, AtomicLockCoordinator>();
 
@@ -101,6 +113,7 @@ export class AtomicLockCoordinator {
   private readonly incarnation: string | null;
   private readonly probeIncarnation: (pid: number) => string | null;
   private cachedDb: DatabaseLike | null = null;
+  private lastSweepMs = 0;
 
   constructor(private readonly dbPath: string, options: AtomicLockCoordinatorOptions = {}) {
     this.pid = options.pid ?? process.pid;
@@ -116,6 +129,7 @@ export class AtomicLockCoordinator {
     const token = randomUUID();
     const now = Date.now();
     const db = this.open();
+    this.sweepDeadLocks(db, now);
     let acquired = false;
 
     db.exec('BEGIN IMMEDIATE');
@@ -174,6 +188,7 @@ export class AtomicLockCoordinator {
     return {
       token,
       release: () => this.release(key, token),
+      renew: () => this.renew(key, token),
     };
   }
 
@@ -193,6 +208,37 @@ export class AtomicLockCoordinator {
     return row?.token === token;
   }
 
+  /**
+   * Extend a held lease. A holder whose work legitimately outlives staleMs
+   * (a consolidation child can run for minutes) must beat periodically or a
+   * peer will reclaim the lease out from under it. Beating also lets staleMs
+   * stay short, so a holder that stops making progress is reclaimed in
+   * seconds instead of after its worst-case runtime.
+   *
+   * Token-fenced: a lease that has already been taken over renews nothing and
+   * returns false.
+   */
+  renew(key: string, token: string): boolean {
+    const db = this.open();
+    db.exec('BEGIN IMMEDIATE');
+    try {
+      const owner = db.prepare('SELECT token FROM locks WHERE lock_key = ?').get(key) as { token: string } | undefined;
+      const owned = owner?.token === token;
+      if (owned) {
+        db.prepare('UPDATE locks SET acquired_at = ? WHERE lock_key = ? AND token = ?').run(Date.now(), key, token);
+      }
+      db.exec('COMMIT');
+      return owned;
+    } catch (error) {
+      try {
+        db.exec('ROLLBACK');
+      } catch {
+        this.discardCachedDb();
+      }
+      throw error;
+    }
+  }
+
   release(key: string, token: string): void {
     const pendingKey = this.pendingReleaseKey(key, token);
     for (let attempt = 0; attempt < RELEASE_ATTEMPTS; attempt++) {
@@ -209,6 +255,49 @@ export class AtomicLockCoordinator {
   private deleteOwnedLock(key: string, token: string): void {
     const db = this.open();
     db.prepare('DELETE FROM locks WHERE lock_key = ? AND token = ?').run(key, token);
+  }
+
+  /**
+   * Delete rows whose holder process is gone.
+   *
+   * Without this, a row is only ever reclaimed by a peer that asks for the
+   * same lock key again. A key belonging to an identity that never returns
+   * (a deleted project, a one-shot `pi -p` run) leaks its row forever, and a
+   * much later session using that identity pays a spurious wait.
+   *
+   * A dead process can never release or renew its lease, so deleting its row
+   * is always safe. Probing happens outside any transaction and the DELETE is
+   * fenced on (token, acquired_at) so a row re-taken in between is left alone.
+   */
+  private sweepDeadLocks(db: DatabaseLike, now: number): void {
+    if (now - this.lastSweepMs < DEAD_LOCK_SWEEP_INTERVAL_MS) return;
+    this.lastSweepMs = now;
+    try {
+      const rows = db
+        .prepare('SELECT lock_key, token, pid, acquired_at FROM locks WHERE acquired_at <= ?')
+        .all(now - DEAD_LOCK_SWEEP_GRACE_MS) as Array<{
+          lock_key: string;
+          token: string;
+          pid: number;
+          acquired_at: number;
+        }>;
+      const dead = rows.filter((row) => this.holderIsGone(row.pid));
+      if (dead.length === 0) return;
+      const remove = db.prepare('DELETE FROM locks WHERE lock_key = ? AND token = ? AND acquired_at = ?');
+      for (const row of dead) {
+        remove.run(row.lock_key, row.token, row.acquired_at);
+      }
+    } catch {
+      // GC is best-effort — never fail an acquisition because of it.
+    }
+  }
+
+  /** Same liveness test tryAcquire steals on, cheapest check first. */
+  private holderIsGone(pid: number): boolean {
+    if (!Number.isSafeInteger(pid) || pid <= 0) return false;
+    if (pid === this.pid) return false;
+    if (processIsAlive(pid)) return false;
+    return this.probeIncarnation(pid) === null;
   }
 
   private retryPendingReleases(key: string): void {

--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -249,6 +249,15 @@ export class MemoryStore {
     const consolidation = await this.consolidator(target, signal).catch(
       (err): ConsolidationResult => ({ consolidated: false, error: `consolidator threw ${String(err).slice(0, 200)}` }),
     );
+    if (consolidation.deferred) {
+      // Lock contention, not breakage — another session is consolidating this
+      // target right now. Tell the model to retry instead of reporting a
+      // failed consolidation it can do nothing about (#144).
+      return {
+        ...result,
+        error: `${result.error} Another session is consolidating '${target}' right now, so this entry was not saved — retry in a moment.`,
+      };
+    }
     if (!consolidation.consolidated) {
       const reason = consolidation.error || "no reason reported";
       return { ...result, error: `${result.error} Auto-consolidation attempted but failed: ${reason}` };

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,6 +117,12 @@ export interface ConsolidationResult {
   consolidated: boolean;
   /** Error message if consolidation failed */
   error?: string;
+  /**
+   * Set when another session already holds the consolidation lock for this
+   * target. Nothing is broken — the work is happening elsewhere — so callers
+   * should tell the user to retry rather than report a failed consolidation.
+   */
+  deferred?: boolean;
 }
 
 export type SkillScope = "global" | "project";

--- a/tests/handlers/auto-consolidate.test.ts
+++ b/tests/handlers/auto-consolidate.test.ts
@@ -100,6 +100,21 @@ async function settle(ms = 10) {
   await new Promise((r) => setTimeout(r, ms));
 }
 
+/** Scope the contended-lock poll window so contention tests stay fast. */
+async function withLockWait(waitMs: string, run: () => Promise<void>): Promise<void> {
+  const previous = process.env.PI_HERMES_CONSOLIDATION_LOCK_WAIT_MS;
+  process.env.PI_HERMES_CONSOLIDATION_LOCK_WAIT_MS = waitMs;
+  try {
+    await run();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.PI_HERMES_CONSOLIDATION_LOCK_WAIT_MS;
+    } else {
+      process.env.PI_HERMES_CONSOLIDATION_LOCK_WAIT_MS = previous;
+    }
+  }
+}
+
 type ManualCommandHandler = (args: unknown, ctx: unknown) => Promise<void>;
 
 async function runManualConsolidate(timeoutMs?: number): Promise<void> {
@@ -174,7 +189,7 @@ describe("triggerConsolidation", () => {
     }
   });
 
-  it("skips a duplicate subprocess while the same target is consolidating", async () => {
+  it("defers a duplicate subprocess while the same target is consolidating", async () => {
     const releaseExecs: Array<() => void> = [];
     let markExecStarted!: () => void;
     const execStarted = new Promise<void>((resolve) => { markExecStarted = resolve; });
@@ -190,21 +205,95 @@ describe("triggerConsolidation", () => {
       registerCommand: () => {},
     } as any;
 
-    const first = triggerConsolidation(pi, mockStore, "memory");
-    await execStarted;
-    const second = triggerConsolidation(pi, mockStore, "memory");
-    const raced = await Promise.race([
-      second.then((result) => ({ result })),
-      settle(100).then(() => ({ timeout: true as const })),
-    ]);
+    await withLockWait("0", async () => {
+      const first = triggerConsolidation(pi, mockStore, "memory");
+      await execStarted;
+      const second = triggerConsolidation(pi, mockStore, "memory");
+      const raced = await Promise.race([
+        second.then((result) => ({ result })),
+        settle(100).then(() => ({ timeout: true as const })),
+      ]);
 
-    releaseExecs.forEach((release) => release());
-    await Promise.allSettled([first, second]);
+      releaseExecs.forEach((release) => release());
+      await Promise.allSettled([first, second]);
 
-    assert.ok("result" in raced, "duplicate consolidation should return without spawning another child");
-    assert.strictEqual(raced.result.consolidated, false);
-    assert.match(raced.result.error!, /already in progress/i);
-    assert.strictEqual(execCalls.length, 1, "only one child Pi process should be spawned");
+      assert.ok("result" in raced, "duplicate consolidation should return without spawning another child");
+      assert.strictEqual(raced.result.consolidated, false);
+      assert.strictEqual(raced.result.deferred, true, "contention is deferral, not failure");
+      assert.match(raced.result.error!, /already in progress/i);
+      assert.strictEqual(execCalls.length, 1, "only one child Pi process should be spawned");
+    });
+  });
+
+  it("waits out transient contention instead of failing the caller", async () => {
+    const releaseExecs: Array<() => void> = [];
+    let markFirstExecStarted!: () => void;
+    const firstExecStarted = new Promise<void>((resolve) => { markFirstExecStarted = resolve; });
+    const pi = {
+      on: () => {},
+      exec: async (...args: any[]) => {
+        execCalls.push(captureExecArgs(args));
+        if (execCalls.length === 1) {
+          markFirstExecStarted();
+          await new Promise<void>((resolve) => { releaseExecs.push(resolve); });
+        }
+        return { code: 0, stdout: "Done", stderr: "" };
+      },
+      registerTool: () => {},
+      registerCommand: () => {},
+    } as any;
+
+    await withLockWait("2000", async () => {
+      const first = triggerConsolidation(pi, mockStore, "memory");
+      await firstExecStarted;
+      const second = triggerConsolidation(pi, mockStore, "memory");
+      await settle(20);
+      releaseExecs.forEach((release) => release());
+
+      const [firstResult, secondResult] = await Promise.all([first, second]);
+      assert.strictEqual(firstResult.consolidated, true);
+      assert.strictEqual(secondResult.consolidated, true, "the queued caller should consolidate, not hard-fail");
+      assert.strictEqual(secondResult.deferred, undefined);
+      assert.strictEqual(execCalls.length, 2);
+    });
+  });
+
+  it("skips its own child when the session it queued behind already freed space", async () => {
+    let entries = ["old entry 1", "old entry 2"];
+    const shrinkingStore = {
+      getMemoryEntries: () => entries,
+      getUserEntries: () => [],
+      getAllFailureEntries: () => [],
+      getStorageIdentity: async (target: string) => path.join("shrinking-store", target),
+      loadFromDisk: async () => { entries = ["merged"]; },
+    } as any;
+
+    const releaseExecs: Array<() => void> = [];
+    let markFirstExecStarted!: () => void;
+    const firstExecStarted = new Promise<void>((resolve) => { markFirstExecStarted = resolve; });
+    const pi = {
+      on: () => {},
+      exec: async (...args: any[]) => {
+        execCalls.push(captureExecArgs(args));
+        markFirstExecStarted();
+        await new Promise<void>((resolve) => { releaseExecs.push(resolve); });
+        return { code: 0, stdout: "Done", stderr: "" };
+      },
+      registerTool: () => {},
+      registerCommand: () => {},
+    } as any;
+
+    await withLockWait("2000", async () => {
+      const first = triggerConsolidation(pi, shrinkingStore, "memory");
+      await firstExecStarted;
+      const second = triggerConsolidation(pi, shrinkingStore, "memory");
+      await settle(20);
+      releaseExecs.forEach((release) => release());
+
+      const [, secondResult] = await Promise.all([first, second]);
+      assert.strictEqual(secondResult.consolidated, true);
+      assert.strictEqual(execCalls.length, 1, "a second LLM pass is pure cost once space is already free");
+    });
   });
 
   it("allows the same project target to consolidate concurrently in distinct stores", async () => {
@@ -821,6 +910,24 @@ describe("MemoryStore auto-consolidation integration", () => {
     const result = await store.add("memory", "b".repeat(20));
 
     assert.ok(result.error!.includes("Auto-consolidation attempted but failed: no reason reported"), result.error);
+  });
+
+  it("add() asks for a retry instead of reporting failure when consolidation is deferred", async () => {
+    const store = await storeWithConsolidator("deferred", async () => ({
+      consolidated: false,
+      deferred: true,
+      error: "Consolidation already in progress for target 'memory' in another session (waited 5000ms).",
+    }));
+
+    const result = await store.add("memory", "b".repeat(20));
+
+    assert.ok(!result.success, "the entry genuinely was not saved");
+    assert.ok(result.error!.startsWith("Memory at "), "original capacity error must be preserved");
+    assert.ok(result.error!.includes("retry in a moment"), result.error);
+    assert.ok(
+      !result.error!.includes("Auto-consolidation attempted but failed"),
+      `lock contention must not read as a broken consolidation, got: ${result.error}`,
+    );
   });
 
   it("add() surfaces a consolidator that throws", async () => {

--- a/tests/store/atomic-lock-coordinator.test.ts
+++ b/tests/store/atomic-lock-coordinator.test.ts
@@ -275,4 +275,107 @@ describe('AtomicLockCoordinator', () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it('keeps a beating holder out of reach of a stale takeover', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'atomic-lock-renew-'));
+    try {
+      const dbPath = path.join(tmpDir, 'locks.sqlite');
+      const owner = new AtomicLockCoordinator(dbPath, {
+        pid: process.pid,
+        probeIncarnation: () => null,
+      });
+      const lease = owner.tryAcquire('shared', { staleMs: 60_000 });
+      assert.ok(lease);
+
+      // Age the lease well past the contender's stale window. Without a beat
+      // this is exactly the state 'reclaims an alive unknown-incarnation owner
+      // after staleMs elapses' proves is stealable.
+      const lockDb = new Database(dbPath);
+      try {
+        lockDb.prepare('UPDATE locks SET acquired_at = ? WHERE lock_key = ?').run(Date.now() - 10_000, 'shared');
+      } finally {
+        lockDb.close();
+      }
+
+      assert.strictEqual(lease.renew(), true);
+
+      const contender = new AtomicLockCoordinator(dbPath, {
+        pid: process.pid,
+        incarnation: 'known-later',
+        probeIncarnation: () => 'known-later',
+      });
+      assert.strictEqual(contender.tryAcquire('shared', { staleMs: 5_000 }), null);
+      lease.release();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to renew a lease that was already taken over', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'atomic-lock-renew-fence-'));
+    try {
+      const dbPath = path.join(tmpDir, 'locks.sqlite');
+      const owner = new AtomicLockCoordinator(dbPath, {
+        pid: process.pid,
+        probeIncarnation: () => null,
+      });
+      const original = owner.tryAcquire('shared', { staleMs: 60_000 });
+      assert.ok(original);
+
+      const lockDb = new Database(dbPath);
+      try {
+        lockDb.prepare('UPDATE locks SET acquired_at = ? WHERE lock_key = ?').run(Date.now() - 10_000, 'shared');
+      } finally {
+        lockDb.close();
+      }
+
+      const contender = new AtomicLockCoordinator(dbPath, {
+        pid: process.pid,
+        incarnation: 'known-later',
+        probeIncarnation: () => 'known-later',
+      });
+      const successor = contender.tryAcquire('shared', { staleMs: 50 });
+      assert.ok(successor);
+
+      assert.strictEqual(original.renew(), false, 'a stolen lease must not resurrect itself');
+      assert.strictEqual(successor.renew(), true);
+      successor.release();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('collects lock rows whose holder process is gone', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'atomic-lock-sweep-'));
+    try {
+      const dbPath = path.join(tmpDir, 'locks.sqlite');
+      new AtomicLockCoordinator(dbPath).tryAcquire('schema-init', { staleMs: 0 })!.release();
+
+      const lockDb = new Database(dbPath);
+      try {
+        const insert = lockDb.prepare(
+          'INSERT INTO locks (lock_key, token, pid, incarnation, acquired_at) VALUES (?, ?, ?, NULL, ?)',
+        );
+        insert.run('abandoned', 'dead-owner', 999_999, Date.now() - 120_000);
+        insert.run('just-taken', 'dead-owner-2', 999_999, Date.now());
+        insert.run('ours', 'live-owner', process.pid, Date.now() - 120_000);
+      } finally {
+        lockDb.close();
+      }
+
+      // The sweep piggybacks on the next acquisition, for any key.
+      new AtomicLockCoordinator(dbPath).tryAcquire('unrelated', { staleMs: 0 })!.release();
+
+      const verifyDb = new Database(dbPath);
+      try {
+        const keys = (verifyDb.prepare('SELECT lock_key FROM locks ORDER BY lock_key').all() as Array<{ lock_key: string }>)
+          .map((row) => row.lock_key);
+        assert.deepStrictEqual(keys, ['just-taken', 'ours'], 'only dead rows past the grace period are collected');
+      } finally {
+        verifyDb.close();
+      }
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
Closes #144. Supersedes #143 — same diagnosis; credit to @Frank-Opus for the report, the deterministic repro, and for landing on the polling + GC shape first.

## What was wrong

A held consolidation lock made **every** capacity-exceeding memory write fail hard, in every session, for the full `staleMs` window:

```
{"success":false,"error":"Memory at 4991/5000 chars. ... Auto-consolidation attempted but failed: Consolidation already in progress for target 'memory'. Skipping duplicate subprocess."}
```

Three separate defects behind that one line:

1. `tryAcquireConsolidationLock` returned `null` on the **first** collision. `acquireMarkdownMutationLock` already polls with a deadline for the *mutation* locks — the right pattern was in the codebase, consolidation just didn't use it.
2. `staleMs = timeoutMs + 30_000` (210s default) while the holder can legitimately run for `2 x timeoutMs` (360s) once `retryWithoutOverrides` fires. Both ends were wrong: a healthy holder could be robbed mid-run, and a wedged one blocked everyone for 210s.
3. Contention was reported as a *failure*, so a transient lock hiccup surfaced to the model as a broken memory tool mid-task.

## What changed

**Poll, don't hard-fail.** Bounded 5s window, mirroring `acquireMarkdownMutationLock`. `PI_HERMES_CONSOLIDATION_LOCK_WAIT_MS` overrides it (used by tests).

**Heartbeat the lease.** `AtomicLockCoordinator.renew()` is a token-fenced `UPDATE locks SET acquired_at`; the consolidation holder beats every 10s while its child runs, on an `unref`'d timer. That decouples `staleMs` from `timeoutMs` entirely — it is now a fixed 45s:

| holder state | before | after |
|---|---|---|
| healthy, slow (up to 360s) | lease stolen at 210s, two consolidators write concurrently | held for as long as it beats |
| alive but wedged | blocks every session for 210s | reclaimed at 45s |
| dead | already immediate (incarnation probe) | unchanged |

**Contention is `deferred`, not a failure.** New `ConsolidationResult.deferred`. The memory tool now says *"Another session is consolidating 'memory' right now, so this entry was not saved — retry in a moment"*, and `index.ts` logs it at info level instead of `Auto-consolidation failed`. The write still honestly reports failure — it just names a cause the model can act on.

**Skip redundant work.** After waiting out a contended lock, re-read the target from disk. If the session ahead already freed space, return without spawning our own child — a second LLM pass there is pure cost and over-compresses memory.

**GC dead-pid rows.** Rows were only ever reclaimed by a peer asking for the *same* key, so an identity that never returns (deleted project, one-shot `pi -p`) leaked its row forever. Throttled sweep on acquisition, liveness probed outside any transaction, `DELETE` fenced on `(token, acquired_at)` so a row re-taken in between is left alone. Uses the injectable `probeIncarnation` so test doubles with synthetic pids behave.

## Verification

The issue's exact repro — live pid, fresh `acquired_at`, so genuinely unstealable:

```
waited 5027ms
"Memory at 105/120 chars. ... Another session is consolidating 'memory' right now,
 so this entry was not saved — retry in a moment."
```

New tests: bounded-wait deferral, transient contention resolving into a real consolidation, the skip-redundant-child path, the deferred store message, `renew` defeating a stale takeover, `renew` refusing a stolen lease, and the dead-row sweep (live rows and in-grace rows left alone).

`npm run check` clean, all 40 test files pass.
