### PR TITLE
fix(memory): expose mutation targets in search

### DIFF
--- a/src/store/memory-lookup.ts
+++ b/src/store/memory-lookup.ts
@@ -8,6 +8,12 @@ export function normalizeMemoryLookupText(text: string): string {
     .find((line) => line.length > 0);
   if (firstNonEmptyLine) normalized = firstNonEmptyLine;
 
+  // Current memory_search results use a URL-encoded scope token so arbitrary
+  // project names cannot terminate the prefix early.
+  normalized = normalized.replace(
+    /^\S+\s+scope=(?:global|project:[^\s]+)\s+\[target=(?:memory|user|project|failure)\]\s+/u,
+    "",
+  );
   normalized = normalized.replace(/^\S+\s+\[[^\]]+\]\s+/u, "");
   // memory_search labels each result with its mutation target after the scope.
   // Keep copied search lines usable as replace/remove lookup text.

--- a/src/store/memory-lookup.ts
+++ b/src/store/memory-lookup.ts
@@ -9,6 +9,9 @@ export function normalizeMemoryLookupText(text: string): string {
   if (firstNonEmptyLine) normalized = firstNonEmptyLine;
 
   normalized = normalized.replace(/^\S+\s+\[[^\]]+\]\s+/u, "");
+  // memory_search labels each result with its mutation target after the scope.
+  // Keep copied search lines usable as replace/remove lookup text.
+  normalized = normalized.replace(/^\[target=(?:memory|user|project|failure)\]\s+/u, "");
   normalized = normalized.replace(/^(\[[^\]]+\])\s+\1(\s+|$)/, "$1 ");
 
   return normalized.trim();

--- a/src/tools/memory-search-tool.ts
+++ b/src/tools/memory-search-tool.ts
@@ -14,6 +14,14 @@ interface SearchResult {
   output?: string;
 }
 
+function mutationTarget(entry: { target: "memory" | "user" | "failure"; project: string | null }): "memory" | "user" | "failure" | "project" {
+  return entry.project ? "project" : entry.target;
+}
+
+function scopeLabel(project: string | null): string {
+  return project ? `project:${project}` : "global";
+}
+
 export function registerMemorySearchTool(pi: ExtensionAPI, dbManager: DatabaseManager): void {
   pi.registerTool({
     name: 'memory_search',
@@ -26,7 +34,7 @@ Use cases:
 - Find user preferences: "What are the user's testing preferences?"
 - Search for past failures: "memory_search('auth', category='failure')"
 
-Returns matching memory entries with project context and dates.`,
+Returns matching memory entries with their mutation target, scope, and dates. The displayed target is the value required by memory_replace and memory_remove.`,
     promptSnippet: 'Search extended memory store (unlimited capacity)',
     promptGuidelines: [
       'Use memory_search when you need context beyond what is in the system prompt.',
@@ -69,10 +77,12 @@ Returns matching memory entries with project context and dates.`,
       let output = `Found ${results.length} memories matching "${query}":\n\n`;
 
       for (const entry of results) {
-        const projectLabel = entry.project ? `[${entry.project}]` : '[global]';
+        const target = mutationTarget(entry);
+        const projectLabel = `[scope=${scopeLabel(entry.project)}]`;
+        const mutationTargetLabel = `[target=${target}]`;
         const targetLabel = entry.target === 'user' ? '👤' : entry.target === 'failure' ? '⚠️' : '🧠';
         const categoryLabel = entry.category ? ` [${entry.category}]` : '';
-        output += `${targetLabel} ${projectLabel}${categoryLabel} ${entry.content}\n`;
+        output += `${targetLabel} ${projectLabel} ${mutationTargetLabel}${categoryLabel} ${entry.content}\n`;
         output += `   Created: ${entry.created} | Last used: ${entry.lastReferenced}\n\n`;
       }
 

--- a/src/tools/memory-search-tool.ts
+++ b/src/tools/memory-search-tool.ts
@@ -15,11 +15,13 @@ interface SearchResult {
 }
 
 function mutationTarget(entry: { target: "memory" | "user" | "failure"; project: string | null }): "memory" | "user" | "failure" | "project" {
-  return entry.project ? "project" : entry.target;
+  // A project name scopes ordinary memory entries, but project-attributed
+  // failures still live in (and must be mutated through) the failure store.
+  return entry.target === "memory" && entry.project ? "project" : entry.target;
 }
 
 function scopeLabel(project: string | null): string {
-  return project ? `project:${project}` : "global";
+  return project ? `project:${encodeURIComponent(project)}` : "global";
 }
 
 export function registerMemorySearchTool(pi: ExtensionAPI, dbManager: DatabaseManager): void {
@@ -78,7 +80,7 @@ Returns matching memory entries with their mutation target, scope, and dates. Th
 
       for (const entry of results) {
         const target = mutationTarget(entry);
-        const projectLabel = `[scope=${scopeLabel(entry.project)}]`;
+        const projectLabel = `scope=${scopeLabel(entry.project)}`;
         const mutationTargetLabel = `[target=${target}]`;
         const targetLabel = entry.target === 'user' ? '👤' : entry.target === 'failure' ? '⚠️' : '🧠';
         const categoryLabel = entry.category ? ` [${entry.category}]` : '';

--- a/src/tools/memory-tool.ts
+++ b/src/tools/memory-tool.ts
@@ -21,6 +21,7 @@ import {
 import { MEMORY_TOOL_DESCRIPTION } from "../constants.js";
 import { resolveProjectName, resolveProjectStore, type ProjectNameRef, type ProjectStoreRef } from "../project-context.js";
 import type { MemoryCategory, MemoryResult } from "../types.js";
+import { normalizeMemoryLookupText } from "../store/memory-lookup.js";
 import { createSharedToolResultRenderer } from "./shared-output-view.js";
 import { memoryResultView } from "./tool-result-views.js";
 
@@ -69,6 +70,44 @@ function sqliteProjectFor(rawTarget: "memory" | "user" | "project" | "failure", 
 function sqliteTargetFor(rawTarget: "memory" | "user" | "project" | "failure"): "memory" | "user" | "failure" {
   if (rawTarget === "project") return "memory";
   return rawTarget;
+}
+
+function matchingMutationTargets(
+  oldText: string,
+  store: MemoryStore,
+  projectStore: MemoryStore | null,
+): Array<"memory" | "user" | "failure" | "project"> {
+  const lookup = normalizeMemoryLookupText(oldText);
+  if (!lookup) return [];
+
+  const targets: Array<"memory" | "user" | "failure" | "project"> = [];
+  if (store.getMemoryEntries().some((entry) => entry.includes(lookup))) targets.push("memory");
+  if (store.getUserEntries().some((entry) => entry.includes(lookup))) targets.push("user");
+  if (store.getAllFailureEntries().some((entry) => entry.includes(lookup))) targets.push("failure");
+  if (projectStore?.getMemoryEntries().some((entry) => entry.includes(lookup))) targets.push("project");
+  return targets;
+}
+
+function addWrongTargetHint(
+  result: MemoryResult,
+  rawTarget: "memory" | "user" | "project" | "failure",
+  oldText: string,
+  store: MemoryStore,
+  projectStore: MemoryStore | null,
+): MemoryResult {
+  if (result.success || !result.error?.startsWith("No entry matched")) return result;
+
+  const alternatives = matchingMutationTargets(oldText, store, projectStore)
+    .filter((target) => target !== rawTarget);
+  if (alternatives.length === 0) return result;
+
+  const quotedTargets = alternatives.map((target) => `"${target}"`).join(", ");
+  const noun = alternatives.length === 1 ? "target" : "targets";
+  return {
+    ...result,
+    error: `No match in target "${rawTarget}"; matching entry found in ${noun} ${quotedTargets}. Retry with the displayed target.`,
+    matching_targets: alternatives,
+  };
 }
 
 async function syncAddToSqlite(
@@ -328,6 +367,10 @@ export function registerMemoryTool(
           syncWarning = await syncRemoveFromSqlite(rawTarget, old_text, dbManager, activeProjectName);
         }
         break;
+    }
+
+    if (action !== "add" && old_text) {
+      result = addWrongTargetHint(result, rawTarget, old_text, store, activeProjectStore);
     }
 
     if (result.success && !syncHandled && typeof store_.getRawEntriesForSync === "function") {

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,6 +111,8 @@ export interface MemoryResult {
   evicted_entries?: string[];
   evicted_count?: number;
   matches?: string[];
+  /** Targets that contain old_text when a replace/remove was sent to the wrong one. */
+  matching_targets?: Array<"memory" | "user" | "failure" | "project">;
 }
 
 export interface MemoryMutationOperation {

--- a/tests/store/memory-store.test.ts
+++ b/tests/store/memory-store.test.ts
@@ -696,7 +696,7 @@ describe("MemoryStore", { concurrency: 1 }, () => {
       await store.add("memory", `${TEST_MARKER} prefers pnpm over npm`);
       await settle();
 
-      const result = await store.remove("memory", `🧠 [scope=global] [target=memory] ${TEST_MARKER} prefers pnpm over npm\n   Created: 2026-05-27 | Last used: 2026-05-27`);
+      const result = await store.remove("memory", `🧠 scope=global [target=memory] ${TEST_MARKER} prefers pnpm over npm\n   Created: 2026-05-27 | Last used: 2026-05-27`);
       await settle();
 
       assert.ok(result.success);

--- a/tests/store/memory-store.test.ts
+++ b/tests/store/memory-store.test.ts
@@ -696,7 +696,7 @@ describe("MemoryStore", { concurrency: 1 }, () => {
       await store.add("memory", `${TEST_MARKER} prefers pnpm over npm`);
       await settle();
 
-      const result = await store.remove("memory", `🧠 [global] ${TEST_MARKER} prefers pnpm over npm\n   Created: 2026-05-27 | Last used: 2026-05-27`);
+      const result = await store.remove("memory", `🧠 [scope=global] [target=memory] ${TEST_MARKER} prefers pnpm over npm\n   Created: 2026-05-27 | Last used: 2026-05-27`);
       await settle();
 
       assert.ok(result.success);

--- a/tests/store/sqlite-memory-store.test.ts
+++ b/tests/store/sqlite-memory-store.test.ts
@@ -291,7 +291,7 @@ describe('sqlite-memory-store', () => {
 
       const result = replaceSyncedMemories(
         dbManager,
-        '🧠 [scope=global] [target=memory] prefers pnpm over npm\n   Created: 2026-05-27 | Last used: 2026-05-27',
+        '🧠 scope=global [target=memory] prefers pnpm over npm\n   Created: 2026-05-27 | Last used: 2026-05-27',
         {
           content: 'prefers pnpm over npm and bun when needed',
           target: 'memory',

--- a/tests/store/sqlite-memory-store.test.ts
+++ b/tests/store/sqlite-memory-store.test.ts
@@ -291,7 +291,7 @@ describe('sqlite-memory-store', () => {
 
       const result = replaceSyncedMemories(
         dbManager,
-        '🧠 [global] prefers pnpm over npm\n   Created: 2026-05-27 | Last used: 2026-05-27',
+        '🧠 [scope=global] [target=memory] prefers pnpm over npm\n   Created: 2026-05-27 | Last used: 2026-05-27',
         {
           content: 'prefers pnpm over npm and bun when needed',
           target: 'memory',

--- a/tests/tools/memory-search-tool.test.ts
+++ b/tests/tools/memory-search-tool.test.ts
@@ -41,4 +41,25 @@ describe('registerMemorySearchTool', () => {
 
     dbManager.close();
   });
+
+  it('labels every result with its mutation target and unambiguous scope', async () => {
+    const dbManager = makeDbManager();
+    addMemory(dbManager, 'global deployment convention');
+    addMemory(dbManager, 'user deployment preference', 'user');
+    addMemory(dbManager, 'failure deployment lesson', 'failure');
+    addMemory(dbManager, 'project deployment convention', 'memory', 'project-a');
+
+    let captured: any;
+    registerMemorySearchTool({ registerTool: (def: any) => { captured = def; } } as any, dbManager);
+
+    const result = await captured.execute('tc-1', { query: 'deployment' });
+    const text = result.content[0].text;
+
+    assert.match(text, /\[scope=global\] \[target=memory\] global deployment convention/);
+    assert.match(text, /\[scope=global\] \[target=user\] user deployment preference/);
+    assert.match(text, /\[scope=global\] \[target=failure\] failure deployment lesson/);
+    assert.match(text, /\[scope=project:project-a\] \[target=project\] project deployment convention/);
+
+    dbManager.close();
+  });
 });

--- a/tests/tools/memory-search-tool.test.ts
+++ b/tests/tools/memory-search-tool.test.ts
@@ -5,6 +5,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { DatabaseManager } from '../../src/store/db.js';
 import { addMemory } from '../../src/store/sqlite-memory-store.js';
+import { normalizeMemoryLookupText } from '../../src/store/memory-lookup.js';
 import { registerMemorySearchTool } from '../../src/tools/memory-search-tool.js';
 
 let ROOT_DIR = '';
@@ -48,6 +49,7 @@ describe('registerMemorySearchTool', () => {
     addMemory(dbManager, 'user deployment preference', 'user');
     addMemory(dbManager, 'failure deployment lesson', 'failure');
     addMemory(dbManager, 'project deployment convention', 'memory', 'project-a');
+    addMemory(dbManager, 'project failure deployment lesson', 'failure', 'project-a');
 
     let captured: any;
     registerMemorySearchTool({ registerTool: (def: any) => { captured = def; } } as any, dbManager);
@@ -55,10 +57,27 @@ describe('registerMemorySearchTool', () => {
     const result = await captured.execute('tc-1', { query: 'deployment' });
     const text = result.content[0].text;
 
-    assert.match(text, /\[scope=global\] \[target=memory\] global deployment convention/);
-    assert.match(text, /\[scope=global\] \[target=user\] user deployment preference/);
-    assert.match(text, /\[scope=global\] \[target=failure\] failure deployment lesson/);
-    assert.match(text, /\[scope=project:project-a\] \[target=project\] project deployment convention/);
+    assert.match(text, /scope=global \[target=memory\] global deployment convention/);
+    assert.match(text, /scope=global \[target=user\] user deployment preference/);
+    assert.match(text, /scope=global \[target=failure\] failure deployment lesson/);
+    assert.match(text, /scope=project:project-a \[target=project\] project deployment convention/);
+    assert.match(text, /scope=project:project-a \[target=failure\] project failure deployment lesson/);
+
+    dbManager.close();
+  });
+
+  it('keeps copied results reversible when a project name contains brackets', async () => {
+    const dbManager = makeDbManager();
+    addMemory(dbManager, 'literal project entry', 'memory', 'foo] bar');
+
+    let captured: any;
+    registerMemorySearchTool({ registerTool: (def: any) => { captured = def; } } as any, dbManager);
+
+    const result = await captured.execute('tc-1', { query: 'literal' });
+    const firstResultLine = result.content[0].text.split('\n').find((line: string) => line.startsWith('🧠'))!;
+
+    assert.match(firstResultLine, /scope=project:foo%5D%20bar \[target=project\]/);
+    assert.equal(normalizeMemoryLookupText(firstResultLine), 'literal project entry');
 
     dbManager.close();
   });

--- a/tests/tools/memory-tool.test.ts
+++ b/tests/tools/memory-tool.test.ts
@@ -147,6 +147,50 @@ describe("registerMemoryTool", () => {
     assert.strictEqual(results[0].content, 'Entry one');
   });
 
+  it("reports the matching target when replace is sent to the wrong target", async () => {
+    let removeTool: any;
+    const mockPi = {
+      registerTool: (def: any) => {
+        if (def.name === "memory_remove") removeTool = def;
+      },
+    } as unknown as ExtensionAPI;
+    const store = new MemoryStore({
+      memoryMode: "policy-only",
+      memoryCharLimit: 5000,
+      userCharLimit: 5000,
+      projectCharLimit: 5000,
+      nudgeInterval: 10,
+      reviewEnabled: false,
+      flushOnCompact: false,
+      flushOnShutdown: false,
+      flushMinTurns: 6,
+      autoConsolidate: false,
+      correctionDetection: false,
+      failureInjectionEnabled: true,
+      failureInjectionMaxAgeDays: 7,
+      failureInjectionMaxEntries: 5,
+      nudgeToolCalls: 15,
+      consolidationTimeoutMs: 60000,
+      memoryDir: tmpDir,
+    });
+    await store.loadFromDisk();
+    await store.addFailure("use pnpm for lockfiles", { category: "correction" });
+
+    registerMemoryTool(mockPi, store, null);
+    const result = await removeTool.execute(
+      "tc-1",
+      { target: "memory", old_text: "use pnpm for lockfiles" },
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    assert.equal(result.details.success, false);
+    assert.match(result.details.error, /No match in target "memory"/);
+    assert.match(result.details.error, /target "failure"/);
+    assert.deepEqual(result.details.matching_targets, ["failure"]);
+  });
+
   it("prunes same-scope SQLite orphans after a Markdown mutation", async () => {
     let capturedResult: any;
     const mockPi = {


### PR DESCRIPTION
Fixes #180.\n\nSearch results now label both scope and the target required by memory_replace and memory_remove. Copied result lines remain valid mutation text, and wrong-target mutation failures identify matching target(s) rather than asking the agent to guess.\n\nValidation: npm run check; npm test.