### PR TITLE
ci: verify the declared minimum Pi SDK, and correct it to 0.80.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,23 @@ jobs:
 
       - run: npm run check
 
+  min-sdk:
+    name: Min Supported SDK
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - run: npm install
+
+      # The `check` job installs whatever the devDependency range resolves to,
+      # which is always new enough to hide a broken peerDependencies floor.
+      # This one type-checks against the oldest Pi we advertise support for.
+      - run: npm run check:min-sdk
+
   test:
     name: Tests
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,8 @@
         "typescript": "^6.0.3"
       },
       "peerDependencies": {
-        "@earendil-works/pi-ai": "*",
-        "@earendil-works/pi-coding-agent": ">=0.74.0"
+        "@earendil-works/pi-ai": ">=0.80.1",
+        "@earendil-works/pi-coding-agent": ">=0.80.1"
       }
     },
     "node_modules/@aws-crypto/crc32": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "check": "node scripts/ensure-dev.mjs check && tsc --noEmit",
+    "check:min-sdk": "node scripts/ensure-dev.mjs check && node scripts/check-min-sdk.mjs",
     "test": "node scripts/ensure-dev.mjs test && tests/run-all.sh"
   },
   "keywords": [
@@ -46,8 +47,8 @@
     "url": "https://github.com/chandra447/pi-hermes-memory"
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": ">=0.74.0"
+    "@earendil-works/pi-ai": ">=0.80.1",
+    "@earendil-works/pi-coding-agent": ">=0.80.1"
   },
   "devDependencies": {
     "@earendil-works/pi-ai": "^0.80.2",

--- a/scripts/check-min-sdk.mjs
+++ b/scripts/check-min-sdk.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Type-check the extension against the OLDEST Pi SDK we claim to support.
+ *
+ * Why this exists: `peerDependencies` is the only thing telling a user whether
+ * this extension works on their Pi, and nothing verified it. The declared floor
+ * had drifted to `>=0.74.0` while `src/handlers/review-memory-ops.ts` imports
+ * `@earendil-works/pi-ai/compat`, a subpath that does not exist before 0.80.1 —
+ * so anyone on 0.74-0.79.x got ERR_PACKAGE_PATH_NOT_EXPORTED and no extension
+ * at all, with nothing in CI to catch it.
+ *
+ * The regular `check` job structurally cannot catch this: it installs whatever
+ * the devDependency range resolves to, which is always new enough.
+ *
+ * Run: node scripts/check-min-sdk.mjs
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, renameSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SCOPE = "@earendil-works";
+// pi-tui is a direct dependency rather than a peer, but its types cross the
+// boundary (ExtensionCommandContext.ui.custom takes a pi-tui TUI). Leaving it
+// at a different version yields a duplicate-private-property error instead of
+// a real finding, so it moves with the floor.
+const FLOOR_PACKAGES = [`${SCOPE}/pi-coding-agent`, `${SCOPE}/pi-ai`, `${SCOPE}/pi-tui`];
+
+const scopeDir = path.join(repoRoot, "node_modules", SCOPE);
+const stashDir = path.join(repoRoot, "node_modules", `${SCOPE}.real`);
+
+function restore() {
+  // Idempotent: safe to call from the finally block and from signal handlers.
+  try {
+    if (existsSync(stashDir)) {
+      if (existsSync(scopeDir)) unlinkSync(scopeDir);
+      renameSync(stashDir, scopeDir);
+    }
+  } catch (error) {
+    console.error(
+      `\nFAILED TO RESTORE node_modules/${SCOPE}. Run: mv "${stashDir}" "${scopeDir}"\n`,
+      error,
+    );
+  }
+}
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => { restore(); process.exit(130); });
+}
+
+const pkg = JSON.parse(readFileSync(path.join(repoRoot, "package.json"), "utf-8"));
+const range = pkg.peerDependencies?.[`${SCOPE}/pi-coding-agent`];
+const floor = /(\d+\.\d+\.\d+)/.exec(range ?? "")?.[1];
+if (!floor) {
+  console.error(`peerDependencies range "${range}" has no explicit floor — pin one like ">=0.80.1"`);
+  process.exit(1);
+}
+
+console.log(`Minimum supported ${SCOPE}/pi-coding-agent: ${floor}`);
+
+const scratch = mkdtempSync(path.join(tmpdir(), "pi-hermes-min-sdk-"));
+let failed = false;
+try {
+  writeFileSync(path.join(scratch, "package.json"), `${JSON.stringify({ name: "min-sdk-probe", private: true })}\n`);
+  const specs = FLOOR_PACKAGES.map((name) => `${name}@${floor}`);
+  console.log(`Installing ${specs.join(" ")} ...`);
+  execFileSync("npm", ["install", "--silent", "--no-audit", "--no-fund", "--no-package-lock", ...specs], {
+    cwd: scratch,
+    stdio: ["ignore", "ignore", "inherit"],
+  });
+
+  // Swap the scope in place so the project's own tsconfig applies unchanged —
+  // no divergent probe config that could drift from what `npm run check` uses.
+  renameSync(scopeDir, stashDir);
+  symlinkSync(path.join(scratch, "node_modules", SCOPE), scopeDir);
+
+  console.log("Type-checking src against the minimum SDK ...");
+  execFileSync(path.join(repoRoot, "node_modules", ".bin", "tsc"), ["--noEmit"], {
+    cwd: repoRoot,
+    stdio: "inherit",
+  });
+  console.log(`OK — src type-checks against ${SCOPE}/pi-coding-agent@${floor}`);
+} catch (error) {
+  failed = true;
+  if (!/Command failed/.test(String(error?.message))) console.error(error);
+  console.error(
+    `\nsrc does NOT type-check against the declared minimum (${floor}).\n`
+    + "Either raise the peerDependencies floor in package.json to a version that works,\n"
+    + "or stop using the SDK API that is missing at that version.\n",
+  );
+} finally {
+  restore();
+  rmSync(scratch, { recursive: true, force: true });
+}
+
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Found while reviewing #141 and #142. Both raise the `peerDependencies` floor, which I initially pushed back on — then checked, and the number they were raising was already fiction.

## The bug

Declared floor on `main` is `>=0.74.0`. But `src/handlers/review-memory-ops.ts:6` imports `@earendil-works/pi-ai/compat`, and that subpath does not exist before 0.80.1:

```
0.79.10 exports: ., ./base, ./anthropic, ./google, ./openai-completions, ...
0.80.1  exports: ., ./compat, ./providers/*, ./api/*, ...
```

```
$ node -e "import('@earendil-works/pi-ai/compat')"    # against 0.79.10
ERR_PACKAGE_PATH_NOT_EXPORTED - Package subpath './compat' is not defined by "exports"

$ node -e "import('@earendil-works/pi-ai/compat')"    # against 0.80.1
import OK
```

Not a type-only problem — it's a hard module-resolution failure at load. Every user on Pi 0.74 through 0.79.x has been getting no extension at all, with a confusing error, while `package.json` told them they were supported.

Bisected the real floor by type-checking `src` against each published SDK:

| SDK | `tsc --noEmit` errors |
|---|---|
| 0.75.0 / 0.77.0 / 0.79.0 | 2 |
| 0.79.10 | 1 |
| **0.80.1** | **0** |
| 0.80.2 | 0 |

Floor corrected to `>=0.80.1` for both peers (`pi-ai` was `*`, which is meaningless).

## Why CI never caught it

The `check` job runs `npm install`, which resolves the **devDependency** range — always new enough to hide a broken peer floor. No amount of green CI could have found this.

The new `min-sdk` job installs exactly the declared floor and type-checks `src` against it. The advertised range can now never silently drift from reality.

## Implementation notes

`scripts/check-min-sdk.mjs` swaps `node_modules/@earendil-works` for the floor version and runs **the project's own tsconfig** — no divergent probe config that could drift from what `npm run check` uses. (First attempt used a generated tsconfig with `baseUrl`/`paths`; TypeScript 6 deprecates `baseUrl`, and it risked testing something subtly different from the real check anyway.)

Restore is idempotent, runs from a `finally` block plus `SIGINT`/`SIGTERM` handlers, and prints a manual recovery command if it ever fails. Verified:

- a failing run leaves `node_modules` intact (checked after a deliberate failure — SDK back at 0.80.2, `npm run check` still clean)
- the check **fails as intended**: pointing the floor at `0.79.10` produces `error TS2307: Cannot find module '@earendil-works/pi-ai/compat'` and exit 1
- the check passes at the corrected floor
- pi-tui moves with the floor: it isn't a peer, but its types cross the boundary (`ctx.ui.custom` takes a pi-tui `TUI`), and a mismatched copy yields the duplicate-private-property error rather than a real finding — which is exactly the failure #142 is currently hitting

Adds ~10s to CI.

## Knock-on

This makes the floor bumps in #141 and #142 substantially more defensible, and I've said so on both. It doesn't clear their other blockers, but "you're raising a floor nobody validated" is a fair response to my review, and they'd have been right.
