### PR TITLE
feat: add standing instructions that are injected in every mode (#121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,32 @@ System Prompt
 
 Set `"memoryPolicyStyle"` to `"full"`, `"compact"`, `"custom"`, or `"none"` to choose policy verbosity while keeping policy-only mode. Set `"memoryMode": "legacy-inject"` to restore the old behavior that injects MEMORY.md, USER.md, project memory, and recent failures into the prompt.
 
+## Standing Instructions
+
+Recall is probabilistic. In `policy-only` mode a stored rule only takes effect if the agent decides to call `memory_search` **before** the action the rule would have prevented — and for a prohibition, that is exactly the moment it has no reason to look. Preferences survive a missed lookup; prohibitions do not.
+
+Standing instructions are the answer to that: a small, user-authored file that is injected into **every** session, in every memory mode.
+
+```
+/memory-pin never run find / or other root-wide filesystem searches
+/memory-pin                     # list what is pinned and how much budget is left
+/memory-pin remove 2            # drop one
+/memory-pin clear               # drop all
+```
+
+They land in a `<standing-instructions>` block placed after the memory policy, so they read as a direct user directive rather than as recalled context.
+
+| Property | Behavior |
+|---|---|
+| **Provenance** | Stored in `~/.pi/agent/pi-hermes-memory/STANDING.md`. Background review, consolidation, and the correction detector never write there — only your editor or `/memory-pin` can. The agent cannot promote its own memory into this block. |
+| **Budget** | Hard cap of 20 entries / 2,000 characters, separate from `memoryCharLimit` and `userCharLimit`. `/memory-pin` refuses a write past the cap; a hand-edited file over the cap is truncated at injection and the omission is stated loudly inside the block. |
+| **Safety** | Every pin goes through the same `scanContent()` injection/exfiltration scan as any memory write, and the block is fenced. |
+| **Disabling** | Set `"standingInstructionsEnabled": false` to drop the store and the command entirely. |
+
+Run `/memory-preview-context` to see exactly what is injected.
+
+This is deliberately *not* tool enforcement. If you need a hard block on a dangerous command rather than a reliable instruction, add a `tool_call` guard — that is a different feature with a different failure mode.
+
 ## Failure Memory
 
 The agent learns from failures, corrections, and insights — just like humans do.
@@ -483,7 +509,8 @@ Create `~/.pi/agent/hermes-memory-config.json`:
   "flushOnCompact": true,
   "flushOnShutdown": true,
   "flushMinTurns": 6,
-  "flushRecentMessages": 0
+  "flushRecentMessages": 0,
+  "standingInstructionsEnabled": true
 }
 ```
 
@@ -492,6 +519,7 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 | `memoryMode` | `policy-only` | Prompt behavior: `policy-only` injects only memory policy; `legacy-inject` restores full memory prompt injection |
 | `memoryPolicyStyle` | `full` | Policy text used in `policy-only` mode: `full` preserves the default v0.7 policy; `compact` uses shorter built-in guidance; `custom` uses `memoryPolicyCustomText`; `none` injects no policy text |
 | `memoryPolicyCustomText` | unset | Custom policy text used when `memoryPolicyStyle` is `custom`; blank or missing text falls back to `compact` |
+| `standingInstructionsEnabled` | `true` | Inject `STANDING.md` (pinned via `/memory-pin`) into every session, in every memory mode |
 | `memoryCharLimit` | `5000` | Max characters in MEMORY.md |
 | `userCharLimit` | `5000` | Max characters in USER.md |
 | `projectCharLimit` | `5000` | Max characters in project-scoped MEMORY.md |

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,6 +60,7 @@ const DEFAULT_CONFIG: MemoryConfig = {
   failureInjectionMaxEntries: DEFAULT_FAILURE_INJECTION_MAX_ENTRIES,
   consolidationTimeoutMs: DEFAULT_CONSOLIDATION_TIMEOUT_MS,
   nudgeToolCalls: DEFAULT_NUDGE_TOOL_CALLS,
+  standingInstructionsEnabled: true,
   projectsMemoryDir: DEFAULT_PROJECTS_MEMORY_DIR,
   sessionSearch: { variant: "legacy" },
 };
@@ -128,6 +129,7 @@ export function loadConfig(configPath = DEFAULT_CONFIG_PATH): MemoryConfig {
       if (typeof parsed.failureInjectionMaxAgeDays === "number") config.failureInjectionMaxAgeDays = parsed.failureInjectionMaxAgeDays;
       if (typeof parsed.failureInjectionMaxEntries === "number") config.failureInjectionMaxEntries = parsed.failureInjectionMaxEntries;
       if (typeof parsed.nudgeToolCalls === "number") config.nudgeToolCalls = parsed.nudgeToolCalls;
+      if (typeof parsed.standingInstructionsEnabled === "boolean") config.standingInstructionsEnabled = parsed.standingInstructionsEnabled;
       if (typeof parsed.projectCharLimit === "number") config.projectCharLimit = parsed.projectCharLimit;
       if (typeof parsed.memoryDir === "string") {
         const normalizedMemoryDir = normalizeConfiguredMemoryDir(parsed.memoryDir);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,6 +35,15 @@ export const DEFAULT_FAILURE_INJECTION_MAX_ENTRIES = 5;
 // ─── File names ───
 export const MEMORY_FILE = "MEMORY.md";
 export const USER_FILE = "USER.md";
+export const STANDING_FILE = "STANDING.md";
+
+// ─── Standing instructions (#121) ───
+// A hard budget, deliberately separate from memoryCharLimit/userCharLimit.
+// These are injected in every mode including policy-only, so the cost has to
+// stay something a user can hold in their head; MEMORY.md + USER.md routinely
+// run to tens of KB and must never be able to crowd this out.
+export const STANDING_MAX_ENTRIES = 20;
+export const STANDING_MAX_CHARS = 2000;
 
 // ─── Runtime memory policy prompt ───
 export const MEMORY_POLICY_PROMPT = `<memory-policy>

--- a/src/handlers/preview-context.ts
+++ b/src/handlers/preview-context.ts
@@ -5,8 +5,21 @@
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { MemoryStore } from "../store/memory-store.js";
+import type { StandingInstructions } from "../store/standing-instructions.js";
 import { resolveMemoryPolicyPrompt } from "../prompt-context.js";
 import type { MemoryConfig } from "../types.js";
+
+function appendStandingBlock(lines: string[], standing: StandingInstructions | null): number {
+  const rendered = standing?.render();
+  if (!rendered?.block) return 0;
+  lines.push("  ── STANDING INSTRUCTIONS (always injected) ─────────────────");
+  lines.push(rendered.block);
+  if (rendered.omittedCount > 0) {
+    lines.push(`  ⚠️ ${rendered.omittedCount} pinned instruction(s) exceed the budget and are NOT injected.`);
+  }
+  lines.push("");
+  return 1;
+}
 
 export function registerPreviewContextCommand(
   pi: ExtensionAPI,
@@ -14,6 +27,7 @@ export function registerPreviewContextCommand(
   projectStore: MemoryStore | null,
   projectName: string,
   config: Pick<MemoryConfig, "memoryMode" | "memoryPolicyStyle" | "memoryPolicyCustomText"> = { memoryMode: "policy-only" },
+  standing: StandingInstructions | null = null,
 ): void {
   pi.registerCommand("memory-preview-context", {
     description: "Preview the memory policy or legacy memory context blocks",
@@ -31,15 +45,17 @@ export function registerPreviewContextCommand(
         lines.push("  This is the memory policy appended to the system prompt.");
         lines.push("  Full Markdown memories are NOT injected in this mode.");
         lines.push("");
+        let blockCount = 0;
         if (policyPrompt) {
+          blockCount++;
           lines.push(policyPrompt);
           lines.push("");
-          lines.push("  Blocks shown: 1");
         } else {
           lines.push("  No memory policy context is injected for this policy style.");
           lines.push("");
-          lines.push("  Blocks shown: 0");
         }
+        blockCount += appendStandingBlock(lines, standing);
+        lines.push(`  Blocks shown: ${blockCount}`);
         ctx.ui.notify(lines.join("\n"), "info");
         return;
       }
@@ -72,6 +88,8 @@ export function registerPreviewContextCommand(
         lines.push(projectBlock);
         lines.push("");
       }
+
+      blockCount += appendStandingBlock(lines, standing);
 
       if (blockCount === 0) {
         lines.push("  No memory context blocks are currently injected.");

--- a/src/handlers/standing-pin.ts
+++ b/src/handlers/standing-pin.ts
@@ -1,0 +1,111 @@
+/**
+ * /memory-pin — the only writer of STANDING.md besides the user's own editor.
+ *
+ * Deliberately not a tool: background review, consolidation and the correction
+ * detector must have no path into the always-injected block (#121). Keeping it
+ * a slash command makes model-authored standing instructions structurally
+ * impossible rather than merely forbidden by prompt.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { STANDING_MAX_CHARS, STANDING_MAX_ENTRIES } from "../constants.js";
+import type { StandingInstructions } from "../store/standing-instructions.js";
+
+const SUBCOMMANDS = ["list", "remove", "clear"] as const;
+
+function formatList(store: StandingInstructions): string[] {
+  const instructions = store.list();
+  const lines: string[] = [];
+  lines.push("");
+  lines.push("  ╔══════════════════════════════════════════════╗");
+  lines.push("  ║          📌 Standing Instructions            ║");
+  lines.push("  ╚══════════════════════════════════════════════╝");
+  lines.push("");
+
+  if (instructions.length === 0) {
+    lines.push("  (none pinned)");
+    lines.push("");
+    lines.push("  Pin a rule that must hold in every session:");
+    lines.push("    /memory-pin never run find / or other root-wide searches");
+    lines.push("");
+    return lines;
+  }
+
+  const { injectedCount, omittedCount } = store.render();
+  const used = instructions.join("\n").length;
+  for (const [index, instruction] of instructions.entries()) {
+    lines.push(`  ${index + 1}. ${instruction}`);
+  }
+  lines.push("");
+  lines.push(`  ${instructions.length}/${STANDING_MAX_ENTRIES} entries · ${used}/${STANDING_MAX_CHARS} chars`);
+  lines.push(`  Injected into every session: ${injectedCount}`);
+  if (omittedCount > 0) {
+    lines.push(`  ⚠️ ${omittedCount} over budget and NOT injected — remove or shorten entries.`);
+  }
+  lines.push(`  File: ${store.getFilePath()}`);
+  lines.push("");
+  lines.push("  /memory-pin remove <n> · /memory-pin clear");
+  lines.push("");
+  return lines;
+}
+
+export function registerStandingPinCommand(pi: ExtensionAPI, store: StandingInstructions): void {
+  pi.registerCommand("memory-pin", {
+    description: "Pin a standing instruction that is injected into every session",
+    getArgumentCompletions: (prefix) => {
+      const trimmed = prefix.trimStart();
+      if (trimmed.includes(" ")) return null;
+      return SUBCOMMANDS
+        .filter((name) => name.startsWith(trimmed))
+        .map((name) => ({ value: name, label: name }));
+    },
+    handler: async (args, ctx) => {
+      if (!store.isLoaded()) await store.load();
+
+      const input = (args ?? "").trim();
+      const [head, ...rest] = input.split(/\s+/);
+      const subcommand = head?.toLowerCase();
+
+      if (input === "" || subcommand === "list") {
+        ctx.ui.notify(formatList(store).join("\n"), "info");
+        return;
+      }
+
+      if (subcommand === "clear") {
+        const result = await store.clear();
+        ctx.ui.notify(result.success ? `📌 ${result.message}` : `❌ ${result.error}`, result.success ? "info" : "warning");
+        return;
+      }
+
+      if (subcommand === "remove") {
+        const position = Number(rest[0]);
+        const result = await store.remove(position);
+        if (!result.success) {
+          ctx.ui.notify(`❌ ${result.error}`, "warning");
+          return;
+        }
+        ctx.ui.notify([`📌 ${result.message}`, "", ...formatList(store)].join("\n"), "info");
+        return;
+      }
+
+      const result = await store.add(input);
+      if (!result.success) {
+        ctx.ui.notify(`❌ ${result.error}`, "warning");
+        return;
+      }
+
+      // Echo exactly what will be injected, so the user can see the stored text
+      // rather than trusting that their phrasing survived normalization.
+      ctx.ui.notify(
+        [
+          `📌 ${result.message}`,
+          "",
+          "  This is now injected into every session, in all memory modes.",
+          "  It takes effect from your next message.",
+          "",
+        ].join("\n"),
+        "info",
+      );
+    },
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,9 @@ import { registerIndexSessionsCommand } from "./handlers/index-sessions.js";
 import { registerLearnMemoryCommand } from "./handlers/learn-memory.js";
 import { migrateThenSyncMarkdownMemories, registerSyncMarkdownMemoriesCommand } from "./handlers/sync-markdown-memories.js";
 import { registerPreviewContextCommand } from "./handlers/preview-context.js";
+import { registerStandingPinCommand } from "./handlers/standing-pin.js";
+import { StandingInstructions } from "./store/standing-instructions.js";
+import { STANDING_FILE } from "./constants.js";
 import { loadConfig } from "./config.js";
 import { detectProject, detectProjectSkills } from "./project.js";
 import { buildPromptContext } from "./prompt-context.js";
@@ -143,6 +146,11 @@ export default function (pi: ExtensionAPI) {
     ? { ...config, memoryCharLimit: config.projectCharLimit, memoryDir: project.memoryDir }
     : { ...config, memoryDir: undefined };
   const projectStore = project.memoryDir ? new MemoryStore(projectConfig) : null;
+  // Never written by review, consolidation or the correction detector — see
+  // store/standing-instructions.ts for why provenance has to be structural.
+  const standingStore = config.standingInstructionsEnabled !== false
+    ? new StandingInstructions(path.join(globalDir, STANDING_FILE))
+    : null;
 
   // ── 1. Load memory from disk on session start ──
   pi.on("session_start", async (_event, ctx) => {
@@ -172,6 +180,7 @@ export default function (pi: ExtensionAPI) {
     await skillStore.ensureDiscoveredRoots();
     await store.loadFromDisk();
     if (projectStore) await projectStore.loadFromDisk();
+    if (standingStore) await standingStore.load();
 
     if (persistenceInitialized) scheduleSessionBackfill(dbManager, sessionsDir, {
       notify: (message, level) => {
@@ -191,7 +200,7 @@ export default function (pi: ExtensionAPI) {
 
   // ── 2. Inject memory policy by default; legacy mode keeps full frozen memory blocks ──
   pi.on("before_agent_start", async (event, _ctx) => {
-    const promptContext = await buildPromptContext(config, store, projectStore, projectName);
+    const promptContext = await buildPromptContext(config, store, projectStore, projectName, standingStore);
 
     if (promptContext) {
       return {
@@ -257,7 +266,8 @@ export default function (pi: ExtensionAPI) {
   registerSwitchProjectCommand(pi, config);
   registerLearnMemoryCommand(pi);
   registerSyncMarkdownMemoriesCommand(pi, dbManager, globalDir, config.projectsMemoryDir, agentRoot);
-  registerPreviewContextCommand(pi, store, projectStore, projectName, config);
+  registerPreviewContextCommand(pi, store, projectStore, projectName, config, standingStore);
+  if (standingStore) registerStandingPinCommand(pi, standingStore);
 
   // ── 10. Live session indexing ──
   pi.on("message_end", async (_event, ctx) => {

--- a/src/prompt-context.ts
+++ b/src/prompt-context.ts
@@ -1,6 +1,7 @@
 import { MEMORY_POLICY_PROMPT, MEMORY_POLICY_PROMPT_COMPACT } from "./constants.js";
 import type { MemoryConfig } from "./types.js";
 import type { MemoryStore } from "./store/memory-store.js";
+import type { StandingInstructions } from "./store/standing-instructions.js";
 
 type MemoryPolicyConfig = Pick<MemoryConfig, "memoryPolicyStyle" | "memoryPolicyCustomText">;
 
@@ -22,14 +23,24 @@ export function resolveMemoryPolicyPrompt(config: MemoryPolicyConfig): string {
   }
 }
 
+/**
+ * Standing instructions are appended in *every* mode, including policy-only
+ * and policy style "none". That is the whole point of the store: a rule the
+ * user pinned must not depend on the model choosing to run memory_search
+ * before the action it forbids (#121). They go last so they read as the
+ * operative directive rather than as recalled context.
+ */
 export async function buildPromptContext(
   config: Pick<MemoryConfig, "memoryMode" | "memoryPolicyStyle" | "memoryPolicyCustomText">,
   store: MemoryStore,
   projectStore: MemoryStore | null,
   projectName: string,
+  standing: StandingInstructions | null = null,
 ): Promise<string> {
+  const standingBlock = standing?.formatForSystemPrompt() ?? "";
+
   if (config.memoryMode === "policy-only") {
-    return resolveMemoryPolicyPrompt(config);
+    return [resolveMemoryPolicyPrompt(config), standingBlock].filter(Boolean).join("\n\n");
   }
 
   const memoryBlock = store.formatForSystemPrompt();
@@ -38,6 +49,7 @@ export async function buildPromptContext(
   const parts: string[] = [];
   if (memoryBlock) parts.push(memoryBlock);
   if (projectBlock) parts.push(projectBlock);
+  if (standingBlock) parts.push(standingBlock);
 
   return parts.join("\n\n");
 }

--- a/src/store/standing-instructions.ts
+++ b/src/store/standing-instructions.ts
@@ -1,0 +1,247 @@
+/**
+ * Standing instructions — bounded, user-authored directives injected into
+ * every session regardless of memoryMode.
+ *
+ * Why this is a separate store rather than a flag on MEMORY.md / USER.md
+ * (#121): in policy-only mode a persisted constraint only takes effect if the
+ * model decides to call memory_search *before* the action the constraint would
+ * have prevented. For a prohibition that is exactly the moment the model has no
+ * reason to look, so the recall path is structurally unable to enforce it,
+ * independent of model quality. Such constraints have to be unconditionally
+ * present instead.
+ *
+ * Provenance is a property of the storage, not of a flag: background review,
+ * consolidation and the correction detector all write through MemoryStore and
+ * never touch this file, so a model-generated memory has no path into the
+ * always-injected block. Only a direct user edit or /memory-pin can write here.
+ *
+ * The budget is hard and separate from the Markdown stores: a user whose
+ * MEMORY.md + USER.md already run to tens of KB must still be able to pin a
+ * handful of rules without paying for the rest.
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import {
+  STANDING_MAX_CHARS,
+  STANDING_MAX_ENTRIES,
+} from "../constants.js";
+import { scanContent } from "./content-scanner.js";
+import { withMarkdownMutationLock } from "./markdown-mutation-lock.js";
+
+export interface StandingInstructionResult {
+  success: boolean;
+  error?: string;
+  message?: string;
+  instructions?: string[];
+}
+
+/** What actually reached the prompt, so callers can report truncation loudly. */
+export interface StandingInstructionRender {
+  block: string;
+  injectedCount: number;
+  omittedCount: number;
+}
+
+export class StandingInstructions {
+  private instructions: string[] = [];
+  private loaded = false;
+
+  constructor(
+    private readonly filePath: string,
+    private readonly maxEntries: number = STANDING_MAX_ENTRIES,
+    private readonly maxChars: number = STANDING_MAX_CHARS,
+  ) {}
+
+  getFilePath(): string {
+    return this.filePath;
+  }
+
+  async load(): Promise<void> {
+    try {
+      const raw = await fs.readFile(this.filePath, "utf-8");
+      this.instructions = parseInstructions(raw);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      this.instructions = [];
+    }
+    this.loaded = true;
+  }
+
+  isLoaded(): boolean {
+    return this.loaded;
+  }
+
+  list(): string[] {
+    return [...this.instructions];
+  }
+
+  async add(text: string): Promise<StandingInstructionResult> {
+    const instruction = normalizeInstruction(text);
+    if (!instruction) {
+      return { success: false, error: "A standing instruction cannot be empty." };
+    }
+
+    // Same scan every memory write goes through. A file the user is told is
+    // "always in context" is the most attractive injection target we have.
+    const blocked = scanContent(instruction);
+    if (blocked) return { success: false, error: blocked };
+
+    return this.mutate((current) => {
+      if (current.some((existing) => existing.toLowerCase() === instruction.toLowerCase())) {
+        return { error: "That standing instruction is already pinned." };
+      }
+      if (current.length >= this.maxEntries) {
+        return {
+          error: `Standing instructions are capped at ${this.maxEntries} entries`
+            + ` (currently ${current.length}). Remove one first with /memory-pin remove <n>.`,
+        };
+      }
+      const projected = [...current, instruction];
+      const projectedChars = projected.join("\n").length;
+      if (projectedChars > this.maxChars) {
+        return {
+          error: `Standing instructions are capped at ${this.maxChars} characters`
+            + ` and this entry would make ${projectedChars}. Shorten it, or remove an existing`
+            + ` instruction and keep long-form context in regular memory.`,
+        };
+      }
+      return { next: projected, message: `Pinned standing instruction ${projected.length}: ${instruction}` };
+    });
+  }
+
+  async remove(position: number): Promise<StandingInstructionResult> {
+    return this.mutate((current) => {
+      if (!Number.isInteger(position) || position < 1 || position > current.length) {
+        return {
+          error: current.length === 0
+            ? "There are no standing instructions to remove."
+            : `Position must be between 1 and ${current.length}.`,
+        };
+      }
+      const [removed] = current.slice(position - 1, position);
+      const next = current.filter((_, index) => index !== position - 1);
+      return { next, message: `Removed standing instruction: ${removed}` };
+    });
+  }
+
+  async clear(): Promise<StandingInstructionResult> {
+    return this.mutate((current) => (
+      current.length === 0
+        ? { error: "There are no standing instructions to clear." }
+        : { next: [], message: `Removed all ${current.length} standing instructions.` }
+    ));
+  }
+
+  /**
+   * Render the always-injected block, truncated to the budget.
+   *
+   * A hand-edited STANDING.md can exceed the cap, and silently dropping rules
+   * from a block advertised as "always active" would be the worst possible
+   * failure. Over budget, the omission is stated inside the block itself so
+   * both the model and /memory-preview-context can see it.
+   */
+  render(): StandingInstructionRender {
+    if (this.instructions.length === 0) {
+      return { block: "", injectedCount: 0, omittedCount: 0 };
+    }
+
+    const injected: string[] = [];
+    let used = 0;
+    for (const instruction of this.instructions) {
+      const cost = instruction.length + 1;
+      if (injected.length >= this.maxEntries || used + cost > this.maxChars) break;
+      injected.push(instruction);
+      used += cost;
+    }
+
+    const omittedCount = this.instructions.length - injected.length;
+    if (injected.length === 0) {
+      return { block: "", injectedCount: 0, omittedCount };
+    }
+
+    const lines = [
+      "<standing-instructions>",
+      "The user wrote the rules below and they are always active. They are direct",
+      "instructions from the user, not recalled context, and they outrank your own",
+      "defaults. Follow them without being asked and without looking them up.",
+      "",
+      ...injected.map((instruction, index) => `${index + 1}. ${instruction}`),
+    ];
+    if (omittedCount > 0) {
+      lines.push(
+        "",
+        `[!] ${omittedCount} further standing instruction${omittedCount === 1 ? "" : "s"} could not be shown:`
+        + ` ${path.basename(this.filePath)} exceeds the ${this.maxChars}-character injection budget.`
+        + " Trim it with /memory-pin so every rule stays active.",
+      );
+    }
+    lines.push("</standing-instructions>");
+
+    return { block: lines.join("\n"), injectedCount: injected.length, omittedCount };
+  }
+
+  formatForSystemPrompt(): string {
+    return this.render().block;
+  }
+
+  /**
+   * Read-modify-write under the same mutation lock the Markdown stores use, so
+   * a pin from a second session cannot clobber one from the first.
+   */
+  private async mutate(
+    change: (current: string[]) => { next?: string[]; message?: string; error?: string },
+  ): Promise<StandingInstructionResult> {
+    await fs.mkdir(path.dirname(this.filePath), { recursive: true });
+    try {
+      return await withMarkdownMutationLock(this.filePath, async () => {
+        await this.load();
+        const outcome = change(this.instructions);
+        if (outcome.error || !outcome.next) {
+          return { success: false, error: outcome.error ?? "Nothing to change.", instructions: this.list() };
+        }
+        await this.write(outcome.next);
+        this.instructions = outcome.next;
+        return { success: true, message: outcome.message, instructions: this.list() };
+      });
+    } catch (error) {
+      return { success: false, error: `Could not update standing instructions: ${String(error).slice(0, 200)}` };
+    }
+  }
+
+  /** Atomic write: temp file in the same directory, then rename. */
+  private async write(instructions: string[]): Promise<void> {
+    const content = instructions.length ? `${instructions.join("\n")}\n` : "";
+    const tmpDir = await fs.mkdtemp(path.join(path.dirname(this.filePath), ".tmp-standing-"));
+    const tmpPath = path.join(tmpDir, "write.tmp");
+    try {
+      await fs.writeFile(tmpPath, content, "utf-8");
+      await fs.rename(tmpPath, this.filePath);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  }
+}
+
+/**
+ * One instruction per line. Blank lines, `#` comments and a leading `-`/`*`
+ * bullet are tolerated so a hand-edited STANDING.md stays a normal Markdown
+ * file rather than a format the user has to get exactly right.
+ */
+function parseInstructions(raw: string): string[] {
+  const seen = new Set<string>();
+  const instructions: string[] = [];
+  for (const line of raw.split("\n")) {
+    const instruction = normalizeInstruction(line);
+    if (!instruction || instruction.startsWith("#")) continue;
+    const key = instruction.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    instructions.push(instruction);
+  }
+  return instructions;
+}
+
+function normalizeInstruction(text: string): string {
+  return text.replace(/^\s*[-*]\s+/, "").replace(/\s+/g, " ").trim();
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,8 @@ export interface MemoryConfig {
   nudgeToolCalls: number;
   /** Maximum time in milliseconds for a consolidation run, auto or manual. Default: 180000 */
   consolidationTimeoutMs: number;
+  /** Inject pinned STANDING.md instructions into every session. Default: true */
+  standingInstructionsEnabled: boolean;
 }
 
 export type MemoryCategory =

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -38,6 +38,7 @@ describe("loadConfig", () => {
     assert.deepStrictEqual(config.sessionSearch, { variant: "legacy" });
     assert.strictEqual(config.llmModelOverride, undefined);
     assert.strictEqual(config.llmThinkingOverride, undefined);
+    assert.strictEqual(config.standingInstructionsEnabled, true);
   });
 
   it("honors a configured consolidationTimeoutMs, warning only when it is below the default", () => {

--- a/tests/handlers/prompt-context.test.ts
+++ b/tests/handlers/prompt-context.test.ts
@@ -111,4 +111,56 @@ describe("buildPromptContext", () => {
     assert.match(result, /PROJECT demo/);
     assert.doesNotMatch(result, /<memory-policy>/);
   });
+
+  const standing = {
+    formatForSystemPrompt: () => "<standing-instructions>\n1. never run find /\n</standing-instructions>",
+  } as any;
+
+  it("appends standing instructions after the policy in policy-only mode", async () => {
+    const result = await buildPromptContext(
+      { memoryMode: "policy-only" },
+      store,
+      projectStore,
+      "demo",
+      standing,
+    );
+
+    assert.ok(result.startsWith(MEMORY_POLICY_PROMPT), "the policy still leads");
+    assert.match(result, /<standing-instructions>/);
+    assert.match(result, /never run find \//);
+    assert.doesNotMatch(result, /MEMORY<\/memory-context>/, "stored memories stay out of policy-only");
+  });
+
+  it("injects standing instructions even when the policy style is none", async () => {
+    const result = await buildPromptContext(
+      { memoryMode: "policy-only", memoryPolicyStyle: "none" },
+      store,
+      projectStore,
+      "demo",
+      standing,
+    );
+
+    assert.strictEqual(result, "<standing-instructions>\n1. never run find /\n</standing-instructions>");
+  });
+
+  it("puts standing instructions last in legacy-inject mode", async () => {
+    const result = await buildPromptContext(
+      { memoryMode: "legacy-inject" },
+      store,
+      projectStore,
+      "demo",
+      standing,
+    );
+
+    assert.ok(
+      result.indexOf("<standing-instructions>") > result.indexOf("PROJECT demo"),
+      "user directives read last, closest to the task",
+    );
+  });
+
+  it("injects nothing extra when no standing store is wired", async () => {
+    const result = await buildPromptContext({ memoryMode: "policy-only" }, store, projectStore, "demo");
+
+    assert.strictEqual(result, MEMORY_POLICY_PROMPT);
+  });
 });

--- a/tests/handlers/standing-pin.test.ts
+++ b/tests/handlers/standing-pin.test.ts
@@ -1,0 +1,134 @@
+/**
+ * /memory-pin — the only command that writes STANDING.md (#121).
+ */
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { registerStandingPinCommand } from "../../src/handlers/standing-pin.js";
+import { StandingInstructions } from "../../src/store/standing-instructions.js";
+import { STANDING_MAX_ENTRIES } from "../../src/constants.js";
+
+let root = "";
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-standing-pin-"));
+});
+
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+function setup() {
+  const commands: { name: string; conf: any }[] = [];
+  const notifyCalls: { message: string; severity: string }[] = [];
+  const mockPi = {
+    registerCommand: (name: string, conf: any) => { commands.push({ name, conf }); },
+  } as any;
+
+  const store = new StandingInstructions(path.join(root, "STANDING.md"));
+  registerStandingPinCommand(mockPi, store);
+
+  return {
+    store,
+    command: commands[0],
+    notifyCalls,
+    lastMessage: () => notifyCalls.at(-1)!,
+    ctx: {
+      ui: {
+        notify: (message: string, severity: string) => { notifyCalls.push({ message, severity }); },
+      },
+    },
+  };
+}
+
+describe("registerStandingPinCommand", () => {
+  it("registers /memory-pin", () => {
+    const { command } = setup();
+    assert.strictEqual(command.name, "memory-pin");
+    assert.match(command.conf.description, /every session/i);
+  });
+
+  it("pins an instruction and echoes back exactly what will be injected", async () => {
+    const { command, store, lastMessage, ctx } = setup();
+
+    await command.conf.handler("never   run find / from root", ctx);
+
+    assert.deepStrictEqual(store.list(), ["never run find / from root"]);
+    assert.strictEqual(lastMessage().severity, "info");
+    assert.match(lastMessage().message, /Pinned standing instruction 1: never run find \/ from root/);
+    assert.match(lastMessage().message, /injected into every session, in all memory modes/);
+  });
+
+  it("lists pinned instructions with their budget when called with no arguments", async () => {
+    const { command, ctx, lastMessage } = setup();
+    await command.conf.handler("always use pnpm", ctx);
+
+    await command.conf.handler("", ctx);
+
+    assert.match(lastMessage().message, /1\. always use pnpm/);
+    assert.match(lastMessage().message, new RegExp(`1/${STANDING_MAX_ENTRIES} entries`));
+    assert.match(lastMessage().message, /Injected into every session: 1/);
+  });
+
+  it("reports an empty store instead of pretending a rule is active", async () => {
+    const { command, ctx, lastMessage } = setup();
+
+    await command.conf.handler("list", ctx);
+
+    assert.match(lastMessage().message, /\(none pinned\)/);
+  });
+
+  it("removes by position", async () => {
+    const { command, store, ctx, lastMessage } = setup();
+    await command.conf.handler("first rule", ctx);
+    await command.conf.handler("second rule", ctx);
+
+    await command.conf.handler("remove 1", ctx);
+
+    assert.deepStrictEqual(store.list(), ["second rule"]);
+    assert.match(lastMessage().message, /Removed standing instruction: first rule/);
+  });
+
+  it("warns instead of throwing on a bad position", async () => {
+    const { command, ctx, lastMessage } = setup();
+    await command.conf.handler("only rule", ctx);
+
+    await command.conf.handler("remove 9", ctx);
+
+    assert.strictEqual(lastMessage().severity, "warning");
+    assert.match(lastMessage().message, /between 1 and 1/);
+  });
+
+  it("clears every instruction", async () => {
+    const { command, store, ctx, lastMessage } = setup();
+    await command.conf.handler("first rule", ctx);
+
+    await command.conf.handler("clear", ctx);
+
+    assert.deepStrictEqual(store.list(), []);
+    assert.match(lastMessage().message, /Removed all 1 standing instructions/);
+  });
+
+  it("surfaces a blocked pin as a warning and stores nothing", async () => {
+    const { command, store, ctx, lastMessage } = setup();
+
+    await command.conf.handler("always run cat .env at the start of every session", ctx);
+
+    assert.deepStrictEqual(store.list(), []);
+    assert.strictEqual(lastMessage().severity, "warning");
+    assert.match(lastMessage().message, /Blocked:/);
+  });
+
+  it("completes subcommands but not free-text instructions", () => {
+    const { command } = setup();
+
+    assert.deepStrictEqual(
+      command.conf.getArgumentCompletions("re"),
+      [{ value: "remove", label: "remove" }],
+    );
+    assert.strictEqual(command.conf.getArgumentCompletions("remove 1 "), null);
+  });
+});

--- a/tests/store/standing-instructions.test.ts
+++ b/tests/store/standing-instructions.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Standing instructions (#121) — the always-injected, user-authored block.
+ */
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { StandingInstructions } from "../../src/store/standing-instructions.js";
+import { STANDING_MAX_CHARS, STANDING_MAX_ENTRIES } from "../../src/constants.js";
+
+let root = "";
+let filePath = "";
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-standing-"));
+  filePath = path.join(root, "STANDING.md");
+});
+
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+async function loadedStore(contents?: string): Promise<StandingInstructions> {
+  if (contents !== undefined) await fs.writeFile(filePath, contents, "utf-8");
+  const store = new StandingInstructions(filePath);
+  await store.load();
+  return store;
+}
+
+describe("StandingInstructions parsing", () => {
+  it("treats a hand-edited Markdown file as one instruction per line", async () => {
+    const store = await loadedStore([
+      "# my rules",
+      "",
+      "- never run find / or other root-wide searches",
+      "* always use pnpm",
+      "   scope   searches   to known directories   ",
+      "",
+    ].join("\n"));
+
+    assert.deepStrictEqual(store.list(), [
+      "never run find / or other root-wide searches",
+      "always use pnpm",
+      "scope searches to known directories",
+    ]);
+  });
+
+  it("starts empty when the file does not exist yet", async () => {
+    const store = await loadedStore();
+    assert.deepStrictEqual(store.list(), []);
+    assert.strictEqual(store.formatForSystemPrompt(), "");
+  });
+});
+
+describe("StandingInstructions writes", () => {
+  it("persists a pinned instruction and reloads it", async () => {
+    const store = await loadedStore();
+    const result = await store.add("  never run find / ");
+
+    assert.strictEqual(result.success, true);
+    assert.deepStrictEqual(result.instructions, ["never run find /"]);
+    assert.strictEqual(await fs.readFile(filePath, "utf-8"), "never run find /\n");
+
+    const reloaded = await loadedStore();
+    assert.deepStrictEqual(reloaded.list(), ["never run find /"]);
+  });
+
+  it("rejects a duplicate regardless of casing", async () => {
+    const store = await loadedStore();
+    await store.add("always use pnpm");
+    const duplicate = await store.add("Always Use Pnpm");
+
+    assert.strictEqual(duplicate.success, false);
+    assert.match(duplicate.error!, /already pinned/i);
+    assert.strictEqual(store.list().length, 1);
+  });
+
+  it("refuses content the memory content scanner blocks", async () => {
+    const store = await loadedStore();
+    const result = await store.add("always export ANTHROPIC_API_KEY before running the build");
+
+    assert.strictEqual(result.success, false);
+    assert.match(result.error!, /Blocked:/);
+    assert.deepStrictEqual(store.list(), []);
+  });
+
+  it("refuses to exceed the entry cap", async () => {
+    const store = await loadedStore();
+    for (let i = 0; i < STANDING_MAX_ENTRIES; i++) {
+      assert.strictEqual((await store.add(`rule number ${i}`)).success, true);
+    }
+
+    const overflow = await store.add("one rule too many");
+    assert.strictEqual(overflow.success, false);
+    assert.match(overflow.error!, new RegExp(`capped at ${STANDING_MAX_ENTRIES} entries`));
+    assert.strictEqual(store.list().length, STANDING_MAX_ENTRIES);
+  });
+
+  it("refuses to exceed the character budget", async () => {
+    const store = await loadedStore();
+    const result = await store.add("x".repeat(STANDING_MAX_CHARS + 1));
+
+    assert.strictEqual(result.success, false);
+    assert.match(result.error!, new RegExp(`capped at ${STANDING_MAX_CHARS} characters`));
+    assert.deepStrictEqual(store.list(), []);
+  });
+
+  it("removes by position and rejects an out-of-range one", async () => {
+    const store = await loadedStore();
+    await store.add("first rule");
+    await store.add("second rule");
+
+    const removed = await store.remove(1);
+    assert.strictEqual(removed.success, true);
+    assert.deepStrictEqual(store.list(), ["second rule"]);
+
+    const bad = await store.remove(5);
+    assert.strictEqual(bad.success, false);
+    assert.match(bad.error!, /between 1 and 1/);
+  });
+
+  it("clears every instruction", async () => {
+    const store = await loadedStore();
+    await store.add("first rule");
+    await store.add("second rule");
+
+    const cleared = await store.clear();
+    assert.strictEqual(cleared.success, true);
+    assert.deepStrictEqual(store.list(), []);
+    assert.strictEqual(await fs.readFile(filePath, "utf-8"), "");
+  });
+});
+
+describe("StandingInstructions rendering", () => {
+  it("renders a numbered, fenced block that reads as user directive", async () => {
+    const store = await loadedStore("never run find /\nalways use pnpm\n");
+    const rendered = store.render();
+
+    assert.match(rendered.block, /^<standing-instructions>/);
+    assert.match(rendered.block, /<\/standing-instructions>$/);
+    assert.match(rendered.block, /1\. never run find \//);
+    assert.match(rendered.block, /2\. always use pnpm/);
+    assert.match(rendered.block, /direct\s+instructions from the user, not recalled context/);
+    assert.strictEqual(rendered.injectedCount, 2);
+    assert.strictEqual(rendered.omittedCount, 0);
+  });
+
+  it("truncates a hand-edited over-budget file loudly rather than silently", async () => {
+    // Written straight to disk: the /memory-pin cap cannot catch this path.
+    const long = Array.from({ length: 6 }, (_, i) => `${i} ${"y".repeat(450)}`);
+    const store = await loadedStore(`${long.join("\n")}\n`);
+    const rendered = store.render();
+
+    assert.ok(rendered.injectedCount > 0, "some rules still make it in");
+    assert.ok(rendered.omittedCount > 0, "the rest are dropped");
+    assert.strictEqual(rendered.injectedCount + rendered.omittedCount, 6);
+    assert.match(rendered.block, /could not be shown/);
+    assert.match(rendered.block, new RegExp(`${STANDING_MAX_CHARS}-character injection budget`));
+    assert.ok(
+      rendered.block.length < STANDING_MAX_CHARS + 1000,
+      "the block must stay near its budget, not blow past it",
+    );
+  });
+
+  it("renders nothing when no instructions are pinned", async () => {
+    const store = await loadedStore("# only a comment\n");
+    assert.deepStrictEqual(store.render(), { block: "", injectedCount: 0, omittedCount: 0 });
+  });
+});


### PR DESCRIPTION
Closes #121. Implements the design agreed in that thread, property by property. Original report and the four properties from @jagaliano.

## The problem, restated

Not a persistence bug. In `policy-only` mode a persisted constraint only takes effect if the model chooses to run `memory_search` **before** the tool call the constraint would have prevented. For a prohibition, that is precisely the moment the model has no reason to look — a model that doesn't already suspect `find /` is forbidden has no trigger to go check. The recall path is structurally unable to enforce prohibitions, independent of model quality. It works fine for preferences, where a wrong guess is cheap and recoverable.

Both existing workarounds (`legacy-inject`, duplicating into `AGENTS.md`) work by removing the lookup step. "Always present" is the actual requirement.

## What shipped

**1. Provenance is structural, not a flag.** `~/.pi/agent/pi-hermes-memory/STANDING.md`, written only by a direct user edit or `/memory-pin`. Background review, consolidation and the correction detector all write through `MemoryStore` and never touch this file, so a model-generated memory has no path into the trusted block — impossible by construction rather than forbidden by prompt. `/memory-pin` is a command, not a tool, for the same reason.

Deliberately **not** the lower-scope "inject memories marked critical" variant: that puts the trust boundary inside the same store the model writes to.

**2. Bounded budget.** Hard cap of 20 entries / 2000 chars, independent of `memoryCharLimit` and `userCharLimit` — the 31 KB in the report is exactly why this can't share a budget. `/memory-pin` refuses a write past the cap with a message that says which cap and by how much. A hand-edited file over the cap is truncated at injection and the omission is stated **inside** the block:

```
[!] 3 further standing instructions could not be shown: STANDING.md exceeds the
    2000-character injection budget. Trim it with /memory-pin so every rule stays active.
```

Silently dropping rules from a block advertised as "always active" would be the worst possible failure mode.

**3. Precedence and removal.** Injected in every mode — including `policy-only` and `memoryPolicyStyle: "none"` — in its own `<standing-instructions>` block placed after the memory policy and last overall, so it reads as an operative user directive rather than as recalled context. `/memory-pin` with no args lists entries with live budget usage; `remove <n>` and `clear` manage them; subcommands get argument completions. `/memory-preview-context` shows the block and flags over-budget entries.

**4. Enforcement hooks: out of scope**, as argued in the thread. A `tool_call` guard that pattern-matches dangerous commands has a different failure mode (false positives blocking legitimate work) and shouldn't ride in under a memory change. The README says so explicitly and points at the guard as the right shape for hard enforcement.

**Content safety.** Every pin goes through the same `scanContent()` injection/exfiltration scan as any memory write, and the block is fenced. A file the user is told is always in context is the most attractive target we have.

**Opt-out.** `standingInstructionsEnabled: false` drops both the store and the command.

## Compatibility

`policy-only` still means "no stored Markdown memories in the prompt" — the existing tests that pin that pass untouched. `buildPromptContext` takes the standing store as a trailing optional parameter, so a call without it is byte-identical to before. What changes is that `policy-only` is no longer "nothing but policy": it is now "policy, plus anything you explicitly pinned". That is a documented behaviour change and the README says so.

Writes go through the existing `withMarkdownMutationLock`, so a pin from a second session can't clobber one from the first. Loads once per session, consistent with the frozen-snapshot design; a pin takes effect from the next turn.

## Verification

End-to-end against the extension's real wiring — temp `PI_CODING_AGENT_DIR`, real `session_start` and `before_agent_start` handlers, default config:

```
$ /memory-pin never run find / or other root-wide filesystem searches
policy still present: true
standing block injected: true
rule present verbatim: true
markdown memories still NOT injected: true
```

Unit tests cover hand-edited-file parsing (bullets, comments, dedupe), persistence and reload, duplicate rejection, scanner rejection, both caps, remove/clear, block rendering, and loud truncation of an over-budget file; plus injection in all three modes, ordering behind project memory, and the full `/memory-pin` command surface.

`npm run check` clean, all 42 test files pass.
