### PR TITLE
chore: prepare 0.9.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.9.3] - 2026-08-08
+## [0.9.4] - 2026-08-08
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hermes-memory",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-tui": "^0.80.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "🧠 Persistent memory + 🔍 session search + 🛡️ secret scanning for Pi. Token-aware policy-only memory by default, SQLite FTS5 search, auto-consolidation, procedural skills. 732 tests. Ported from Hermes agent.",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
Prepares the next publishable release as `0.9.4`.

## Summary
- Bump `package.json` and `package-lock.json` to `0.9.4`.
- Rename the unreleased release-notes heading to `0.9.4`.
- Keep the release notes for the merged #151, #155, #156, and #157 fixes.

## Verification
- `npm run check`
- `npm pack --dry-run --json` produced `pi-hermes-memory-0.9.4.tgz`.
- `git diff --check`
