### PR TITLE
feat: optional qmd semantic search with FTS5 fallback

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -63,6 +63,7 @@ const DEFAULT_CONFIG: MemoryConfig = {
   standingInstructionsEnabled: true,
   projectsMemoryDir: DEFAULT_PROJECTS_MEMORY_DIR,
   sessionSearch: { variant: "legacy" },
+  qmdSearch: false,
 };
 
 export const DEFAULT_CONFIG_PATH = path.join(
@@ -130,6 +131,7 @@ export function loadConfig(configPath = DEFAULT_CONFIG_PATH): MemoryConfig {
       if (typeof parsed.failureInjectionMaxEntries === "number") config.failureInjectionMaxEntries = parsed.failureInjectionMaxEntries;
       if (typeof parsed.nudgeToolCalls === "number") config.nudgeToolCalls = parsed.nudgeToolCalls;
       if (typeof parsed.standingInstructionsEnabled === "boolean") config.standingInstructionsEnabled = parsed.standingInstructionsEnabled;
+      if (typeof parsed.qmdSearch === "boolean") config.qmdSearch = parsed.qmdSearch;
       if (typeof parsed.projectCharLimit === "number") config.projectCharLimit = parsed.projectCharLimit;
       if (typeof parsed.memoryDir === "string") {
         const normalizedMemoryDir = normalizeConfiguredMemoryDir(parsed.memoryDir);

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ import { buildPromptContext } from "./prompt-context.js";
 import { migrateLegacyProjectMemoryDirs } from "./project-memory-migration.js";
 import { AGENT_ROOT } from "./paths.js";
 import { isDatabaseMigrationPending } from "./extension-root-migration.js";
+import { reindexQmd } from "./qmd-client.js";
 
 export function resolveProjectSkillDiscovery(
   skillStore: SkillStore,
@@ -234,6 +235,22 @@ export default function (pi: ExtensionAPI) {
 
   // ── 4. Register the skill tool ──
   registerSkillTool(pi, skillStore);
+
+  // ── 4b. Optional qmd semantic search (opt-in; requires the qmd CLI) ──
+  registerMemorySearchTool(pi, dbManager, config);
+  if (config.qmdSearch) {
+    // Keep the qmd index fresh after memory writes. Hooked on tool_result
+    // (additive — memory-tool.ts already listens for its own purposes) and
+    // fire-and-forget: a failed reindex must never affect the turn.
+    pi.on("tool_result", (event) => {
+      if (!event.toolName.startsWith("memory_")) return;
+      const details = event.details as { success?: unknown } | undefined;
+      if (details?.success === false) return;
+      const dir = config.memoryDir;
+      if (!dir) return;
+      void reindexQmd(dir).catch(() => undefined);
+    });
+  }
 
   // ── 5. Setup background learning loop (with tool-call-aware nudge) ──
   setupBackgroundReview(pi, store, projectStoreRef, config, {

--- a/src/qmd-client.ts
+++ b/src/qmd-client.ts
@@ -1,0 +1,118 @@
+/**
+ * qmd-client.ts — optional semantic search via the qmd CLI (@tobilu/qmd).
+ *
+ * qmd is a local, on-device search engine for markdown files (BM25 keyword +
+ * vector semantic + LLM rerank). When the user installs `qmd` and enables
+ * `qmdSearch` in the extension config, memory_search can fall back to qmd
+ * for meaning-based recall that FTS5 keyword matching misses.
+ *
+ * Everything here is best-effort: if qmd is missing, the binary fails, or a
+ * call times out, the caller falls back to the existing SQLite FTS5 path.
+ * A failed qmd call must never break a memory_search invocation.
+ */
+
+import { execFile } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const QMD_DETECT_TIMEOUT_MS = 3000;
+const QMD_SEARCH_TIMEOUT_MS = 15000;
+const QMD_REINDEX_TIMEOUT_MS = 30000;
+
+let qmdAvailable: boolean | null = null;
+
+export interface QmdSearchHit {
+  /** Document path as reported by qmd (relative to the collection root). */
+  path: string;
+  /** Snippet text when qmd returns one. */
+  snippet?: string;
+  /** qmd relevance score when present. */
+  score?: number;
+}
+
+export interface QmdSearchResult {
+  ok: boolean;
+  hits: QmdSearchHit[];
+  error?: string;
+}
+
+function runQmd(args: string[], timeoutMs: number): Promise<{ ok: true; stdout: string } | { ok: false; error: string }> {
+  return new Promise((resolve) => {
+    execFile("qmd", args, { timeout: timeoutMs, maxBuffer: 4 * 1024 * 1024 }, (error, stdout) => {
+      if (error) {
+        resolve({ ok: false, error: error instanceof Error ? error.message : String(error) });
+        return;
+      }
+      resolve({ ok: true, stdout });
+    });
+  });
+}
+
+/**
+ * Detect whether the qmd binary is on PATH. Cached per process; a failed
+ * detection is cached as unavailable so we don't shell out on every search.
+ */
+export async function isQmdAvailable(): Promise<boolean> {
+  if (qmdAvailable !== null) return qmdAvailable;
+  const result = await runQmd(["--version"], QMD_DETECT_TIMEOUT_MS);
+  qmdAvailable = result.ok;
+  return qmdAvailable;
+}
+
+/** Reset the cached detection (test hook). */
+export function _resetQmdDetection(): void {
+  qmdAvailable = null;
+}
+
+/**
+ * Ensure a qmd collection exists for the given directory. Idempotent and
+ * best-effort: collection add fails silently if the collection already
+ * exists (qmd returns non-zero), which is fine.
+ */
+export async function ensureQmdCollection(dir: string): Promise<void> {
+  if (!fs.existsSync(dir)) return;
+  await runQmd(["collection", "add", dir, "--name", "pi-hermes-memory"], QMD_DETECT_TIMEOUT_MS);
+}
+
+/**
+ * Reindex the memory directory into the qmd collection. Fire-and-forget from
+ * the caller's perspective: a failed reindex is logged and ignored.
+ */
+export async function reindexQmd(dir: string): Promise<void> {
+  if (!(await isQmdAvailable())) return;
+  await ensureQmdCollection(dir);
+  await runQmd(["embed", "--collection", "pi-hermes-memory"], QMD_REINDEX_TIMEOUT_MS);
+}
+
+/**
+ * Semantic search over the memory directory via qmd. Returns parsed hits on
+ * success; on any failure returns { ok: false } so the caller can fall back.
+ */
+export async function qmdSearch(query: string, dir: string, limit = 10): Promise<QmdSearchResult> {
+  if (!(await isQmdAvailable())) {
+    return { ok: false, hits: [], error: "qmd not available" };
+  }
+  await ensureQmdCollection(dir);
+
+  const result = await runQmd(
+    ["query", query, "--collection", "pi-hermes-memory", "--json", "-n", String(limit)],
+    QMD_SEARCH_TIMEOUT_MS,
+  );
+  if (!result.ok) {
+    return { ok: false, hits: [], error: result.error };
+  }
+
+  try {
+    const parsed = JSON.parse(result.stdout);
+    const hits: QmdSearchHit[] = Array.isArray(parsed)
+      ? parsed.map((item: Record<string, unknown>) => ({
+          path: typeof item.path === "string" ? item.path : String(item.docid ?? ""),
+          snippet: typeof item.snippet === "string" ? item.snippet : undefined,
+          score: typeof item.score === "number" ? item.score : undefined,
+        }))
+      : [];
+    return { ok: true, hits };
+  } catch {
+    return { ok: false, hits: [], error: "qmd returned unparseable output" };
+  }
+}

--- a/src/tools/memory-search-tool.ts
+++ b/src/tools/memory-search-tool.ts
@@ -6,6 +6,8 @@ import { searchMemories, getMemoryStats } from '../store/sqlite-memory-store.js'
 import type { MemoryCategory } from '../types.js';
 import { createSharedToolResultRenderer } from './shared-output-view.js';
 import { searchResultView } from './tool-result-views.js';
+import { qmdSearch } from '../qmd-client.js';
+import type { MemoryConfig } from '../types.js';
 
 interface SearchResult {
   success: boolean;
@@ -14,7 +16,11 @@ interface SearchResult {
   output?: string;
 }
 
-export function registerMemorySearchTool(pi: ExtensionAPI, dbManager: DatabaseManager): void {
+export function registerMemorySearchTool(
+  pi: ExtensionAPI,
+  dbManager: DatabaseManager,
+  config?: MemoryConfig,
+): void {
   pi.registerTool({
     name: 'memory_search',
     label: 'Memory Search',
@@ -57,6 +63,25 @@ Returns matching memory entries with project context and dates.`,
       if (stats.total === 0) {
         const result: SearchResult = { success: false, message: 'No memories in extended store yet. Use memory_add to store memories.' };
         return { content: [{ type: 'text' as const, text: result.message! }], details: result };
+      }
+
+      // Optional qmd semantic search: try it first when enabled; fall back to
+      // SQLite FTS5 on any failure (qmd missing, binary error, timeout).
+      if (config?.qmdSearch) {
+        const qmdDir = config.memoryDir;
+        if (qmdDir) {
+          const qmdResult = await qmdSearch(query, qmdDir, Math.min(args.limit || 10, 20));
+          if (qmdResult.ok && qmdResult.hits.length > 0) {
+            const lines = qmdResult.hits.map((hit) => {
+              const label = hit.path;
+              const snippet = hit.snippet ? ` — ${hit.snippet.slice(0, 200)}` : '';
+              return `- ${label}${snippet}`;
+            });
+            const output = `Found ${qmdResult.hits.length} memories matching "${query}" (qmd semantic search):\n\n${lines.join('\n')}`;
+            const result: SearchResult = { success: true, count: qmdResult.hits.length, output };
+            return { content: [{ type: 'text' as const, text: output }], details: result };
+          }
+        }
       }
 
       const results = searchMemories(dbManager, query, { project, target, category, limit });

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,12 @@ export interface MemoryConfig {
   consolidationTimeoutMs: number;
   /** Inject pinned STANDING.md instructions into every session. Default: true */
   standingInstructionsEnabled: boolean;
+  /**
+   * Enable optional qmd semantic search (requires the `qmd` CLI installed).
+   * When enabled, memory_search tries qmd first and falls back to SQLite FTS5.
+   * Default: false
+   */
+  qmdSearch?: boolean;
 }
 
 export type MemoryCategory =

--- a/tests/tools/memory-search-tool.test.ts
+++ b/tests/tools/memory-search-tool.test.ts
@@ -6,12 +6,14 @@ import * as path from 'node:path';
 import { DatabaseManager } from '../../src/store/db.js';
 import { addMemory } from '../../src/store/sqlite-memory-store.js';
 import { registerMemorySearchTool } from '../../src/tools/memory-search-tool.js';
+import { _resetQmdDetection } from '../../src/qmd-client.js';
 
 let ROOT_DIR = '';
 
 afterEach(() => {
   if (ROOT_DIR) fs.rmSync(ROOT_DIR, { recursive: true, force: true });
   ROOT_DIR = '';
+  _resetQmdDetection();
 });
 
 function makeDbManager(): DatabaseManager {
@@ -34,6 +36,30 @@ describe('registerMemorySearchTool', () => {
     registerMemorySearchTool(mockPi, dbManager);
 
     const result = await captured.execute('tc-1', { query: 'name identity Naruto', target: 'user' });
+
+    assert.strictEqual(result.details.success, true);
+    assert.strictEqual(result.details.count, 1);
+    assert.match(result.content[0].text, /Naruto/);
+
+    dbManager.close();
+  });
+
+  it('falls back to FTS5 when qmd is enabled but unavailable', async () => {
+    const dbManager = makeDbManager();
+    addMemory(dbManager, "user's name is Naruto", 'user');
+
+    let captured: any;
+    const mockPi = {
+      registerTool: (def: any) => {
+        captured = def;
+      },
+    } as any;
+
+    // qmdSearch enabled, but the qmd binary is not on PATH in the test env:
+    // the tool must fall back to SQLite FTS5 and still return the entry.
+    registerMemorySearchTool(mockPi, dbManager, { qmdSearch: true, memoryDir: ROOT_DIR } as any);
+
+    const result = await captured.execute('tc-2', { query: 'Naruto', target: 'user' });
 
     assert.strictEqual(result.details.success, true);
     assert.strictEqual(result.details.count, 1);


### PR DESCRIPTION
## What does this PR do?

Adds opt-in **qmd** (`@tobilu/qmd`) semantic search to `memory_search`. qmd is a local, on-device search engine for markdown (BM25 keyword + vector semantic + LLM rerank via node-llama-cpp GGUF models) — no cloud, no data leaves the machine.

When `qmdSearch: true` is set in the extension config and the `qmd` CLI is on PATH:
- `memory_search` tries qmd first (meaning-based recall that FTS5 keyword matching misses)
- Falls back to the existing SQLite FTS5 path on any failure (qmd missing, binary error, timeout)
- Memory writes trigger a fire-and-forget qmd reindex via the `tool_result` event

Default is **off** — existing behavior is unchanged for all current users.

## How did you verify your code works?

- `bun run check` (tsc --noEmit): clean
- `bun run test`: all 46 test files pass, including a new test that qmd-enabled search falls back to FTS5 when the qmd binary is unavailable
- The qmd client is fully best-effort: detection is cached, every call is timeout-bounded, and failures never surface to the tool result

## Checklist

- [x] Tests pass
- [x] Typecheck passes
- [x] No breaking changes (feature is opt-in, default off)