### PR TITLE
fix(auto-consolidation): defer stale extension ctx errors instead of reporting failure

### DIFF
--- a/src/handlers/auto-consolidate.ts
+++ b/src/handlers/auto-consolidate.ts
@@ -274,10 +274,22 @@ export async function triggerConsolidation(
       consolidated: false,
       error: describeConsolidationFailure(result, timeoutMs),
     };
-  } catch (err) {
+} catch (err) {
+    const message = String(err);
+    if (message.includes("extension ctx is stale")) {
+      // Session replaced/reloaded while consolidation was running. The new
+      // session re-initializes the store and will consolidate on its own next
+      // write, so this is a skip, not a failure — report it as deferred so the
+      // caller asks for a retry instead of surfacing a stale-ctx error.
+      return {
+        consolidated: false,
+        deferred: true,
+        error: "session replaced or reloaded during consolidation — will consolidate on next write",
+      };
+    }
     return {
       consolidated: false,
-      error: `Consolidation failed: ${String(err).slice(0, 200)}`,
+      error: `Consolidation failed: ${message.slice(0, 200)}`,
     };
   } finally {
     if (lock) {

--- a/tests/handlers/auto-consolidate.test.ts
+++ b/tests/handlers/auto-consolidate.test.ts
@@ -359,7 +359,7 @@ describe("triggerConsolidation", () => {
     assert.match(result.error!, /60000ms/);
   });
 
-  it("returns { consolidated: false } when pi.exec throws", async () => {
+it("returns { consolidated: false } when pi.exec throws", async () => {
     const crashPi = {
       on: () => {},
       exec: async () => { throw new Error("network failure"); },
@@ -372,6 +372,22 @@ describe("triggerConsolidation", () => {
     assert.strictEqual(result.consolidated, false);
     assert.ok(result.error!.includes("Consolidation failed"), "should mention failure");
     assert.ok(result.error!.includes("network failure"), "should include original error");
+  });
+
+  it("defers instead of failing when pi.exec throws a stale extension ctx error", async () => {
+    const stalePi = {
+      on: () => {},
+      exec: async () => { throw new Error("This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession()"); },
+      registerTool: () => {},
+      registerCommand: () => {},
+    } as any;
+
+    const result = await triggerConsolidation(stalePi, mockStore, "memory");
+
+    assert.strictEqual(result.consolidated, false);
+    assert.strictEqual(result.deferred, true, "stale ctx should defer, not fail");
+    assert.ok(!result.error!.includes("Consolidation failed"), "should not report a failure");
+    assert.ok(result.error!.includes("session replaced or reloaded"), "should explain the skip");
   });
 
   it("includes user profile entries when target is 'user'", async () => {


### PR DESCRIPTION
## Problem

When a memory write triggers auto-consolidation and the session is replaced or reloaded while the consolidation child process is still running (`newSession`/`fork`/`switchSession`/`reload`), the captured extension `pi` object is invalidated by the framework. The in-flight `pi.exec` call then throws:

```
This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload().
```

`triggerConsolidation` caught this and reported it as a **failure**:
- `⚠️ Auto-consolidation failed for 'failure': Consolidation failed: Error: This extension ctx is stale...` (session console warning, `index.ts`)
- the triggering memory write returned an "Auto-consolidation attempted but failed" error

This is noise, not data loss: the new session re-initializes the memory store and consolidates on its own next write.

## Fix

Detect the stale-ctx error message in `triggerConsolidation`'s catch block and return a **deferred** result instead of a failure. The caller (`addWithConsolidation` / `runAutoConsolidation`) already treats deferred as "retry shortly" — no failure warning, no failed tool result.

## Changes

- `src/handlers/auto-consolidate.ts`: recognize `extension ctx is stale` errors → `{ consolidated: false, deferred: true, error: "session replaced or reloaded during consolidation — will consolidate on next write" }`
- `tests/handlers/auto-consolidate.test.ts`: new test verifying a stale-ctx `pi.exec` throw defers instead of failing

## Validation

- `npx tsc --noEmit` clean
- `tests/handlers/auto-consolidate.test.ts`: 35/35 pass (incl. new test)
- `tests/store/memory-store.test.ts`: 78/78 pass (deferred path unaffected)