### PR TITLE
fix(test): guard each test file with timeout

### DIFF
--- a/tests/run-all-timeout.test.ts
+++ b/tests/run-all-timeout.test.ts
@@ -1,0 +1,107 @@
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+interface RunnerResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+async function createRunnerFixture(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-run-all-timeout-"));
+  await fs.mkdir(path.join(root, "tests"));
+  await fs.copyFile(
+    path.join(REPO_ROOT, "tests/run-all.sh"),
+    path.join(root, "tests/run-all.sh"),
+  );
+  await fs.writeFile(path.join(root, "tests/sample.test.ts"), "// executed by the test double\n");
+  return root;
+}
+
+async function writeExecutable(file: string, content: string): Promise<void> {
+  await fs.writeFile(file, content, { mode: 0o755 });
+  await fs.chmod(file, 0o755);
+}
+
+function runRunner(root: string, env: Record<string, string>): Promise<RunnerResult> {
+  const { promise, resolve, reject } = Promise.withResolvers<RunnerResult>();
+  const child = spawn("bash", ["tests/run-all.sh"], {
+    cwd: root,
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => { stdout += chunk; });
+  child.stderr.on("data", (chunk: string) => { stderr += chunk; });
+  child.once("error", reject);
+  child.once("close", (code) => resolve({ code, stdout, stderr }));
+  return promise;
+}
+
+describe("tests/run-all.sh timeout guard", () => {
+  it("accepts TEST_TIMEOUT=0 and preserves the no-timeout fallback", async () => {
+    const root = await createRunnerFixture();
+    const bin = path.join(root, "bin");
+    await fs.mkdir(bin);
+    await writeExecutable(path.join(bin, "npx"), "#!/bin/sh\nexit 0\n");
+    try {
+      const result = await runRunner(root, {
+        PATH: `${bin}:${process.env.PATH ?? ""}`,
+        TEST_TIMEOUT: "0",
+      });
+      assert.equal(result.code, 0);
+      assert.match(result.stdout, /All 1 test files passed/);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("reports the timed-out file and requests forced process-tree cleanup", async () => {
+    const root = await createRunnerFixture();
+    const bin = path.join(root, "bin");
+    const timeoutArgs = path.join(root, "timeout-args");
+    await fs.mkdir(bin);
+    await writeExecutable(path.join(bin, "npx"), "#!/bin/sh\nexit 0\n");
+    await writeExecutable(
+      path.join(bin, "timeout"),
+      `#!/bin/sh\nprintf '%s\\n' "$@" > "${timeoutArgs}"\nexit 124\n`,
+    );
+    try {
+      const result = await runRunner(root, {
+        PATH: `${bin}:${process.env.PATH ?? ""}`,
+        TEST_TIMEOUT: "0.1",
+      });
+      assert.equal(result.code, 1);
+      assert.match(result.stdout, />0\.1s\): tests\/sample\.test\.ts/);
+      assert.deepEqual(
+        (await fs.readFile(timeoutArgs, "utf8")).trim().split("\n").slice(0, 2),
+        ["--kill-after=5s", "0.1"],
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects invalid and negative timeout values before running tests", async () => {
+    const root = await createRunnerFixture();
+    try {
+      for (const value of ["-1", "not-a-number"]) {
+        const result = await runRunner(root, { TEST_TIMEOUT: value });
+        assert.equal(result.code, 2);
+        assert.match(result.stderr, new RegExp(`Invalid TEST_TIMEOUT: ${value}`));
+      }
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -1,13 +1,45 @@
 #!/usr/bin/env bash
 # Run each test file in its own tsx process to avoid node:test runner hang.
 set -euo pipefail
-
 PASS=0
+
+TEST_TIMEOUT="${TEST_TIMEOUT:-120}"
+if [[ ! "$TEST_TIMEOUT" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+  echo "Invalid TEST_TIMEOUT: $TEST_TIMEOUT (expected a non-negative number of seconds)" >&2
+  exit 2
+fi
+
+TIMEOUT_BIN=()
+if [[ ! "$TEST_TIMEOUT" =~ ^0+([.]0+)?$ ]]; then
+  if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_BIN=(timeout)
+  elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_BIN=(gtimeout)
+  fi
+fi
+
+run_test_file() {
+  local file="$1"
+  if ((${#TIMEOUT_BIN[@]} > 0)); then
+    "${TIMEOUT_BIN[@]}" --kill-after=5s "$TEST_TIMEOUT" npx tsx --test "$file"
+  else
+    npx tsx --test "$file"
+  fi
+}
 
 for f in $(find tests -name '*.test.ts' | sort); do
   echo "--- $f ---"
-  npx tsx --test "$f" || { echo "FAILED: $f"; exit 1; }
-  PASS=$((PASS + 1))
+  if run_test_file "$f"; then
+    PASS=$((PASS + 1))
+  else
+    rc=$?
+    if [[ "$rc" -eq 124 && ${#TIMEOUT_BIN[@]} -gt 0 ]]; then
+      echo "TIMEOUT (>${TEST_TIMEOUT}s): $f"
+    else
+      echo "FAILED (exit $rc): $f"
+    fi
+    exit 1
+  fi
 done
 
 echo "All $PASS test files passed"


### PR DESCRIPTION
Closes #155.

Add a per-test-file timeout guard to tests/run-all.sh:

- Defaults TEST_TIMEOUT to 120 seconds and allows TEST_TIMEOUT=0 to disable it.
- Rejects invalid and negative values before running tests.
- Detects GNU timeout or macOS gtimeout when a timeout is enabled.
- Uses --kill-after=5s so timed-out test process groups are forcibly cleaned up.
- Preserves the existing no-timeout fallback when neither utility is installed.
- Reports the timed-out test file and exits with failure.

Adds deterministic regression coverage for timeout-disabled, timeout-triggered, process-tree cleanup arguments, and invalid values.

Verification:
- npx tsx --test tests/run-all-timeout.test.ts (3 passed)
- npm run check / tsc --noEmit --pretty false (passed)
- npm test (all 45 test files passed)
