### PR TITLE
fix: resolve provider auth against fresh credentials on every direct call (#139)

### DIFF
--- a/src/handlers/review-memory-ops.ts
+++ b/src/handlers/review-memory-ops.ts
@@ -121,6 +121,61 @@ export function resolveReviewModel(
   return ctxModel;
 }
 
+/**
+ * Provider responses that mean "this key is no longer good", as opposed to a
+ * transport hiccup or a model error worth falling back to a subprocess for.
+ */
+const AUTH_REJECTION_PATTERN = new RegExp([
+  String.raw`\b(401|403)\b`,
+  "unauthorized",
+  "forbidden",
+  String.raw`invalid[\s_-]*api[\s_-]*key`,
+  String.raw`authentication[\s_-]*(failed|error)`,
+  String.raw`(invalid|expired|revoked)[\s_-]*(access[\s_-]*)?(token|key|credential)`,
+  String.raw`(token|key|credential)[\s_-]*(is[\s_-]*|has[\s_-]*been[\s_-]*)?(invalid|expired|revoked)`,
+].join("|"), "i");
+
+export function isAuthRejection(message: string): boolean {
+  return AUTH_REJECTION_PATTERN.test(message);
+}
+
+/**
+ * Mirrors the SDK's ResolvedRequestAuth. pi-coding-agent declares it in
+ * core/model-registry but does not re-export it from the package root, and its
+ * `exports` map blocks deep imports — so name it here. tsc still checks the
+ * shape against the real registry at the call below, so drift is a build error.
+ */
+export type ResolvedRequestAuth =
+  | { ok: true; apiKey?: string; headers?: Record<string, string>; env?: Record<string, string> }
+  | { ok: false; error: string };
+
+/**
+ * Resolve request auth against credentials re-read from disk.
+ *
+ * Pi's AuthStorage parses auth.json once in its constructor and only reloads
+ * it when an OAuth refresh fails, and ExtensionRunner hands every event the
+ * same ModelRegistry singleton — so an api_key credential is effectively
+ * frozen for the process lifetime. A key rotated on disk by another tool
+ * (e.g. @lnilluv/pi-opencode-go-rotation swapping an opencode-go subscription
+ * key after a weekly limit) stays invisible to this session, and every direct
+ * memory completion keeps presenting the revoked key (#139).
+ *
+ * reload() is public and is a synchronous re-read of that one file, so pay it
+ * per completion — a handful per session — instead of caching a key forever.
+ */
+export async function resolveFreshRequestAuth(
+  modelRegistry: ReviewModelRegistry,
+  model: Model<Api>,
+): Promise<ResolvedRequestAuth> {
+  try {
+    modelRegistry.authStorage?.reload();
+  } catch {
+    // A malformed or unreadable auth.json must not take the review path down;
+    // fall through to whatever credentials are already loaded.
+  }
+  return modelRegistry.getApiKeyAndHeaders(model);
+}
+
 function extractJsonPayload(text: string): unknown {
   const trimmed = text.trim();
   if (!trimmed) return null;
@@ -304,13 +359,15 @@ export async function runDirectMemoryCompletion(
   options: RunDirectMemoryCompletionOptions,
   dbManager: DatabaseManager | null = null,
   projectName?: string | null,
+  deps: { completeSimple?: typeof completeSimple } = {},
 ): Promise<DirectReviewResult> {
+  const complete = deps.completeSimple ?? completeSimple;
   const model = resolveReviewModel(ctx.model, ctx.modelRegistry, options.config);
   if (!model) {
     return { ok: false, appliedCount: 0, fallbackReason: "no_model" };
   }
 
-  const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+  const auth = await resolveFreshRequestAuth(ctx.modelRegistry, model);
   if (!auth.ok || !auth.apiKey) {
     return {
       ok: false,
@@ -319,6 +376,7 @@ export async function runDirectMemoryCompletion(
       error: auth.ok ? `No API key for ${model.provider}` : auth.error,
     };
   }
+  let requestAuth = { apiKey: auth.apiKey, headers: auth.headers, env: auth.env };
 
   const controller = new AbortController();
   const timeoutMs = options.timeoutMs ?? 120000;
@@ -334,17 +392,34 @@ export async function runDirectMemoryCompletion(
     timestamp: Date.now(),
   };
 
+  const request = { systemPrompt: options.systemPrompt, messages: [userMessage] };
+
   try {
-    const response = await completeSimple(
-      model,
-      { systemPrompt: options.systemPrompt, messages: [userMessage] },
-      buildDirectReviewCompletionOptions(
+    let response;
+    try {
+      response = await complete(
         model,
-        { apiKey: auth.apiKey, headers: auth.headers, env: auth.env },
-        thinking,
-        controller.signal,
-      ),
-    );
+        request,
+        buildDirectReviewCompletionOptions(model, requestAuth, thinking, controller.signal),
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (controller.signal.aborted || !isAuthRejection(message)) throw err;
+
+      // The provider rejected the key mid-flight. A rotation tool may have
+      // written a new one since we resolved auth; re-read and retry once, but
+      // only if the key actually changed — otherwise this is a real auth
+      // problem and the subprocess fallback should handle it (#139).
+      const rotated = await resolveFreshRequestAuth(ctx.modelRegistry, model);
+      if (!rotated.ok || !rotated.apiKey || rotated.apiKey === requestAuth.apiKey) throw err;
+
+      requestAuth = { apiKey: rotated.apiKey, headers: rotated.headers, env: rotated.env };
+      response = await complete(
+        model,
+        request,
+        buildDirectReviewCompletionOptions(model, requestAuth, thinking, controller.signal),
+      );
+    }
 
     if (response.stopReason === "aborted") {
       return { ok: false, appliedCount: 0, fallbackReason: "aborted" };

--- a/tests/handlers/review-memory-ops.test.ts
+++ b/tests/handlers/review-memory-ops.test.ts
@@ -8,7 +8,9 @@ import type { Api, Model } from "@earendil-works/pi-ai";
 import {
   applyReviewOperations,
   buildDirectReviewCompletionOptions,
+  isAuthRejection,
   parseReviewOperations,
+  runDirectMemoryCompletion,
 } from "../../src/handlers/review-memory-ops.js";
 import { DatabaseManager } from "../../src/store/db.js";
 import { reconcileMarkdownMemoryScope } from "../../src/store/sqlite-memory-store.js";
@@ -60,6 +62,153 @@ describe("buildDirectReviewCompletionOptions", () => {
 
     assert.strictEqual(off.reasoning, undefined);
     assert.strictEqual(nonReasoning.reasoning, undefined);
+  });
+});
+
+describe("provider auth freshness", () => {
+  /**
+   * Mirrors AuthStorage: `disk` is auth.json, `loaded` is the in-memory
+   * snapshot, and only reload() copies one onto the other. A rotation tool
+   * rewrites `disk`; a session that never reloads keeps sending `loaded`.
+   */
+  function rotatingRegistry(initialKey: string) {
+    const state = { disk: initialKey, loaded: initialKey, reloads: 0 };
+    const modelRegistry = {
+      authStorage: {
+        reload: () => {
+          state.reloads++;
+          state.loaded = state.disk;
+        },
+      },
+      getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: state.loaded }),
+      getAll: () => [mockModel(false)],
+      getAvailable: () => [mockModel(false)],
+    };
+    return { state, modelRegistry };
+  }
+
+  function completionStub(behaviour: (apiKey: string | undefined, attempt: number) => unknown) {
+    const usedKeys: Array<string | undefined> = [];
+    const complete = async (_model: unknown, _request: unknown, options: { apiKey?: string }) => {
+      usedKeys.push(options.apiKey);
+      const outcome = behaviour(options.apiKey, usedKeys.length);
+      if (outcome instanceof Error) throw outcome;
+      return outcome;
+    };
+    return { usedKeys, complete };
+  }
+
+  const emptyOperations = {
+    stopReason: "stop",
+    content: [{ type: "text", text: JSON.stringify({ operations: [] }) }],
+  };
+
+  function directOptions() {
+    return { userPrompt: "u", systemPrompt: "s", config: {} };
+  }
+
+  it("re-reads credentials before each completion so a rotated key is picked up", async () => {
+    const { state, modelRegistry } = rotatingRegistry("stale-key");
+    state.disk = "rotated-key";
+    const { usedKeys, complete } = completionStub(() => emptyOperations);
+
+    const result = await runDirectMemoryCompletion(
+      { model: mockModel(false), modelRegistry } as never,
+      null as never,
+      null,
+      directOptions(),
+      null,
+      null,
+      { completeSimple: complete as never },
+    );
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(state.reloads, 1, "credentials must be re-read, not taken from the startup snapshot");
+    assert.deepStrictEqual(usedKeys, ["rotated-key"], "the stale snapshot key must never reach the provider");
+  });
+
+  it("retries once with the rotated key when the provider rejects the current one", async () => {
+    const { state, modelRegistry } = rotatingRegistry("revoked-key");
+    const { usedKeys, complete } = completionStub((_key, attempt) => {
+      if (attempt > 1) return emptyOperations;
+      // Hitting the weekly limit is what triggers the external rotation.
+      state.disk = "rotated-key";
+      return new Error("HTTP 401 Unauthorized: invalid api key");
+    });
+
+    const result = await runDirectMemoryCompletion(
+      { model: mockModel(false), modelRegistry } as never,
+      null as never,
+      null,
+      directOptions(),
+      null,
+      null,
+      { completeSimple: complete as never },
+    );
+
+    assert.strictEqual(result.ok, true);
+    assert.deepStrictEqual(usedKeys, ["revoked-key", "rotated-key"]);
+  });
+
+  it("does not retry when the refreshed key is the same one the provider rejected", async () => {
+    const { modelRegistry } = rotatingRegistry("only-key");
+    const { usedKeys, complete } = completionStub(() => new Error("HTTP 401 Unauthorized"));
+
+    const result = await runDirectMemoryCompletion(
+      { model: mockModel(false), modelRegistry } as never,
+      null as never,
+      null,
+      directOptions(),
+      null,
+      null,
+      { completeSimple: complete as never },
+    );
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.fallbackReason, "provider_error");
+    assert.strictEqual(usedKeys.length, 1, "an unchanged key means a real auth problem, not a rotation race");
+  });
+
+  it("keeps working when reloading the credential file throws", async () => {
+    const { modelRegistry } = rotatingRegistry("only-key");
+    modelRegistry.authStorage.reload = () => { throw new Error("auth.json is not valid JSON"); };
+    const { usedKeys, complete } = completionStub(() => emptyOperations);
+
+    const result = await runDirectMemoryCompletion(
+      { model: mockModel(false), modelRegistry } as never,
+      null as never,
+      null,
+      directOptions(),
+      null,
+      null,
+      { completeSimple: complete as never },
+    );
+
+    assert.strictEqual(result.ok, true);
+    assert.deepStrictEqual(usedKeys, ["only-key"]);
+  });
+
+  it("classifies provider auth rejections without swallowing other failures", () => {
+    for (const message of [
+      "HTTP 401 Unauthorized",
+      "403 Forbidden",
+      "invalid_api_key",
+      "Invalid API key provided",
+      "authentication failed",
+      "token expired",
+      "subscription key revoked",
+    ]) {
+      assert.strictEqual(isAuthRejection(message), true, message);
+    }
+
+    for (const message of [
+      "HTTP 500 Internal Server Error",
+      "429 rate limit exceeded",
+      "socket hang up",
+      "context length exceeded",
+    ]) {
+      assert.strictEqual(isAuthRejection(message), false, message);
+    }
   });
 });
 


### PR DESCRIPTION
Closes #139.

Overlaps with #142 by @xz-dev, which fixes the same root cause but bundles it with consolidation-plan validation, atomic shrinking updates, subprocess-transport semantics, dependency bumps and a ~1900-line lockfile churn. This branch is the minimal, isolated fix so the auth change can be reviewed and shipped on its own — happy to close it in favour of #142 if you'd rather take the bundle.

## Root cause

Traced through the SDK rather than inferred:

- `AuthStorage` calls `this.reload()` exactly once, in its constructor (`core/auth-storage.js`). For an `api_key` credential, `this.data` is never re-read again — the only automatic reload is on an OAuth refresh *failure*.
- `ExtensionRunner.createContext()` exposes `modelRegistry` through a getter onto a single instance assigned in the runner constructor, so every event's `ctx.modelRegistry` is the same singleton for the process lifetime.

So `runDirectMemoryCompletion` resolved auth against a snapshot taken at session start. When `@lnilluv/pi-opencode-go-rotation` writes a new `opencode-go` key to `auth.json` after a weekly limit, the running session never sees it and keeps presenting the revoked key until it exits. The subprocess transport accidentally worked, because a fresh `pi -p` builds its own `AuthStorage`.

## Fix

`resolveFreshRequestAuth()` calls the public `modelRegistry.authStorage.reload()` before `getApiKeyAndHeaders()`. `reload()` is a synchronous read of one small file and runs a handful of times per session (background review, flush, correction, consolidation) — cheap enough to pay every time, which is what the issue asked for: *"at minimum re-read it on each call rather than caching indefinitely."*

Plus a reactive path for a rotation that lands mid-request: on a provider auth rejection, re-read and retry **once**, but only if the key actually changed. An unchanged key is a real auth problem, so it still falls through to the subprocess transport rather than burning a pointless retry.

A malformed `auth.json` can't take the review path down — a throwing `reload()` falls through to the already-loaded credentials.

No new events or handlers: `ctx.modelRegistry.authStorage` is public SDK surface, and there is no auth-change event to subscribe to.

## Known gap (upstream)

`!command`-backed keys stay stale. They're memoized in the SDK's `commandResultCache`, and `clearApiKeyCache` is declared in `core/model-registry` but not re-exported from the package root — the `exports` map is `{".": ...}` only, so there's no supported way to clear it from an extension. Worth an upstream request; deliberately not deep-imported here.

## Verification

`runDirectMemoryCompletion` gains a `deps.completeSimple` seam, matching the existing `deps` convention in `triggerConsolidation`. New tests use a registry double that mirrors `AuthStorage` (a `disk` value and a `loaded` snapshot that only `reload()` copies across):

- a key rotated on disk reaches the provider; the stale snapshot never does
- a 401 mid-flight triggers exactly one retry, with the rotated key
- an unchanged key after refresh does **not** retry
- a throwing `reload()` degrades to the loaded credentials
- `isAuthRejection` accepts 401/403/invalid-key/expired-token phrasings and rejects 500/429/socket/context-length

`npm run check` clean, all 40 test files pass.
