### PR TITLE
fix(project): rebind memory stores on session switch

### DIFF
--- a/src/handlers/auto-consolidate.ts
+++ b/src/handlers/auto-consolidate.ts
@@ -13,6 +13,7 @@
  * The subprocess child process modifies files on disk, so the parent MUST
  * reload from disk after a subprocess-based consolidation completes.
  */
+import { resolveProjectName, resolveProjectStore, type ProjectNameRef, type ProjectStoreRef } from "../project-context.js";
 
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
@@ -292,8 +293,8 @@ export function registerConsolidateCommand(
   pi: ExtensionAPI,
   store: MemoryStore,
   timeoutMs: number = DEFAULT_CONSOLIDATION_TIMEOUT_MS,
-  projectStore: MemoryStore | null = null,
-  projectName?: string | null,
+  projectStore: ProjectStoreRef = null,
+  projectName: ProjectNameRef = null,
   llmConfig: ConsolidationLlmConfig = {},
   dbManager: DatabaseManager | null = null,
   deps: { runDirectMemoryCompletion?: typeof runDirectMemoryCompletion } = {},
@@ -302,6 +303,8 @@ export function registerConsolidateCommand(
     description: "Manually trigger memory consolidation to free up space",
     handler: async (_args, ctx) => {
       const results: string[] = [];
+      const activeProjectStore = resolveProjectStore(projectStore);
+      const activeProjectName = resolveProjectName(projectName);
       const targets: Array<{
         label: string;
         store: MemoryStore;
@@ -313,10 +316,10 @@ export function registerConsolidateCommand(
         { label: "failure", store, target: "failure", toolTarget: "failure" },
       ];
 
-      if (projectStore) {
+      if (activeProjectStore) {
         targets.push({
-          label: projectName ? `project:${projectName}` : "project",
-          store: projectStore,
+          label: activeProjectName ? `project:${activeProjectName}` : "project",
+          store: activeProjectStore,
           target: "memory",
           toolTarget: "project",
         });
@@ -359,7 +362,7 @@ export function registerConsolidateCommand(
           llmConfig,
           ctx,
           dbManager,
-          projectName,
+          activeProjectName,
           deps,
         );
 

--- a/src/handlers/background-review.ts
+++ b/src/handlers/background-review.ts
@@ -16,9 +16,10 @@ import { applyRecentMessageLimit, collectMessageParts } from "./message-parts.js
 import { execChildPrompt } from "./pi-child-process.js";
 import { runDirectMemoryCompletion, usesDirectTransport, type DirectReviewResult } from "./review-memory-ops.js";
 
+import { resolveProjectName, resolveProjectStore, type ProjectNameRef, type ProjectStoreRef } from "../project-context.js";
 export interface BackgroundReviewOptions {
   dbManager?: DatabaseManager | null;
-  projectName?: string | null;
+  projectName?: ProjectNameRef;
   deps?: BackgroundReviewDeps;
 }
 
@@ -116,7 +117,7 @@ async function runSubprocessReview(
 export function setupBackgroundReview(
   pi: ExtensionAPI,
   store: MemoryStore,
-  projectStore: MemoryStore | null,
+  projectStore: ProjectStoreRef,
   config: MemoryConfig,
   options: BackgroundReviewOptions = {},
 ): void {
@@ -183,11 +184,13 @@ export function setupBackgroundReview(
     }
 
     const parts = applyRecentMessageLimit(allParts, config.reviewRecentMessages);
+    const activeProjectStore = resolveProjectStore(projectStore);
+    const activeProjectName = resolveProjectName(projectName);
     const promptInput: ReviewPromptInput = {
       parts,
       currentMemory: store.getMemoryEntries().join("\n§\n"),
       currentUser: store.getUserEntries().join("\n§\n"),
-      currentProject: projectStore ? projectStore.getMemoryEntries().join("\n§\n") : null,
+      currentProject: activeProjectStore ? activeProjectStore.getMemoryEntries().join("\n§\n") : null,
     };
 
     const subprocessPrompt = buildSubprocessReviewPrompt(promptInput);
@@ -210,10 +213,10 @@ export function setupBackgroundReview(
           const directResult = await runDirectReview(
             ctx as Pick<ExtensionContext, "model" | "modelRegistry">,
             store,
-            projectStore,
+            activeProjectStore,
             { userPrompt: directPrompt, systemPrompt: DIRECT_REVIEW_SYSTEM_PROMPT, config, timeoutMs: 120000 },
             dbManager,
-            projectName,
+            activeProjectName,
           );
 
           if (directResult.ok) {

--- a/src/handlers/correction-detector.ts
+++ b/src/handlers/correction-detector.ts
@@ -23,6 +23,7 @@ import {
 import type { MemoryConfig } from "../types.js";
 import { getMessageText } from "../types.js";
 import { execChildPrompt } from "./pi-child-process.js";
+import { resolveProjectName, resolveProjectStore, type ProjectNameRef, type ProjectStoreRef } from "../project-context.js";
 import { runDirectMemoryCompletion, usesDirectTransport } from "./review-memory-ops.js";
 
 /**
@@ -123,10 +124,10 @@ export function isCorrection(text: string, config?: CorrectionPatternConfig): bo
 export function setupCorrectionDetector(
   pi: ExtensionAPI,
   store: MemoryStore,
-  projectStore: MemoryStore | null,
+  projectStore: ProjectStoreRef,
   config: MemoryConfig,
   dbManager: DatabaseManager | null = null,
-  projectName?: string | null,
+  projectName: ProjectNameRef = null,
   deps: { runDirectMemoryCompletion?: typeof runDirectMemoryCompletion } = {},
 ): void {
   if (!config.correctionDetection) return;
@@ -178,9 +179,11 @@ export function setupCorrectionDetector(
       // Only include last few exchanges (correction context is recent)
       const recentParts = parts.slice(-6);
 
+      const activeProjectStore = resolveProjectStore(projectStore);
+      const activeProjectName = resolveProjectName(projectName);
       const currentMemory = store.getMemoryEntries().join(ENTRY_DELIMITER);
       const currentUser = store.getUserEntries().join(ENTRY_DELIMITER);
-      const currentProject = projectStore ? projectStore.getMemoryEntries().join(ENTRY_DELIMITER) : null;
+      const currentProject = activeProjectStore ? activeProjectStore.getMemoryEntries().join(ENTRY_DELIMITER) : null;
 
       const promptBody = [
         "--- Current Memory ---",
@@ -224,7 +227,7 @@ export function setupCorrectionDetector(
           const directResult = await runDirect(
             ctx,
             store,
-            projectStore,
+            activeProjectStore,
             {
               systemPrompt: DIRECT_CORRECTION_SYSTEM_PROMPT,
               userPrompt: promptBody.join("\n"),
@@ -233,7 +236,7 @@ export function setupCorrectionDetector(
               signal: ctx.signal,
             },
             dbManager,
-            projectName,
+            activeProjectName,
           );
           if (directResult.ok) {
             savedViaLlm = directResult.appliedCount > 0;
@@ -259,7 +262,7 @@ export function setupCorrectionDetector(
         if (correctionText) {
           const directive = extractCorrectionDirective(correctionText);
           const failureReason = "User corrected the agent";
-          const scopedProjectName = projectStore ? projectName?.trim() || null : null;
+          const scopedProjectName = activeProjectStore ? activeProjectName : null;
           await store.addFailure(directive, {
             category: "correction",
             failureReason,

--- a/src/handlers/insights.ts
+++ b/src/handlers/insights.ts
@@ -8,6 +8,7 @@ import { resolveProjectName, resolveProjectStore, type ProjectNameRef, type Proj
 
 export function registerInsightsCommand(pi: ExtensionAPI, store: MemoryStore, projectStore: ProjectStoreRef, projectName: ProjectNameRef): void {
   pi.registerCommand("memory-insights", {
+    description: "Show what's stored in persistent memory",
     handler: async (_args, ctx) => {
       const memoryEntries = store.getMemoryEntries();
       const userEntries = store.getUserEntries();

--- a/src/handlers/insights.ts
+++ b/src/handlers/insights.ts
@@ -4,14 +4,16 @@
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { MemoryStore } from "../store/memory-store.js";
+import { resolveProjectName, resolveProjectStore, type ProjectNameRef, type ProjectStoreRef } from "../project-context.js";
 
-export function registerInsightsCommand(pi: ExtensionAPI, store: MemoryStore, projectStore: MemoryStore | null, projectName: string): void {
+export function registerInsightsCommand(pi: ExtensionAPI, store: MemoryStore, projectStore: ProjectStoreRef, projectName: ProjectNameRef): void {
   pi.registerCommand("memory-insights", {
-    description: "Show what's stored in persistent memory",
     handler: async (_args, ctx) => {
       const memoryEntries = store.getMemoryEntries();
       const userEntries = store.getUserEntries();
-      const projectEntries = projectStore ? projectStore.getMemoryEntries() : null;
+      const activeProjectStore = resolveProjectStore(projectStore);
+      const activeProjectName = resolveProjectName(projectName);
+      const projectEntries = activeProjectStore ? activeProjectStore.getMemoryEntries() : null;
 
       const lines: string[] = [];
       lines.push("");
@@ -52,9 +54,8 @@ export function registerInsightsCommand(pi: ExtensionAPI, store: MemoryStore, pr
       }
       lines.push("");
 
-      // Project section
       if (projectEntries !== null) {
-        lines.push(`  📁 PROJECT MEMORY: ${projectName}`);
+        lines.push(`  📁 PROJECT MEMORY: ${activeProjectName ?? ""}`);
         lines.push("  " + "─".repeat(44));
         if (projectEntries.length === 0) {
           lines.push("  (empty)");

--- a/src/handlers/preview-context.ts
+++ b/src/handlers/preview-context.ts
@@ -8,6 +8,7 @@ import { MemoryStore } from "../store/memory-store.js";
 import type { StandingInstructions } from "../store/standing-instructions.js";
 import { resolveMemoryPolicyPrompt } from "../prompt-context.js";
 import type { MemoryConfig } from "../types.js";
+import { resolveProjectName, resolveProjectStore, type ProjectNameRef, type ProjectStoreRef } from "../project-context.js";
 
 function appendStandingBlock(lines: string[], standing: StandingInstructions | null): number {
   const rendered = standing?.render();
@@ -24,8 +25,8 @@ function appendStandingBlock(lines: string[], standing: StandingInstructions | n
 export function registerPreviewContextCommand(
   pi: ExtensionAPI,
   store: MemoryStore,
-  projectStore: MemoryStore | null,
-  projectName: string,
+  projectStore: ProjectStoreRef,
+  projectName: ProjectNameRef,
   config: Pick<MemoryConfig, "memoryMode" | "memoryPolicyStyle" | "memoryPolicyCustomText"> = { memoryMode: "policy-only" },
   standing: StandingInstructions | null = null,
 ): void {
@@ -59,9 +60,10 @@ export function registerPreviewContextCommand(
         ctx.ui.notify(lines.join("\n"), "info");
         return;
       }
-
+      const activeProjectStore = resolveProjectStore(projectStore);
+      const activeProjectName = resolveProjectName(projectName);
       const memoryBlock = store.formatForSystemPrompt();
-      const projectBlock = projectStore ? projectStore.formatProjectBlock(projectName) : "";
+      const projectBlock = activeProjectStore ? activeProjectStore.formatProjectBlock(activeProjectName ?? "") : "";
 
       const lines: string[] = [];
       lines.push("");
@@ -81,10 +83,9 @@ export function registerPreviewContextCommand(
         lines.push(memoryBlock);
         lines.push("");
       }
-
       if (projectBlock) {
         blockCount++;
-        lines.push(`  ── PROJECT MEMORY (${projectName}) ─────────────────────────`);
+        lines.push(`  ── PROJECT MEMORY (${activeProjectName ?? ""}) ─────────────────────────`);
         lines.push(projectBlock);
         lines.push("");
       }

--- a/src/handlers/session-flush.ts
+++ b/src/handlers/session-flush.ts
@@ -16,6 +16,7 @@ import type { MemoryConfig } from "../types.js";
 import { collectMessageParts } from "./message-parts.js";
 import { execChildPrompt } from "./pi-child-process.js";
 import { runDirectMemoryCompletion, usesDirectTransport } from "./review-memory-ops.js";
+import { resolveProjectName, resolveProjectStore, type ProjectNameRef, type ProjectStoreRef } from "../project-context.js";
 
 function buildDirectFlushUserPrompt(
   store: MemoryStore,
@@ -50,10 +51,10 @@ function buildDirectFlushUserPrompt(
 export function setupSessionFlush(
   pi: ExtensionAPI,
   store: MemoryStore,
-  projectStore: MemoryStore | null,
+  projectStore: ProjectStoreRef,
   config: MemoryConfig,
   dbManager: DatabaseManager | null = null,
-  projectName?: string | null,
+  projectName: ProjectNameRef = null,
   deps: { runDirectMemoryCompletion?: typeof runDirectMemoryCompletion } = {},
 ): void {
   let userTurnCount = 0;
@@ -79,22 +80,24 @@ export function setupSessionFlush(
     }
 
     const parts = collectMessageParts(entries, config.flushRecentMessages);
+    const activeProjectStore = resolveProjectStore(projectStore);
+    const activeProjectName = resolveProjectName(projectName);
 
     if (usesDirectTransport(config)) {
       try {
         const directResult = await runDirect(
           ctx,
           store,
-          projectStore,
+          activeProjectStore,
           {
             systemPrompt: DIRECT_FLUSH_SYSTEM_PROMPT,
-            userPrompt: buildDirectFlushUserPrompt(store, projectStore, parts),
+            userPrompt: buildDirectFlushUserPrompt(store, activeProjectStore, parts),
             config,
             timeoutMs,
             signal,
           },
           dbManager,
-          projectName,
+          activeProjectName,
         );
         if (directResult.ok) return;
       } catch {

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,6 +155,7 @@ export default function (pi: ExtensionAPI) {
   const projectStoreRef = () => projectStore;
   const projectNameRef = () => projectName;
   let configureProjectStore: (candidate: MemoryStore | null) => void = () => {};
+  let configureMemoryToolProjectStore: (candidate: MemoryStore | null) => void = () => {};
   // Never written by review, consolidation or the correction detector — see
   // store/standing-instructions.ts for why provenance has to be structural.
   const standingStore = config.standingInstructionsEnabled !== false
@@ -190,6 +191,7 @@ export default function (pi: ExtensionAPI) {
       projectMemoryDir = nextProjectMemoryDir;
       projectStore = createProjectStore(nextProject);
       configureProjectStore(projectStore);
+      configureMemoryToolProjectStore(projectStore);
     }
     project = nextProject;
     projectName = nextProject.name ?? "";
@@ -228,7 +230,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   // ── 3. Register action-specific memory write tools with SQLite sync ──
-  registerMemoryTool(pi, store, projectStoreRef, dbManager, projectNameRef);
+  configureMemoryToolProjectStore = registerMemoryTool(pi, store, projectStoreRef, dbManager, projectNameRef);
 
   // ── 4. Register the skill tool ──
   registerSkillTool(pi, skillStore);

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,8 +105,8 @@ export default function (pi: ExtensionAPI) {
   let persistenceInitialized = false;
 
   const store = new MemoryStore({ ...config, memoryDir: globalDir });
-  const project = detectProject(config.projectsMemoryDir);
-  const projectName = project.name ?? "";
+  let project = detectProject(config.projectsMemoryDir);
+  let projectName = project.name ?? "";
   const skillStore = new SkillStore({
     globalSkillsDir: path.join(globalDir, "skills"),
     piGlobalSkillsDir: path.join(agentRoot, "skills"),
@@ -142,10 +142,19 @@ export default function (pi: ExtensionAPI) {
   migrateLegacyProjectMemoryDirs(agentRoot, config.projectsMemoryDir);
   // Detect project from cwd using shared helper
   // Project-scoped store: ~/.pi/agent/<projectsMemoryDir>/<project_name>/
-  const projectConfig = project.memoryDir
-    ? { ...config, memoryCharLimit: config.projectCharLimit, memoryDir: project.memoryDir }
-    : { ...config, memoryDir: undefined };
-  const projectStore = project.memoryDir ? new MemoryStore(projectConfig) : null;
+  const createProjectStore = (projectInfo: ReturnType<typeof detectProject>): MemoryStore | null => {
+    if (!projectInfo.memoryDir) return null;
+    return new MemoryStore({
+      ...config,
+      memoryCharLimit: config.projectCharLimit,
+      memoryDir: projectInfo.memoryDir,
+    });
+  };
+  let projectMemoryDir = project.memoryDir ?? null;
+  let projectStore = createProjectStore(project);
+  const projectStoreRef = () => projectStore;
+  const projectNameRef = () => projectName;
+  let configureProjectStore: (candidate: MemoryStore | null) => void = () => {};
   // Never written by review, consolidation or the correction detector — see
   // store/standing-instructions.ts for why provenance has to be structural.
   const standingStore = config.standingInstructionsEnabled !== false
@@ -175,6 +184,15 @@ export default function (pi: ExtensionAPI) {
       }
     }
 
+    const nextProject = detectProject(config.projectsMemoryDir, ctx.cwd);
+    const nextProjectMemoryDir = nextProject.memoryDir ?? null;
+    if (nextProjectMemoryDir !== projectMemoryDir) {
+      projectMemoryDir = nextProjectMemoryDir;
+      projectStore = createProjectStore(nextProject);
+      configureProjectStore(projectStore);
+    }
+    project = nextProject;
+    projectName = nextProject.name ?? "";
     refreshSkillProjectContext(ctx.cwd);
     await skillStore.migrateLegacySkills();
     await skillStore.ensureDiscoveredRoots();
@@ -200,7 +218,7 @@ export default function (pi: ExtensionAPI) {
 
   // ── 2. Inject memory policy by default; legacy mode keeps full frozen memory blocks ──
   pi.on("before_agent_start", async (event, _ctx) => {
-    const promptContext = await buildPromptContext(config, store, projectStore, projectName, standingStore);
+    const promptContext = await buildPromptContext(config, store, projectStoreRef(), projectNameRef(), standingStore);
 
     if (promptContext) {
       return {
@@ -210,19 +228,19 @@ export default function (pi: ExtensionAPI) {
   });
 
   // ── 3. Register action-specific memory write tools with SQLite sync ──
-  registerMemoryTool(pi, store, projectStore, dbManager, projectName);
+  registerMemoryTool(pi, store, projectStoreRef, dbManager, projectNameRef);
 
   // ── 4. Register the skill tool ──
   registerSkillTool(pi, skillStore);
 
   // ── 5. Setup background learning loop (with tool-call-aware nudge) ──
-  setupBackgroundReview(pi, store, projectStore, config, {
+  setupBackgroundReview(pi, store, projectStoreRef, config, {
     dbManager,
-    projectName: projectName || null,
+    projectName: projectNameRef,
   });
 
   // ── 6. Setup session-end flush ──
-  setupSessionFlush(pi, store, projectStore, config, dbManager, projectName);
+  setupSessionFlush(pi, store, projectStoreRef, config, dbManager, projectNameRef);
 
   // ── 7. Setup auto-consolidation (inject consolidator into stores) ──
   // A failed auto-consolidation is otherwise invisible outside the tool result,
@@ -251,24 +269,26 @@ export default function (pi: ExtensionAPI) {
   };
 
   store.setConsolidator((target, signal) => runAutoConsolidation(target, store, target, signal));
-  if (projectStore) {
-    projectStore.setConsolidator((target, signal) =>
-      runAutoConsolidation(target, projectStore, target === "memory" ? "project" : target, signal),
+  configureProjectStore = (candidate) => {
+    if (!candidate) return;
+    candidate.setConsolidator((target, signal) =>
+      runAutoConsolidation(target, candidate, target === "memory" ? "project" : target, signal),
     );
-  }
-  registerConsolidateCommand(pi, store, config.consolidationTimeoutMs, projectStore, projectName, config, dbManager);
+  };
+  configureProjectStore(projectStore);
+  registerConsolidateCommand(pi, store, config.consolidationTimeoutMs, projectStoreRef, projectNameRef, config, dbManager);
 
   // ── 8. Setup correction detection ──
-  setupCorrectionDetector(pi, store, projectStore, config, dbManager, projectName);
+  setupCorrectionDetector(pi, store, projectStoreRef, config, dbManager, projectNameRef);
 
   // ── 9. Register commands ──
-  registerInsightsCommand(pi, store, projectStore, projectName);
+  registerInsightsCommand(pi, store, projectStoreRef, projectNameRef);
   registerSkillsCommand(pi, skillStore);
   registerInterviewCommand(pi, store);
   registerSwitchProjectCommand(pi, config);
   registerLearnMemoryCommand(pi);
   registerSyncMarkdownMemoriesCommand(pi, dbManager, globalDir, config.projectsMemoryDir, agentRoot);
-  registerPreviewContextCommand(pi, store, projectStore, projectName, config, standingStore);
+  registerPreviewContextCommand(pi, store, projectStoreRef, projectNameRef, config, standingStore);
   if (standingStore) registerStandingPinCommand(pi, standingStore);
 
   // ── 10. Live session indexing ──

--- a/src/project-context.ts
+++ b/src/project-context.ts
@@ -1,0 +1,13 @@
+import type { MemoryStore } from "./store/memory-store.js";
+
+export type ProjectStoreRef = MemoryStore | null | (() => MemoryStore | null);
+export type ProjectNameRef = string | null | (() => string | null | undefined);
+
+export function resolveProjectStore(ref: ProjectStoreRef): MemoryStore | null {
+  return typeof ref === "function" ? ref() : ref;
+}
+
+export function resolveProjectName(ref: ProjectNameRef): string | null {
+  const value = typeof ref === "function" ? ref() : ref;
+  return value?.trim() || null;
+}

--- a/src/tools/memory-tool.ts
+++ b/src/tools/memory-tool.ts
@@ -230,17 +230,25 @@ export function registerMemoryTool(
   projectStore: ProjectStoreRef,
   dbManager: DatabaseManager | null = null,
   projectName: ProjectNameRef = null,
-): void {
+): (candidate: MemoryStore | null) => void {
   const reconciledStores = new WeakSet<MemoryStore>();
-  const attachMutationObserver = (candidate: MemoryStore | null): void => {
+  const attachMutationObserver = (candidate: MemoryStore | null, isProjectStore = false): void => {
     if (!candidate || reconciledStores.has(candidate) || typeof candidate.setMutationObserver !== "function") return;
     candidate.setMutationObserver((target, entries) =>
-      reconcileStoreScope(entries, target, dbManager, resolveProjectName(projectName)),
+      reconcileStoreScope(
+        entries,
+        isProjectStore && target === "memory" ? "project" : target,
+        dbManager,
+        resolveProjectName(projectName),
+      ),
     );
     reconciledStores.add(candidate);
   };
+  const configureProjectStore = (candidate: MemoryStore | null): void => {
+    attachMutationObserver(candidate, true);
+  };
   attachMutationObserver(store);
-  attachMutationObserver(resolveProjectStore(projectStore));
+  configureProjectStore(resolveProjectStore(projectStore));
 
   if (typeof pi.on === "function") {
     pi.on("tool_result", (event) => {
@@ -410,4 +418,5 @@ Remove one existing entry. The target and old_text fields are required.`,
       old_text: Type.String({ description: "Substring identifying the entry to remove." }),
     }),
   );
+  return configureProjectStore;
 }

--- a/src/tools/memory-tool.ts
+++ b/src/tools/memory-tool.ts
@@ -19,6 +19,7 @@ import {
   syncMemoryEntry,
 } from "../store/sqlite-memory-store.js";
 import { MEMORY_TOOL_DESCRIPTION } from "../constants.js";
+import { resolveProjectName, resolveProjectStore, type ProjectNameRef, type ProjectStoreRef } from "../project-context.js";
 import type { MemoryCategory, MemoryResult } from "../types.js";
 import { createSharedToolResultRenderer } from "./shared-output-view.js";
 import { memoryResultView } from "./tool-result-views.js";
@@ -223,23 +224,23 @@ type MemoryToolParams = {
   category?: MemoryCategory;
   failure_reason?: string;
 };
-
 export function registerMemoryTool(
   pi: ExtensionAPI,
   store: MemoryStore,
-  projectStore: MemoryStore | null,
+  projectStore: ProjectStoreRef,
   dbManager: DatabaseManager | null = null,
-  projectName?: string | null,
+  projectName: ProjectNameRef = null,
 ): void {
   const reconciledStores = new WeakSet<MemoryStore>();
-  if (typeof store.setMutationObserver === "function") {
-    store.setMutationObserver((target, entries) => reconcileStoreScope(entries, target, dbManager, projectName));
-    reconciledStores.add(store);
-  }
-  if (projectStore && typeof projectStore.setMutationObserver === "function") {
-    projectStore.setMutationObserver((_target, entries) => reconcileStoreScope(entries, "project", dbManager, projectName));
-    reconciledStores.add(projectStore);
-  }
+  const attachMutationObserver = (candidate: MemoryStore | null): void => {
+    if (!candidate || reconciledStores.has(candidate) || typeof candidate.setMutationObserver !== "function") return;
+    candidate.setMutationObserver((target, entries) =>
+      reconcileStoreScope(entries, target, dbManager, resolveProjectName(projectName)),
+    );
+    reconciledStores.add(candidate);
+  };
+  attachMutationObserver(store);
+  attachMutationObserver(resolveProjectStore(projectStore));
 
   if (typeof pi.on === "function") {
     pi.on("tool_result", (event) => {
@@ -256,9 +257,11 @@ export function registerMemoryTool(
   ) => {
     const { target: rawTarget, content, old_text, category, failure_reason } = params;
     const target = rawTarget === "project" ? "memory" : rawTarget;
-    const activeStore = rawTarget === "project" ? projectStore : store;
+    const activeProjectStore = resolveProjectStore(projectStore);
+    const activeProjectName = resolveProjectName(projectName);
+    const activeStore = rawTarget === "project" ? activeProjectStore : store;
 
-    if (rawTarget === "project" && !projectStore) {
+    if (rawTarget === "project" && !activeProjectStore) {
       return {
         content: [{
           type: "text" as const,
@@ -275,6 +278,7 @@ export function registerMemoryTool(
     }
 
     const store_ = activeStore!;
+    attachMutationObserver(store_);
     let result: MemoryResult;
     let syncWarning: string | null = null;
     const syncHandled = reconciledStores.has(store_);
@@ -291,13 +295,13 @@ export function registerMemoryTool(
             failureReason: failure_reason,
           });
           if (result.success && !syncHandled) {
-            syncWarning = await syncAddToSqlite(rawTarget, content, memoryCategory, failure_reason, dbManager, projectName);
+            syncWarning = await syncAddToSqlite(rawTarget, content, memoryCategory, failure_reason, dbManager, activeProjectName);
           }
         } else {
           result = await store_.add(target, content, signal);
           if (result.success && !syncHandled) {
-            await syncEvictionsFromSqlite(rawTarget, result.evicted_entries, dbManager, projectName);
-            syncWarning = await syncAddToSqlite(rawTarget, content, undefined, undefined, dbManager, projectName);
+            await syncEvictionsFromSqlite(rawTarget, result.evicted_entries, dbManager, activeProjectName);
+            syncWarning = await syncAddToSqlite(rawTarget, content, undefined, undefined, dbManager, activeProjectName);
           }
         }
         break;
@@ -306,20 +310,20 @@ export function registerMemoryTool(
         if (!content) throw new Error("content is required for 'replace' action.");
         result = await store_.replace(target, old_text, content);
         if (result.success && !syncHandled) {
-          syncWarning = await syncReplaceToSqlite(rawTarget, old_text, content, dbManager, projectName);
+          syncWarning = await syncReplaceToSqlite(rawTarget, old_text, content, dbManager, activeProjectName);
         }
         break;
       case "remove":
         if (!old_text) throw new Error("old_text is required for 'remove' action.");
         result = await store_.remove(target, old_text);
         if (result.success && !syncHandled) {
-          syncWarning = await syncRemoveFromSqlite(rawTarget, old_text, dbManager, projectName);
+          syncWarning = await syncRemoveFromSqlite(rawTarget, old_text, dbManager, activeProjectName);
         }
         break;
     }
 
     if (result.success && !syncHandled && typeof store_.getRawEntriesForSync === "function") {
-      const reconciliationWarning = await reconcileStoreScope(store_.getRawEntriesForSync(target), rawTarget, dbManager, projectName);
+      const reconciliationWarning = await reconcileStoreScope(store_.getRawEntriesForSync(target), rawTarget, dbManager, activeProjectName);
       if (reconciliationWarning !== undefined) syncWarning = reconciliationWarning;
     }
 

--- a/tests/project-rebinding.test.ts
+++ b/tests/project-rebinding.test.ts
@@ -1,0 +1,84 @@
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+
+interface MockPi {
+  handlers: Record<string, Array<(event: any, ctx: any) => unknown>>;
+  on(event: string, handler: (event: any, ctx: any) => unknown): void;
+  registerTool(): void;
+  registerCommand(): void;
+}
+
+describe("session project memory rebinding", () => {
+  it("loads project memory from the active session cwd after a switch", async () => {
+    const agentRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pi-project-rebind-agent-"));
+    const launchDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-project-rebind-launch-"));
+    const targetDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-project-rebind-target-"));
+    const previousAgentRoot = process.env.PI_CODING_AGENT_DIR;
+    const previousCwd = process.cwd();
+    try {
+      await fs.writeFile(
+        path.join(agentRoot, "hermes-memory-config.json"),
+        JSON.stringify({
+          memoryMode: "legacy-inject",
+          reviewEnabled: false,
+          flushOnCompact: false,
+          flushOnShutdown: false,
+          autoConsolidate: false,
+          correctionDetection: false,
+          standingInstructionsEnabled: false,
+        }),
+      );
+      await fs.mkdir(path.join(agentRoot, "projects-memory", path.basename(launchDir)), { recursive: true });
+      await fs.mkdir(path.join(agentRoot, "projects-memory", path.basename(targetDir)), { recursive: true });
+      await fs.writeFile(
+        path.join(agentRoot, "projects-memory", path.basename(launchDir), "MEMORY.md"),
+        "launch-directory memory",
+      );
+      await fs.writeFile(
+        path.join(agentRoot, "projects-memory", path.basename(targetDir), "MEMORY.md"),
+        "active-session memory",
+      );
+
+      process.env.PI_CODING_AGENT_DIR = agentRoot;
+      process.chdir(launchDir);
+      // Import after setting PI_CODING_AGENT_DIR so AGENT_ROOT is test-local.
+      const { default: registerExtension } = await import("../src/index.js");
+      const mockPi: MockPi = {
+        handlers: {},
+        on(event, handler) {
+          (this.handlers[event] ??= []).push(handler);
+        },
+        registerTool() {},
+        registerCommand() {},
+      };
+      registerExtension(mockPi as any);
+
+      const sessionStart = mockPi.handlers.session_start?.[0];
+      const beforeAgentStart = mockPi.handlers.before_agent_start?.[0];
+      assert.ok(sessionStart);
+      assert.ok(beforeAgentStart);
+
+      await sessionStart(
+        {},
+        {
+          cwd: targetDir,
+          sessionManager: { getBranch: () => [] },
+          ui: { notify() {} },
+        },
+      );
+      const result = await beforeAgentStart({ systemPrompt: "base" }, {}) as { systemPrompt: string };
+      assert.match(result.systemPrompt, /active-session memory/);
+      assert.doesNotMatch(result.systemPrompt, /launch-directory memory/);
+    } finally {
+      process.chdir(previousCwd);
+      if (previousAgentRoot === undefined) delete process.env.PI_CODING_AGENT_DIR;
+      else process.env.PI_CODING_AGENT_DIR = previousAgentRoot;
+      await fs.rm(agentRoot, { recursive: true, force: true });
+      await fs.rm(launchDir, { recursive: true, force: true });
+      await fs.rm(targetDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/tools/memory-tool.test.ts
+++ b/tests/tools/memory-tool.test.ts
@@ -404,6 +404,48 @@ describe("registerMemoryTool", () => {
     const projectRows = getMemories(dbManager, { project: "project-b", target: "memory" });
     assert.deepStrictEqual(projectRows.map((row) => row.content), ["second"]);
   });
+  it("reconciles rebound project-store mutations in the project SQLite scope", async () => {
+    let activeProjectName = "project-a";
+    type MutationObserver = (
+      target: "memory" | "user" | "failure",
+      entries: string[],
+    ) => Promise<string | null | undefined>;
+    const observers = new Map<string, MutationObserver>();
+    const stores = new Map<string, MemoryStore>();
+    const makeProjectStore = (name: string) => ({
+      setMutationObserver: (observer: MutationObserver) => {
+        observers.set(name, observer);
+      },
+    }) as unknown as MemoryStore;
+    stores.set("project-a", makeProjectStore("project-a"));
+    stores.set("project-b", makeProjectStore("project-b"));
+    const mockPi = {
+      registerTool: () => {},
+    } as unknown as ExtensionAPI;
+
+    const configureProjectStore = registerMemoryTool(
+      mockPi,
+      {} as MemoryStore,
+      () => stores.get(activeProjectName) ?? null,
+      dbManager,
+      () => activeProjectName,
+    );
+
+    await observers.get("project-a")?.("memory", ["first project entry"]);
+    activeProjectName = "project-b";
+    configureProjectStore(stores.get("project-b") ?? null);
+    await observers.get("project-b")?.("memory", ["second project entry"]);
+
+    assert.deepStrictEqual(
+      getMemories(dbManager, { target: "memory", project: "project-a" }).map((row) => row.content),
+      ["first project entry"],
+    );
+    assert.deepStrictEqual(
+      getMemories(dbManager, { target: "memory", project: "project-b" }).map((row) => row.content),
+      ["second project entry"],
+    );
+    assert.deepStrictEqual(getMemories(dbManager, { target: "memory", project: null }), []);
+  });
 
   it("returns a warning instead of failing when SQLite sync errors", async () => {
     let capturedResult: any;

--- a/tests/tools/memory-tool.test.ts
+++ b/tests/tools/memory-tool.test.ts
@@ -361,6 +361,50 @@ describe("registerMemoryTool", () => {
     assert.strictEqual(results[0].content, 'Project entry');
   });
 
+  it("resolves the active project store and name for each mutation", async () => {
+    let capturedResult: any;
+    const mockPi = {
+      registerTool: (def: any) => {
+        if (!capturedResult || def.name === "memory_add") capturedResult = def;
+      },
+    } as unknown as ExtensionAPI;
+
+    let activeProjectName = "project-a";
+    const calls: string[] = [];
+    const stores = new Map<string, MemoryStore>();
+    const makeProjectStore = (name: string) => ({
+      add: (target: string, content: string) => {
+        calls.push(`${name}:${target}:${content}`);
+        return {
+          success: true,
+          target,
+          entries: [content],
+          usage: "2% — 20/5000 chars",
+          entry_count: 1,
+          message: "Entry added.",
+        };
+      },
+    }) as unknown as MemoryStore;
+    stores.set("project-a", makeProjectStore("project-a"));
+    stores.set("project-b", makeProjectStore("project-b"));
+
+    registerMemoryTool(
+      mockPi,
+      {} as MemoryStore,
+      () => stores.get(activeProjectName) ?? null,
+      dbManager,
+      () => activeProjectName,
+    );
+
+    await capturedResult.execute("tc-1", { target: "project", content: "first" }, undefined as any, undefined as any, undefined as any);
+    activeProjectName = "project-b";
+    await capturedResult.execute("tc-2", { target: "project", content: "second" }, undefined as any, undefined as any, undefined as any);
+
+    assert.deepStrictEqual(calls, ["project-a:memory:first", "project-b:memory:second"]);
+    const projectRows = getMemories(dbManager, { project: "project-b", target: "memory" });
+    assert.deepStrictEqual(projectRows.map((row) => row.content), ["second"]);
+  });
+
   it("returns a warning instead of failing when SQLite sync errors", async () => {
     let capturedResult: any;
     const mockPi = {


### PR DESCRIPTION
Closes #157.

## Summary
- Rebind project-scoped memory and skill context from the active session cwd.
- Pass dynamic project store/name providers through memory handlers, commands, and SQLite synchronization.
- Add an extension-level regression test covering a session switch from one project to another.

## Verification
- `npx tsx --test tests/project-rebinding.test.ts`
- `npx tsx --test tests/tools/memory-tool.test.ts tests/handlers/background-review.test.ts tests/handlers/session-flush.test.ts tests/handlers/correction-detector.test.ts tests/handlers/auto-consolidate.test.ts tests/handlers/insights.test.ts tests/handlers/preview-context.test.ts` (164 passed)
- `npx tsc --noEmit --pretty false`
- `npm test` (all 46 test files passed)
