### PR TITLE
feat(memory-store): include current entries in memoryFullError response

### DIFF
--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -348,9 +348,14 @@ export class MemoryStore {
   private memoryFullError(target: "memory" | "user" | "failure", contentLength: number): MemoryResult {
     const current = this.charCount(target);
     const limit = this.charLimit(target);
+    const entries = this.entriesFor(target).map((raw) => this.decodeEntry(raw).text);
     return {
       success: false,
-      error: `Memory at ${current}/${limit} chars. Adding this entry (${contentLength} chars) would exceed the limit. Replace or remove existing entries first.`,
+      error: `Memory at ${current}/${limit} chars. Adding this entry (${contentLength} chars) would exceed the limit. Replace or remove existing entries first (see the entries list below), then retry this add — all in this turn.`,
+      target,
+      usage: `${current}/${limit} chars`,
+      entry_count: entries.length,
+      entries,
     };
   }
 

--- a/tests/store/memory-store.test.ts
+++ b/tests/store/memory-store.test.ts
@@ -366,6 +366,67 @@ describe("MemoryStore", { concurrency: 1 }, () => {
       assert.ok(raw.includes(existing));
     });
 
+    it("includes current entries in memoryFullError response under reject strategy", async () => {
+      const store = new MemoryStore(makeConfig({
+        memoryCharLimit: 140,
+        memoryOverflowStrategy: "reject",
+      }));
+      await store.loadFromDisk();
+
+      const first = `${TEST_MARKER} first`;
+      const second = `${TEST_MARKER} second`;
+      assert.ok((await store.add("memory", first)).success);
+      assert.ok((await store.add("memory", second)).success);
+
+      const result = await store.add("memory", `${TEST_MARKER} ${"x".repeat(100)}`);
+      await settle();
+
+      assert.ok(!result.success);
+      assert.match(result.error ?? "", /see the entries list below/);
+      assert.equal(result.target, "memory");
+      assert.match(result.usage ?? "", /^\d+\/140 chars$/);
+      assert.equal(result.entry_count, 2);
+      assert.deepEqual(result.entries, [first, second]);
+
+      // Metadata comments must not leak into the decoded entries (#178 regression)
+      for (const entry of result.entries ?? []) {
+        assert.ok(!entry.includes("<!--"), "decoded entry must not leak metadata comment");
+        assert.ok(!entry.includes("created="), "decoded entry must not leak created metadata");
+      }
+    });
+
+    it("includes current entries in memoryFullError response when fifo-evict cannot fit the new entry", async () => {
+      const store = new MemoryStore(makeConfig({
+        memoryCharLimit: 80,
+        memoryOverflowStrategy: "fifo-evict",
+      }));
+      await store.loadFromDisk();
+
+      const existing = `${TEST_MARKER} keep me`;
+      assert.ok((await store.add("memory", existing)).success);
+
+      const result = await store.add("memory", `${TEST_MARKER} ${"x".repeat(120)}`);
+      await settle();
+
+      assert.ok(!result.success);
+      assert.match(result.error ?? "", /see the entries list below/);
+      assert.equal(result.target, "memory");
+      assert.match(result.usage ?? "", /^\d+\/80 chars$/);
+      assert.equal(result.entry_count, 1);
+      assert.deepEqual(result.entries, [existing]);
+
+      // Metadata comments must not leak into the decoded entries (#178 regression)
+      for (const entry of result.entries ?? []) {
+        assert.ok(!entry.includes("<!--"), "decoded entry must not leak metadata comment");
+        assert.ok(!entry.includes("created="), "decoded entry must not leak created metadata");
+      }
+
+      // Existing entry must remain on disk — fifo-evict rotated nothing because
+      // the new entry alone exceeds the limit.
+      const raw = await readRaw(memoryPath);
+      assert.ok(raw.includes(existing));
+    });
+
     it("returns error for empty content", async () => {
       const store = new MemoryStore(makeConfig());
 


### PR DESCRIPTION
## Problem

When memory is at capacity and `memoryOverflowStrategy` is `"reject"` (or when `"fifo-evict"` cannot fit the new entry alone), `memoryFullError` returns only a plain error string:

> Memory at 4991/5000 chars. Adding this entry (235 chars) would exceed the limit. Replace or remove existing entries first.

The agent then has to issue a separate read of the memory file to see the current entries before it can curate (replace/remove then retry). This is the exact friction the [Hermes Agent memory design](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/memory.md) avoids by including `current_entries` in the full error response.

## Solution

Populate the existing optional `entries`, `usage`, and `entry_count` fields on `MemoryResult` in the error path — they were already defined in the type and used by `successResponse`, just not filled by `memoryFullError`.

The `entries` array contains decoded entry text (metadata stripped via `decodeEntry`), so the agent gets a clean list it can act on directly.

The error message is also updated to guide the agent: *"see the entries list below, then retry this add — all in this turn"* — matching the curated-memory path where the agent consolidates and retries in the same turn.

## Why no tool-layer change?

`formatMemoryToolText` in `memory-tool.ts` falls through to `JSON.stringify(result)` when `success === false`, so the new fields are transparently serialized to the LLM with zero changes outside `memory-store.ts`.

## Verification

Tested with a real at-capacity memory store (4991/5000 chars, 7 entries). The `memory_add` call now returns:

```json
{
  "success": false,
  "error": "Memory at 4991/5000 chars. Adding this entry (235 chars) would exceed the limit. Replace or remove existing entries first (see the entries list below), then retry this add — all in this turn.",
  "target": "memory",
  "usage": "4991/5000 chars",
  "entry_count": 7,
  "entries": ["<entry 1 text>", "<entry 2 text>", "..."]
}
```

The agent was able to `memory_replace` an overlapping entry and retry the `add` in the same turn, without a separate file read.
