### PR TITLE
docs: use a git install spec Pi actually accepts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,5 +70,8 @@ pi -e ./src/index.ts
 ## Installation (for users)
 
 ```bash
-pi install github:chandra447/pi-hermes-memory
+pi install npm:pi-hermes-memory
+
+# or from git
+pi install git:github.com/chandra447/pi-hermes-memory
 ```

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -90,7 +90,7 @@ After publishing:
 
 Before (git):
 ```bash
-pi install git:github:chandra447/pi-hermes-memory
+pi install git:github.com/chandra447/pi-hermes-memory
 ```
 
 After (npm):
@@ -102,7 +102,7 @@ pi install npm:pi-hermes-memory
 
 Replace:
 ```
-pi install github:chandra447/pi-hermes-memory
+pi install git:github.com/chandra447/pi-hermes-memory
 ```
 
 With:


### PR DESCRIPTION
Follow-up to #140 by @xz-dev, which found that our documented git install command doesn't work. Their PR fixes `README.md`; this covers the two places it doesn't touch.

There were three variants in the tree, and two of them are broken. Verified by running each through Pi's own `parseGitUrl` (`@earendil-works/pi-coding-agent/dist/utils/git.js`), whose `repo` field is handed straight to `git clone` (`core/package-manager.js:1480`):

| spec | result |
|---|---|
| `git:github.com/owner/repo` | `repo=https://github.com/owner/repo` — correct |
| `git:github:owner/repo` | `repo=https://github:owner/repo` — parses, then fails at clone |
| `github:owner/repo` | `NULL` — rejected outright |

The middle one is the subtle one: `hosted-git-info` resolves `host` and `path` correctly, so it looks fine, but `repo` ends up with `github` as the hostname and `owner` as the port:

```
$ git ls-remote "https://github:chandra447/pi-hermes-memory"
fatal: unable to access '...': URL rejected: Port number was not a decimal number between 0 and 65535
```

The third never even reaches the clone — `parseGitUrl` only accepts explicit protocol URLs when there is no `git:` prefix, so the bare `github:` shorthand is rejected during parsing.

Changed here:
- `AGENTS.md:73` — was the bare `github:` form; now shows the npm install first with the git form as an alternative
- `docs/PUBLISHING.md:93` and `:105` — one of each broken variant

`README.md:116` is deliberately left alone so #140 stays the PR that fixes it.

Docs only, no code paths touched.
