### PR TITLE
feat(memory): configure auto-consolidation failure warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ Create `~/.pi/agent/hermes-memory-config.json`:
   "failureInjectionMaxAgeDays": 7,
   "failureInjectionMaxEntries": 5,
   "consolidationTimeoutMs": 180000,
+  "autoConsolidationWarnOnFailure": true,
   "flushOnCompact": true,
   "flushOnShutdown": true,
   "flushMinTurns": 6,
@@ -539,6 +540,7 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 | `memoryOverflowStrategy` | `auto-consolidate` | Behavior when MEMORY.md, USER.md, failures.md, or project-scoped memory reaches its character limit: `auto-consolidate` runs the existing consolidation flow; `reject` returns an error; `fifo-evict` rotates older entries in file order until the new entry fits |
 | `autoConsolidate` | `true` | Legacy alias for `memoryOverflowStrategy` when `memoryOverflowStrategy` is not set (`true` = `auto-consolidate`, `false` = `reject`) |
 | `consolidationTimeoutMs` | `180000` | Maximum time in milliseconds for a consolidation run (auto and `/memory-consolidate` alike). Configured values are used verbatim; a consolidation pays child-process boot plus a full LLM turn, so values below the default are frequently killed mid-run and log a warning at startup |
+| `autoConsolidationWarnOnFailure` | `true` | Log failed automatic consolidation attempts to the session console. Set to `false` to suppress only this warning; the memory tool result still reports the failure reason |
 | `correctionDetection` | `true` | Detect user corrections and save immediately |
 | `correctionStrongPatterns` | unset | Optional case-insensitive regex sources replacing strong correction patterns; omitted preserves defaults, invalid entries are ignored |
 | `correctionWeakPatterns` | unset | Optional case-insensitive regex sources replacing weak correction patterns; omitted preserves defaults, invalid entries are ignored |

--- a/src/auto-consolidation-warning.ts
+++ b/src/auto-consolidation-warning.ts
@@ -1,0 +1,6 @@
+export function shouldWarnAutoConsolidationFailure(
+  warnOnFailure: boolean,
+  consolidated: boolean,
+): boolean {
+  return !consolidated && warnOnFailure;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,6 +59,7 @@ const DEFAULT_CONFIG: MemoryConfig = {
   failureInjectionMaxAgeDays: DEFAULT_FAILURE_INJECTION_MAX_AGE_DAYS,
   failureInjectionMaxEntries: DEFAULT_FAILURE_INJECTION_MAX_ENTRIES,
   consolidationTimeoutMs: DEFAULT_CONSOLIDATION_TIMEOUT_MS,
+  autoConsolidationWarnOnFailure: true,
   nudgeToolCalls: DEFAULT_NUDGE_TOOL_CALLS,
   standingInstructionsEnabled: true,
   projectsMemoryDir: DEFAULT_PROJECTS_MEMORY_DIR,
@@ -124,6 +125,9 @@ export function loadConfig(configPath = DEFAULT_CONFIG_PATH): MemoryConfig {
             + " Consolidation spawns a child agent turn and is routinely killed mid-run at lower values.",
           );
         }
+      }
+      if (typeof parsed.autoConsolidationWarnOnFailure === "boolean") {
+        config.autoConsolidationWarnOnFailure = parsed.autoConsolidationWarnOnFailure;
       }
       if (typeof parsed.failureInjectionEnabled === "boolean") config.failureInjectionEnabled = parsed.failureInjectionEnabled;
       if (typeof parsed.failureInjectionMaxAgeDays === "number") config.failureInjectionMaxAgeDays = parsed.failureInjectionMaxAgeDays;

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ import { registerStandingPinCommand } from "./handlers/standing-pin.js";
 import { StandingInstructions } from "./store/standing-instructions.js";
 import { STANDING_FILE } from "./constants.js";
 import { loadConfig } from "./config.js";
+import { shouldWarnAutoConsolidationFailure } from "./auto-consolidation-warning.js";
 import { detectProject, detectProjectSkills } from "./project.js";
 import { buildPromptContext } from "./prompt-context.js";
 import { migrateLegacyProjectMemoryDirs } from "./project-memory-migration.js";
@@ -245,8 +246,8 @@ export default function (pi: ExtensionAPI) {
   setupSessionFlush(pi, store, projectStoreRef, config, dbManager, projectNameRef);
 
   // ── 7. Setup auto-consolidation (inject consolidator into stores) ──
-  // A failed auto-consolidation is otherwise invisible outside the tool result,
-  // so log the reason for whoever is watching the session (#135).
+  // Keep the failure in the tool result regardless; session-console logging is
+  // separately configurable for users who already monitor tool results (#135).
   const runAutoConsolidation = async (
     target: "memory" | "user" | "failure",
     targetStore: MemoryStore,
@@ -264,7 +265,7 @@ export default function (pi: ExtensionAPI) {
     );
     if (result.deferred) {
       console.info(`⏳ Auto-consolidation for '${toolTarget}' deferred: ${result.error ?? "another session holds the consolidation lock"}`);
-    } else if (!result.consolidated) {
+    } else if (shouldWarnAutoConsolidationFailure(config.autoConsolidationWarnOnFailure, result.consolidated)) {
       console.warn(`⚠️ Auto-consolidation failed for '${toolTarget}': ${result.error ?? "no reason reported"}`);
     }
     return result;

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,8 @@ export interface MemoryConfig {
   nudgeToolCalls: number;
   /** Maximum time in milliseconds for a consolidation run, auto or manual. Default: 180000 */
   consolidationTimeoutMs: number;
+  /** Log failed auto-consolidation attempts to the session console. Default: true */
+  autoConsolidationWarnOnFailure: boolean;
   /** Inject pinned STANDING.md instructions into every session. Default: true */
   standingInstructionsEnabled: boolean;
 }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -31,6 +31,7 @@ describe("loadConfig", () => {
     assert.strictEqual(config.memoryOverflowStrategy, "auto-consolidate");
     assert.strictEqual(config.autoConsolidate, true);
     assert.strictEqual(config.consolidationTimeoutMs, 180000);
+    assert.strictEqual(config.autoConsolidationWarnOnFailure, true);
     assert.strictEqual(config.failureInjectionEnabled, true);
     assert.strictEqual(config.failureInjectionMaxAgeDays, 7);
     assert.strictEqual(config.failureInjectionMaxEntries, 5);
@@ -82,6 +83,7 @@ describe("loadConfig", () => {
       projectsMemoryDir: "my-memory",
       llmModelOverride: " openrouter/deepseek/deepseek-v4-flash ",
       llmThinkingOverride: "minimal",
+      autoConsolidationWarnOnFailure: false,
     }));
     const config = loadConfig(TEST_CONFIG_PATH);
     assert.strictEqual(config.memoryMode, "legacy-inject");
@@ -92,6 +94,7 @@ describe("loadConfig", () => {
     assert.strictEqual(config.reviewRecentMessages, 25);
     assert.strictEqual(config.flushRecentMessages, 40);
     assert.strictEqual(config.failureInjectionEnabled, false);
+    assert.strictEqual(config.autoConsolidationWarnOnFailure, false);
     assert.strictEqual(config.failureInjectionMaxAgeDays, 30);
     assert.strictEqual(config.failureInjectionMaxEntries, 2);
     assert.strictEqual(config.projectsMemoryDir, "my-memory");

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,0 +1,30 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { shouldWarnAutoConsolidationFailure } from "../src/auto-consolidation-warning.js";
+
+describe("shouldWarnAutoConsolidationFailure", () => {
+  it("warns for failed consolidation by default", () => {
+    assert.strictEqual(
+      shouldWarnAutoConsolidationFailure(true, false),
+      true,
+    );
+  });
+
+  it("suppresses only the session warning when disabled", () => {
+    assert.strictEqual(
+      shouldWarnAutoConsolidationFailure(false, false),
+      false,
+    );
+  });
+
+  it("never warns for a successful consolidation", () => {
+    assert.strictEqual(
+      shouldWarnAutoConsolidationFailure(true, true),
+      false,
+    );
+    assert.strictEqual(
+      shouldWarnAutoConsolidationFailure(false, true),
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add `autoConsolidationWarnOnFailure`, defaulting to `true`
- allow users to suppress only the session-console warning emitted after a failed automatic consolidation
- preserve the failed tool result, automatic consolidation behavior, manual consolidation reporting, timeout startup warnings, SQLite synchronization warnings, and all other errors

## Context

Issue #135 and PR #138 intentionally made failed automatic consolidation observable both in the tool result and through a session-console warning. This keeps that default while adding a narrow opt-out for users who still want mandatory tool-result diagnostics but do not want the repeated console warning.

## Validation

- `npm run check`
- `npx tsx --test tests/config.test.ts tests/index.test.ts` (33 passed)
- mutation check: forcing the warning predicate to always return false fails the default-warning test
- independent review: approved with no functional, minimality, test, or documentation findings

The full suite could not be attested locally because this machine runs Node 26, while `better-sqlite3@12.9.0` supports Node 20–25 and has no Node ABI 147 binding. The changed-area tests and TypeScript check are green; CI can validate on the repository-supported runtime.
