### PR TITLE
fix: allowlist suffixless auth adapters in child subprocesses

### DIFF
--- a/src/handlers/pi-child-process.ts
+++ b/src/handlers/pi-child-process.ts
@@ -116,8 +116,19 @@ const AUTH_ADAPTER_NAME_PATTERNS: readonly RegExp[] = [
   /(^|[-/])auth-adapter$/,
 ];
 
+// These provider adapters predate the *-auth-adapter convention. Keep this
+// list exact so an arbitrary suffixless *-auth package cannot access child
+// maintenance prompts.
+const AUTH_ADAPTER_PACKAGE_NAMES: ReadonlySet<string> = new Set([
+  "pi-claude-auth",
+  "@gotgenes/pi-anthropic-auth",
+]);
+
 function isAuthAdapterPackageName(name: string): boolean {
-  return AUTH_ADAPTER_NAME_PATTERNS.some((pattern) => pattern.test(name));
+  return (
+    AUTH_ADAPTER_PACKAGE_NAMES.has(name)
+    || AUTH_ADAPTER_NAME_PATTERNS.some((pattern) => pattern.test(name))
+  );
 }
 
 // Read a sibling package's "pi": { "extensions": [...] } manifest field —
@@ -166,7 +177,7 @@ function scanRootForAuthAdapters(root: string): string[] {
         continue;
       }
       for (const scopedName of scopedPackages) {
-        if (!isAuthAdapterPackageName(scopedName)) continue;
+        if (!isAuthAdapterPackageName(`${entry}/${scopedName}`)) continue;
         detected.push(...readPackageExtensionEntries(join(scopeDir, scopedName)));
       }
       continue;

--- a/tests/handlers/pi-child-process.test.ts
+++ b/tests/handlers/pi-child-process.test.ts
@@ -27,7 +27,12 @@ const OWN_EXTENSION_PATH = path.resolve(
   "../../src/index.ts",
 );
 
-const EXT_ARGS = ["--no-extensions", "-e", OWN_EXTENSION_PATH];
+// Adapter detection scans the real sibling/agent node_modules trees, so a
+// contributor with a provider auth adapter installed gets extra -e args in
+// every child invocation. Derive them instead of assuming a bare environment.
+const DETECTED_ADAPTER_ARGS = detectAuthAdapterExtensionPaths().flatMap((p) => ["-e", p]);
+
+const EXT_ARGS = ["--no-extensions", "-e", OWN_EXTENSION_PATH, ...DETECTED_ADAPTER_ARGS];
 
 describe("inheritedExtensionArgs", () => {
   it("captures explicit -e and --extension parent args", () => {
@@ -203,6 +208,60 @@ describe("detectAuthAdapterExtensionPaths", () => {
       await fs.rm(rootB, { recursive: true, force: true });
     }
   });
+
+  it("detects the allowlisted pi-claude-auth package", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-auth-detect-claude-"));
+    const adapterDir = path.join(root, "pi-claude-auth");
+    const adapterPath = path.join(adapterDir, "src", "index.ts");
+    await fs.mkdir(path.dirname(adapterPath), { recursive: true });
+    await fs.writeFile(adapterPath, "export default () => {};");
+    await fs.writeFile(
+      path.join(adapterDir, "package.json"),
+      JSON.stringify({ name: "pi-claude-auth", pi: { extensions: ["src/index.ts"] } }),
+    );
+    try {
+      assert.deepStrictEqual(detectAuthAdapterExtensionPaths([root]), [adapterPath]);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("detects the allowlisted scoped @gotgenes/pi-anthropic-auth package", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-auth-detect-anthropic-"));
+    const adapterDir = path.join(root, "@gotgenes", "pi-anthropic-auth");
+    const adapterPath = path.join(adapterDir, "src", "index.ts");
+    await fs.mkdir(path.dirname(adapterPath), { recursive: true });
+    await fs.writeFile(adapterPath, "export default () => {};");
+    await fs.writeFile(
+      path.join(adapterDir, "package.json"),
+      JSON.stringify({
+        name: "@gotgenes/pi-anthropic-auth",
+        pi: { extensions: ["src/index.ts"] },
+      }),
+    );
+    try {
+      assert.deepStrictEqual(detectAuthAdapterExtensionPaths([root]), [adapterPath]);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores a suffixless auth package that is not allowlisted", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-auth-detect-untrusted-"));
+    const pkgDir = path.join(root, "pi-vault-auth");
+    const extPath = path.join(pkgDir, "index.ts");
+    await fs.mkdir(pkgDir, { recursive: true });
+    await fs.writeFile(extPath, "export default () => {};");
+    await fs.writeFile(
+      path.join(pkgDir, "package.json"),
+      JSON.stringify({ name: "pi-vault-auth", pi: { extensions: ["index.ts"] } }),
+    );
+    try {
+      assert.deepStrictEqual(detectAuthAdapterExtensionPaths([root]), []);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
 });
 
 
@@ -250,6 +309,7 @@ describe("buildChildPiPromptArgs", () => {
           "-p", "--no-session", "--no-extensions",
           "-e", OWN_EXTENSION_PATH,
           "-e", configured,
+          ...DETECTED_ADAPTER_ARGS,
           "hello",
         ],
       );


### PR DESCRIPTION
## Summary

Child `pi -p` subprocesses use `--no-extensions`, then re-add provider auth adapters so
subscription billing headers remain active. Detection only recognized the
`*-auth-adapter` / `*-oauth-adapter` convention, so the installed `pi-claude-auth` adapter was
omitted and Anthropic rejected the child request as third-party extra usage.

## Changes

- Keep the existing naming convention as the general trust boundary.
- Add exact allowlist entries for `pi-claude-auth` and `@gotgenes/pi-anthropic-auth`.
- Pass full `@scope/name` values into the matcher so scoped allowlist entries are exact.
- Test both allowlisted packages and reject an arbitrary `pi-vault-auth` package.
- Derive expected child adapter args in tests so contributors with an installed adapter do not
  get environment-dependent failures.

This closes the reported adapter gap without making a generic `*-auth` suffix sufficient to
load an extension into maintenance children. Future suffixless adapters can use
`childExtensionPaths` until reviewed and allowlisted.

## Verification

- `npm run check`
- `npm run check:min-sdk`
- `npm test` — all 42 test files pass (38 tests in `pi-child-process.test.ts`)
- End-to-end reproduction: the child 400s without `pi-claude-auth`; detection now adds its
  extension path and the same child request returns `OK`
