### PR TITLE
feat: FTS5 query quality and session retention pruning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Opt-in memory lifecycle timings**: `PI_TIMING=1` now reports startup synchronization and loading, backfill and live-index callbacks, shutdown flush/index/wait/close, and database open/integrity-check/checkpoint durations. Normal runs produce no timing output.
 
+- **Opt-in SQLite session retention** ([#183](https://github.com/chandra447/pi-hermes-memory/issues/183)): new `sessionRetentionDays` setting (default `0`, disabled). When set to a positive value, sessions whose JSONL source file has not been updated within the window are pruned from SQLite at startup — rows only, the JSONL files themselves are never deleted — and both the deferred backfill and `/memory-index-sessions` skip files outside the window, so pruned sessions stay pruned instead of being re-indexed on every startup. With the default `0`, pruning is fully disabled and startup keeps the legacy count-only backfill preflight.
+
+### Changed
+
+- **Natural-language search now filters common stop words** ([#184](https://github.com/chandra447/pi-hermes-memory/pull/184)): session and memory searches drop function words (`the`, `is`, `what`, …) before FTS5 matching, improving precision for natural-language queries. Intent-bearing words (`can`, `need`, `off`, `like`, `get`, …) are deliberately kept. A query made up entirely of stop words no longer returns an empty result — it degrades to a scoped literal substring search over the original terms.
+
+### Fixed
+
+- **FTS5 index errors during markdown sync are surfaced instead of hidden** ([#184](https://github.com/chandra447/pi-hermes-memory/pull/184)): when the FTS5 search index is broken, memory writes still succeed in Markdown, but the tool result and `/memory-sync-markdown` now report the degraded search state together with the repair command instead of showing a silent zero-count success. Genuine database corruption is unaffected by the fallback and now recovers through the markdown sync path too: reconciliation runs inside `DatabaseManager.withCorruptionRecovery()`, so a corrupt `sessions.db` is quarantined, rebuilt, and the sync retried instead of failing every memory write.
+
 ### Fixed
 
 - **Clean process exit on Node 24+** ([#193](https://github.com/chandra447/pi-hermes-memory/issues/193), reported by [@vanneswong](https://github.com/vanneswong)): `better-sqlite3` 12.x inherits Node's raw `node::ObjectWrap`, whose destructor calls `RemoveEnvironmentCleanupHook` after Node has torn down its Environment — so on Node 24 (observed on Linux aarch64) Pi could abort with SIGABRT and a non-zero exit code at every shutdown, after all work completed. The dependency moves to `better-sqlite3@^13.0.3`, the first N-API/node-addon-api release, which removes that crash path. The public API this extension uses is unchanged; the declared engines (`>=22`) cover every Pi-supported runtime.

--- a/README.md
+++ b/README.md
@@ -495,6 +495,7 @@ Create `~/.pi/agent/hermes-memory-config.json`:
   "memoryDir": "~/.pi/agent/pi-hermes-memory",
   "projectsMemoryDir": "projects-memory",
   "sessionSearch": { "variant": "legacy" },
+  "sessionRetentionDays": 0,
   "llmModelOverride": "openrouter/deepseek/deepseek-v4-flash",
   "llmThinkingOverride": "off",
   "childExtensionPaths": ["~/.pi/agent/git/github.com/example/custom-provider-extension/index.ts"],
@@ -532,6 +533,7 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 | `memoryDir` | `~/.pi/agent/pi-hermes-memory` | Custom directory for extension storage files |
 | `projectsMemoryDir` | `projects-memory` | Subdirectory under `~/.pi/agent/` for project-scoped memory |
 | `sessionSearch` | `{ "variant": "legacy" }` | Session search implementation: `legacy` keeps the existing SQLite/FTS snippet search; `anchors` uses the opt-in Markdown request surface and returns compact JSONL line-range anchors from `~/.pi/agent/sessions/` |
+| `sessionRetentionDays` | `0` | Opt-in SQLite session retention, in days. `0` (default) disables pruning entirely and keeps the legacy count-only backfill preflight. When positive, sessions whose JSONL source file was last modified longer ago than the window are pruned from SQLite at startup — **rows only; the JSONL files in `~/.pi/agent/sessions/` are never deleted** — and both the deferred backfill and `/memory-index-sessions` skip files outside the window, so pruned sessions stay pruned instead of being re-indexed |
 | `llmModelOverride` | unset | Optional model override for background review (direct and subprocess), correction save, session flush, and consolidation |
 | `llmThinkingOverride` | unset | Optional thinking override for those LLM calls; valid values are `off`, `minimal`, `low`, `medium`, `high`, and `xhigh`. If `llmModelOverride` is set and this is omitted, review/child calls default to `off` |
 | `childExtensionPaths` | unset | Trusted provider/auth extension sources explicitly allowed in isolated child Pi processes. Values are passed to Pi's standard `-e` resolver, so absolute paths, `~/...`, paths relative to the child working directory, and `git:`/`npm:` package sources are supported. Sibling packages matching the `*-oauth-adapter`/`*-auth-adapter` naming convention (including scoped packages, via their `package.json` `pi.extensions` manifest) are detected automatically. This setting is only needed for custom providers or adapters that are not detected. In-process direct transport (the default for review/flush/correction/consolidation) doesn't need it, since it reads whatever provider auth is already registered. |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -294,7 +294,7 @@ Agent has access to tools:
 - [ ] Auto-index session on shutdown
 - [ ] Char limits: MEMORY.md 2,200 → 5,000, USER.md 1,375 → 5,000, project 2,200 → 5,000
 - [ ] Config: `sessionSearchEnabled: boolean` (default: true)
-- [ ] Config: `sessionRetentionDays: number` (default: 90)
+- [x] Config: `sessionRetentionDays: number` (default: `0` = disabled) — shipped via [#184](https://github.com/chandra447/pi-hermes-memory/pull/184)
 
 ### What Does NOT Change
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -138,7 +138,10 @@ export function loadConfig(configPath = DEFAULT_CONFIG_PATH): MemoryConfig {
       if (typeof parsed.failureInjectionMaxAgeDays === "number") config.failureInjectionMaxAgeDays = parsed.failureInjectionMaxAgeDays;
       if (typeof parsed.failureInjectionMaxEntries === "number") config.failureInjectionMaxEntries = parsed.failureInjectionMaxEntries;
       if (typeof parsed.nudgeToolCalls === "number") config.nudgeToolCalls = parsed.nudgeToolCalls;
-      if (typeof parsed.sessionRetentionDays === "number" && Number.isFinite(parsed.sessionRetentionDays) && parsed.sessionRetentionDays > 0) {
+      // Accept any finite number >= 0 so a user can both opt in (positive value)
+      // and explicitly disable retention with 0. Invalid/negative values are
+      // ignored, keeping the current (default) semantics.
+      if (typeof parsed.sessionRetentionDays === "number" && Number.isFinite(parsed.sessionRetentionDays) && parsed.sessionRetentionDays >= 0) {
         config.sessionRetentionDays = parsed.sessionRetentionDays;
       }
       if (typeof parsed.standingInstructionsEnabled === "boolean") config.standingInstructionsEnabled = parsed.standingInstructionsEnabled;

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ import {
   DEFAULT_OVERFLOW_GRACE_MS,
   DEFAULT_FAILURE_INJECTION_MAX_AGE_DAYS,
   DEFAULT_FAILURE_INJECTION_MAX_ENTRIES,
+  DEFAULT_SESSION_RETENTION_DAYS,
 } from "./constants.js";
 import { AGENT_ROOT, normalizeConfiguredMemoryDir, normalizeProjectsMemoryDir } from "./paths.js";
 
@@ -66,6 +67,7 @@ const DEFAULT_CONFIG: MemoryConfig = {
   standingInstructionsEnabled: true,
   projectsMemoryDir: DEFAULT_PROJECTS_MEMORY_DIR,
   sessionSearch: { variant: "legacy" },
+  sessionRetentionDays: DEFAULT_SESSION_RETENTION_DAYS,
 };
 
 export const DEFAULT_CONFIG_PATH = path.join(
@@ -136,6 +138,9 @@ export function loadConfig(configPath = DEFAULT_CONFIG_PATH): MemoryConfig {
       if (typeof parsed.failureInjectionMaxAgeDays === "number") config.failureInjectionMaxAgeDays = parsed.failureInjectionMaxAgeDays;
       if (typeof parsed.failureInjectionMaxEntries === "number") config.failureInjectionMaxEntries = parsed.failureInjectionMaxEntries;
       if (typeof parsed.nudgeToolCalls === "number") config.nudgeToolCalls = parsed.nudgeToolCalls;
+      if (typeof parsed.sessionRetentionDays === "number" && Number.isFinite(parsed.sessionRetentionDays) && parsed.sessionRetentionDays > 0) {
+        config.sessionRetentionDays = parsed.sessionRetentionDays;
+      }
       if (typeof parsed.standingInstructionsEnabled === "boolean") config.standingInstructionsEnabled = parsed.standingInstructionsEnabled;
       if (typeof parsed.projectCharLimit === "number") config.projectCharLimit = parsed.projectCharLimit;
       if (typeof parsed.memoryDir === "string") {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,10 +42,13 @@ export const DEFAULT_FAILURE_INJECTION_MAX_ENTRIES = 5;
 
 // ─── Session retention defaults ───
 /**
- * Keep sessions from the last N days. Older sessions are pruned on startup to
- * bound the size of the session index database (see #183).
+ * Default session retention window in days. `0` means retention pruning is
+ * DISABLED by default -- existing searchable session history is never silently
+ * deleted. Users opt in by setting `sessionRetentionDays` to a positive value
+ * in their config; setting it back to `0` (or omitting it) disables pruning
+ * (see #183).
  */
-export const DEFAULT_SESSION_RETENTION_DAYS = 180;
+export const DEFAULT_SESSION_RETENTION_DAYS = 0;
 
 // ─── File names ───
 export const MEMORY_FILE = "MEMORY.md";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,6 +40,13 @@ export const DEFAULT_OVERFLOW_GRACE_MS = 180000;
 export const DEFAULT_FAILURE_INJECTION_MAX_AGE_DAYS = 7;
 export const DEFAULT_FAILURE_INJECTION_MAX_ENTRIES = 5;
 
+// ─── Session retention defaults ───
+/**
+ * Keep sessions from the last N days. Older sessions are pruned on startup to
+ * bound the size of the session index database (see #183).
+ */
+export const DEFAULT_SESSION_RETENTION_DAYS = 180;
+
 // ─── File names ───
 export const MEMORY_FILE = "MEMORY.md";
 export const USER_FILE = "USER.md";

--- a/src/handlers/index-sessions.ts
+++ b/src/handlers/index-sessions.ts
@@ -6,12 +6,13 @@ import path from 'node:path';
 import fs from 'node:fs';
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { DatabaseManager } from '../store/db.js';
-import { indexAllSessions, getSessionStats } from '../store/session-indexer.js';
+import { indexAllSessions, getSessionStats, retentionCutoffMs } from '../store/session-indexer.js';
+import type { MemoryConfig } from '../types.js';
 import { AGENT_ROOT } from '../paths.js';
 
 const SESSIONS_DIR = process.env.PI_CODING_AGENT_SESSION_DIR || path.join(AGENT_ROOT, 'sessions');
 
-export function registerIndexSessionsCommand(pi: ExtensionAPI): void {
+export function registerIndexSessionsCommand(pi: ExtensionAPI, config: MemoryConfig): void {
   pi.registerCommand("memory-index-sessions", {
     description: "Import past Pi sessions into the search database",
     handler: async (_args, ctx: ExtensionCommandContext) => {
@@ -38,7 +39,9 @@ export function registerIndexSessionsCommand(pi: ExtensionAPI): void {
         const dbManager = new DatabaseManager(memoryDir);
 
         try {
-          const result = indexAllSessions(dbManager, SESSIONS_DIR);
+          // Retention is honored here too: a manual reindex must not re-add the
+          // expired sessions the auto pruning just deleted.
+          const result = indexAllSessions(dbManager, SESSIONS_DIR, undefined, retentionCutoffMs(config.sessionRetentionDays));
           const stats = getSessionStats(dbManager);
 
           let output = `\n✅ Session indexing complete!\n\n`;
@@ -46,6 +49,9 @@ export function registerIndexSessionsCommand(pi: ExtensionAPI): void {
           output += `├─ Sessions processed: ${result.sessionsProcessed}\n`;
           output += `├─ Sessions indexed: ${result.sessionsIndexed}\n`;
           output += `├─ Sessions skipped (already indexed): ${result.sessionsSkipped}\n`;
+          if (result.expiredSkipped) {
+            output += `├─ Sessions skipped (outside retention): ${result.expiredSkipped}\n`;
+          }
           output += `└─ Messages indexed: ${result.messagesIndexed}\n`;
 
           if (stats.projects.length > 0) {

--- a/src/handlers/session-backfill.ts
+++ b/src/handlers/session-backfill.ts
@@ -33,6 +33,12 @@ export interface ScheduleSessionBackfillOptions {
   indexSessionsFn?: typeof indexChangedSessions;
   maxFilesToIndex?: number;
   touchBackfillTimestampFn?: typeof touchBackfillTimestamp;
+  /**
+   * Optional retention cutoff (ms epoch). Files older than this are excluded
+   * from the backfill file set so that sessions pruned by retention are not
+   * re-indexed and do not repeatedly schedule a startup backfill.
+   */
+  retentionCutoffMs?: number;
 }
 
 function formatBackfillResult(result: BulkIndexResult): string {
@@ -69,6 +75,7 @@ export function scheduleSessionBackfill(
   const indexSessionsFn = options.indexSessionsFn ?? indexChangedSessions;
   const maxFilesToIndex = options.maxFilesToIndex ?? SESSION_BACKFILL_MAX_FILES;
   const touchBackfillTimestampFn = options.touchBackfillTimestampFn ?? touchBackfillTimestamp;
+  const retentionCutoffMs = options.retentionCutoffMs ?? 0;
 
   if (state.inProgress) {
     return false;
@@ -77,7 +84,7 @@ export function scheduleSessionBackfill(
   try {
     if (!measureLifecycleSync(
       'session-backfill.check',
-      () => needsBackfillFn(dbManager, sessionsDir),
+      () => needsBackfillFn(dbManager, sessionsDir, undefined, retentionCutoffMs),
     )) {
       return false;
     }
@@ -95,7 +102,7 @@ export function scheduleSessionBackfill(
     setTimeoutFn(() => {
       measureLifecycleSync('session-backfill.callback', () => {
         try {
-          const result = indexSessionsFn(dbManager, sessionsDir, { maxFilesToIndex });
+          const result = indexSessionsFn(dbManager, sessionsDir, { maxFilesToIndex, retentionCutoffMs });
           if (!result.reachedLimit) touchBackfillTimestampFn(dbManager);
           notifyBestEffort(options.notify, formatBackfillResult(result), result.errors.length > 0 || result.reachedLimit ? 'warning' : 'info');
         } catch (err) {

--- a/src/handlers/sync-markdown-memories.ts
+++ b/src/handlers/sync-markdown-memories.ts
@@ -165,6 +165,11 @@ export async function syncMarkdownMemoriesToSqlite(
         counters.imported += result.inserted;
         counters.skipped += result.existing;
         counters.removed += result.removed;
+        if (result.degraded) {
+          counters.warnings.push(
+            `${path.basename(project ?? 'global')}/${target}: FTS5 search index error (${result.degradedReason}); run /memory-sync-markdown to rebuild`,
+          );
+        }
       } catch (err) {
         counters.warnings.push(
           `${path.basename(project ?? 'global')}/${target}: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { MemoryStore } from "./store/memory-store.js";
 import { SkillStore } from "./store/skill-store.js";
 import { DatabaseManager } from "./store/db.js";
-import { indexSession, upsertSessionFileMetadata, pruneEphemeralReviewSessions, pruneOldSessions } from "./store/session-indexer.js";
+import { indexSession, upsertSessionFileMetadata, pruneEphemeralReviewSessions, pruneOldSessions, retentionCutoffMs } from "./store/session-indexer.js";
 import { runRecoveryMaintenance } from "./store/recovery-maintenance.js";
 import { scheduleSessionBackfill, waitForSessionBackfill, SESSION_BACKFILL_SHUTDOWN_TIMEOUT_MS } from "./handlers/session-backfill.js";
 import { scheduleLiveSessionIndex, waitForLiveSessionIndex, SESSION_LIVE_INDEX_SHUTDOWN_TIMEOUT_MS } from "./handlers/session-live-index.js";
@@ -253,6 +253,9 @@ export default function (pi: ExtensionAPI) {
             console.info(message);
           }
         },
+        // Exclude files older than the retention cutoff so sessions pruned by
+        // retention are never re-indexed and never schedule another backfill.
+        retentionCutoffMs: retentionCutoffMs(config.sessionRetentionDays),
       });
     }
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -347,7 +347,7 @@ export default function (pi: ExtensionAPI) {
   // ── 11. SQLite session search + extended memory ──
   registerSessionSearchTool(pi, dbManager, config.sessionSearch ?? { variant: "legacy" });
   registerMemorySearchTool(pi, dbManager);
-  registerIndexSessionsCommand(pi);
+  registerIndexSessionsCommand(pi, config);
 
   // ── 12. Auto-index session on shutdown ──
   // Registered last, so this runs after the session-flush shutdown handler and

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { MemoryStore } from "./store/memory-store.js";
 import { SkillStore } from "./store/skill-store.js";
 import { DatabaseManager } from "./store/db.js";
-import { indexSession, upsertSessionFileMetadata, pruneEphemeralReviewSessions } from "./store/session-indexer.js";
+import { indexSession, upsertSessionFileMetadata, pruneEphemeralReviewSessions, pruneOldSessions } from "./store/session-indexer.js";
 import { runRecoveryMaintenance } from "./store/recovery-maintenance.js";
 import { scheduleSessionBackfill, waitForSessionBackfill, SESSION_BACKFILL_SHUTDOWN_TIMEOUT_MS } from "./handlers/session-backfill.js";
 import { scheduleLiveSessionIndex, waitForLiveSessionIndex, SESSION_LIVE_INDEX_SHUTDOWN_TIMEOUT_MS } from "./handlers/session-live-index.js";
@@ -220,6 +220,22 @@ export default function (pi: ExtensionAPI) {
         pruneEphemeralReviewSessions(dbManager);
       } catch (err) {
         console.warn(`⚠️ Ephemeral session cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      // Prune sessions older than the configured retention window to bound the
+      // size of the session index database (see #183). Runs before
+      // scheduleSessionBackfill so pruned sessions are never re-indexed by a
+      // backfill started in the same startup.
+      if (config.sessionRetentionDays && config.sessionRetentionDays > 0) {
+        try {
+          const pruneResult = pruneOldSessions(dbManager, config.sessionRetentionDays);
+          if (pruneResult.sessionsRemoved > 0) {
+            console.info(
+              `🧠 Pruned ${pruneResult.sessionsRemoved} old session(s) (> ${config.sessionRetentionDays} days old)`,
+            );
+          }
+        } catch (err) {
+          console.warn(`⚠️ Session pruning failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
       }
       try {
         await runRecoveryMaintenance({ config, globalDir });

--- a/src/store/fts-query.ts
+++ b/src/store/fts-query.ts
@@ -4,11 +4,14 @@ const NATURAL_LANGUAGE_CONNECTORS = new Set(['and', 'or', 'not', 'near']);
 
 // Common English stop words that add noise to FTS5 searches. They are silently
 // dropped from natural-language queries so common filler words cannot dominate
-// the FTS5 ranking or produce misleading "AND"-style misses.
+// the FTS5 ranking or produce misleading "AND"-style misses. The list is
+// deliberately conservative: only high-frequency function words are dropped.
+// Words that frequently carry the actual search intent (can, need, off, like,
+// get) stay, so "can the app start" still searches for "can".
 const STOP_WORDS = new Set([
   'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
   'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'could', 'should',
-  'may', 'might', 'shall', 'can', 'need', 'dare', 'ought', 'used',
+  'may', 'might', 'shall', 'dare', 'ought', 'used',
   'i', 'me', 'my', 'mine', 'we', 'our', 'ours', 'you', 'your', 'yours',
   'he', 'him', 'his', 'she', 'her', 'hers', 'it', 'its', 'they', 'them',
   'their', 'theirs', 'that', 'this', 'these', 'those', 'what', 'which',
@@ -17,10 +20,10 @@ const STOP_WORDS = new Set([
   'nor', 'not', 'only', 'own', 'same', 'so', 'than', 'too', 'very', 's',
   't', 'just', 'don', 'now', 'about', 'above', 'after', 'again', 'against',
   'am', 'at', 'before', 'behind', 'below', 'between', 'by', 'during',
-  'from', 'further', 'into', 'like', 'off', 'over', 'per', 'through',
+  'from', 'further', 'into', 'over', 'per', 'through',
   'throughout', 'till', 'to', 'under', 'until', 'up', 'upon', 'via', 'with',
   'within', 'without', 'as', 'if', 'or', 'but', 'and', 'out', 'of',
-  'for', 'in', 'on', 'any', 'get', 'got', 'here', 'there',
+  'for', 'in', 'on', 'any', 'got', 'here', 'there',
 ]);
 
 export function hasExplicitFts5Operator(query: string): boolean {
@@ -90,6 +93,30 @@ export function buildFallbackFts5Query(query: string): string | null {
 
 function quoteTerms(terms: string[], separator: string): string {
   return terms.map((term) => `"${term.replace(/"/g, '""')}"`).join(separator);
+}
+
+/**
+ * Collect the raw terms of a query for literal (LIKE) fallback searches.
+ * Unlike normalizeFts5Query this does NOT drop stop words — a literal
+ * substring fallback is the last resort, and the original terms are what the
+ * user typed. Natural-language connectors are skipped because they never
+ * carry search intent.
+ */
+export function collectLikeTerms(query: string): string[] {
+  const terms: string[] = [];
+
+  for (const match of query.matchAll(FTS5_TOKEN_PATTERN)) {
+    const phrase = match[1];
+    const term = match[2];
+    if (phrase === undefined && term && NATURAL_LANGUAGE_CONNECTORS.has(term.toLowerCase())) {
+      continue;
+    }
+
+    const rawValue = phrase ?? term ?? '';
+    if (rawValue.length > 0) terms.push(rawValue);
+  }
+
+  return terms;
 }
 
 /**

--- a/src/store/fts-query.ts
+++ b/src/store/fts-query.ts
@@ -122,8 +122,10 @@ export function buildNaturalLanguageFallbackQuery(query: string): string | null 
 export function isFts5QueryError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   const msg = err.message.toLowerCase();
+  // NOTE: "malformed" and "sql logic error" are intentionally NOT matched here.
+  // They are corruption/recovery signals used by DatabaseManager (#186); swallowing
+  // them would suppress database quarantine/rebuild. Only genuine FTS5 query/index
+  // errors are considered recoverable search-path failures.
   return msg.includes('fts5') ||
-    msg.includes('unterminated string') ||
-    msg.includes('malformed') ||
-    msg.includes('sql logic error');
+    msg.includes('unterminated string');
 }

--- a/src/store/fts-query.ts
+++ b/src/store/fts-query.ts
@@ -2,6 +2,27 @@ const FTS5_OPERATOR_PATTERN = /\b(OR|AND|NOT|NEAR)\b/;
 const FTS5_TOKEN_PATTERN = /"([^"]*)"|(\S+)/g;
 const NATURAL_LANGUAGE_CONNECTORS = new Set(['and', 'or', 'not', 'near']);
 
+// Common English stop words that add noise to FTS5 searches. They are silently
+// dropped from natural-language queries so common filler words cannot dominate
+// the FTS5 ranking or produce misleading "AND"-style misses.
+const STOP_WORDS = new Set([
+  'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
+  'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'could', 'should',
+  'may', 'might', 'shall', 'can', 'need', 'dare', 'ought', 'used',
+  'i', 'me', 'my', 'mine', 'we', 'our', 'ours', 'you', 'your', 'yours',
+  'he', 'him', 'his', 'she', 'her', 'hers', 'it', 'its', 'they', 'them',
+  'their', 'theirs', 'that', 'this', 'these', 'those', 'what', 'which',
+  'who', 'whom', 'whose', 'when', 'where', 'why', 'how', 'all', 'each',
+  'every', 'both', 'few', 'more', 'most', 'other', 'some', 'such', 'no',
+  'nor', 'not', 'only', 'own', 'same', 'so', 'than', 'too', 'very', 's',
+  't', 'just', 'don', 'now', 'about', 'above', 'after', 'again', 'against',
+  'am', 'at', 'before', 'behind', 'below', 'between', 'by', 'during',
+  'from', 'further', 'into', 'like', 'off', 'over', 'per', 'through',
+  'throughout', 'till', 'to', 'under', 'until', 'up', 'upon', 'via', 'with',
+  'within', 'without', 'as', 'if', 'or', 'but', 'and', 'out', 'of',
+  'for', 'in', 'on', 'any', 'get', 'got', 'here', 'there',
+]);
+
 export function hasExplicitFts5Operator(query: string): boolean {
   return FTS5_OPERATOR_PATTERN.test(query.trim());
 }
@@ -13,6 +34,10 @@ function collectNaturalLanguageTerms(query: string): string[] {
     const phrase = match[1];
     const term = match[2];
     if (phrase === undefined && term && NATURAL_LANGUAGE_CONNECTORS.has(term.toLowerCase())) {
+      continue;
+    }
+    // Skip high-frequency stop words so they cannot dominate FTS5 ranking.
+    if (phrase === undefined && term && STOP_WORDS.has(term.toLowerCase())) {
       continue;
     }
 
@@ -97,5 +122,8 @@ export function buildNaturalLanguageFallbackQuery(query: string): string | null 
 export function isFts5QueryError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   const msg = err.message.toLowerCase();
-  return msg.includes('fts5') || msg.includes('unterminated string');
+  return msg.includes('fts5') ||
+    msg.includes('unterminated string') ||
+    msg.includes('malformed') ||
+    msg.includes('sql logic error');
 }

--- a/src/store/session-indexer.ts
+++ b/src/store/session-indexer.ts
@@ -509,3 +509,52 @@ export function getSessionStats(dbManager: DatabaseManager): {
     projects,
   };
 }
+
+/**
+ * Delete sessions older than the given retention window, along with their
+ * messages, to bound the growth of the session index database (see #183).
+ *
+ * `messages` and `session_files` reference `sessions`, but only `session_files`
+ * is declared `ON DELETE CASCADE`. Orphaned `messages` rows are deleted
+ * explicitly first so a `PRAGMA foreign_keys`-enabled delete never trips a
+ * FK constraint, and so an accurate `messagesRemoved` count is reported.
+ *
+ * Returns the number of sessions and messages removed.
+ */
+export function pruneOldSessions(
+  dbManager: DatabaseManager,
+  retentionDays: number,
+): { sessionsRemoved: number; messagesRemoved: number } {
+  const db = dbManager.getDb();
+  const cutoffIso = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000).toISOString();
+
+  // Count what would be removed so we can report accurately even if a DELETE
+  // fails mid-way. Messages are counted upfront because SQLite does not
+  // surface cascade/orphan counts from DELETE ... RETURNING across tables.
+  const sessionCount = db.prepare(
+    'SELECT COUNT(*) as cnt FROM sessions WHERE started_at < ?',
+  ).get(cutoffIso) as { cnt: number };
+  if (sessionCount.cnt === 0) {
+    return { sessionsRemoved: 0, messagesRemoved: 0 };
+  }
+
+  const messageCount = db.prepare(
+    `SELECT COUNT(*) as cnt FROM messages WHERE session_id IN (SELECT id FROM sessions WHERE started_at < ?)`,
+  ).get(cutoffIso) as { cnt: number };
+
+  const prune = () => {
+    const delMessages = db.prepare(
+      'DELETE FROM messages WHERE session_id IN (SELECT id FROM sessions WHERE started_at < ?)',
+    ).run(cutoffIso);
+    const delSessions = db.prepare('DELETE FROM sessions WHERE started_at < ?').run(cutoffIso);
+    return { messagesRemoved: delMessages.changes, sessionsRemoved: delSessions.changes };
+  };
+
+  const result = db.transaction ? db.transaction(prune)() : prune();
+  // Fall back to the pre-counted values if the transaction changed nothing
+  // unexpectedly (defensive; DELETE should always affect the counted rows).
+  return {
+    sessionsRemoved: result.sessionsRemoved || sessionCount.cnt,
+    messagesRemoved: result.messagesRemoved || messageCount.cnt,
+  };
+}

--- a/src/store/session-indexer.ts
+++ b/src/store/session-indexer.ts
@@ -481,27 +481,38 @@ export function needsBackfill(
   if (files.length > indexed.count) {
     // Only files still inside the retention window can demand a backfill;
     // expired (pruned) files must not.
-    const retainedFiles = files.filter((file) => {
+    let retainedCount = 0;
+    for (const file of files) {
       try {
-        return isWithinRetention(getSessionFileMetadata(file).mtimeMs, retentionCutoffMs);
+        if (isWithinRetention(getSessionFileMetadata(file).mtimeMs, retentionCutoffMs)) retainedCount++;
       } catch {
-        return false;
+        // Unreadable files cannot demand a backfill.
       }
-    });
-    if (retainedFiles.length > indexed.count) {
+    }
+    if (retainedCount > indexed.count) {
       return true;
     }
   }
 
+  let hasRetainedFile = false;
   for (const file of files) {
     try {
       const metadata = getSessionFileMetadata(file);
       if (!isWithinRetention(metadata.mtimeMs, retentionCutoffMs)) continue;
+      hasRetainedFile = true;
       if (storedSessionFileMatches(dbManager, metadata)) continue;
       return true;
     } catch {
       return true;
     }
+  }
+
+  // Retention is enabled and every file is outside the window: there is no
+  // work for a backfill to do. Returning here (instead of falling through to
+  // the periodic timestamp check) keeps an all-expired store from scheduling
+  // an empty backfill on every startup before any timestamp is written.
+  if (retentionCutoffMs > 0 && !hasRetainedFile) {
+    return false;
   }
 
   return !isRecentBackfillTimestamp(getLastBackfillTimestamp(dbManager), now.getTime());

--- a/src/store/session-indexer.ts
+++ b/src/store/session-indexer.ts
@@ -25,6 +25,8 @@ export interface BulkIndexResult {
   messagesIndexed: number;
   errors: string[];
   reachedLimit?: boolean;
+  /** Session files skipped because their mtime is outside the retention window. */
+  expiredSkipped?: number;
 }
 
 interface SessionFileMetadata {
@@ -358,26 +360,48 @@ function indexSessionFile(dbManager: DatabaseManager, file: string, result: Bulk
 
 /**
  * Index all sessions from disk.
+ * With retentionCutoffMs > 0, files whose mtime falls outside the window are
+ * skipped (counted in expiredSkipped) so a manual reindex honors the same
+ * retention policy the auto pruning enforces, instead of re-adding expired
+ * sessions that pruning just deleted.
  *
  * @param dbManager — Database manager instance
  * @param sessionsDir — Path to ~/.pi/agent/sessions/
  * @param projectDir — Optional: specific project directory to index
+ * @param retentionCutoffMs — Optional: epoch ms; files modified before it are skipped
  * @returns Bulk index result
  */
 export function indexAllSessions(
   dbManager: DatabaseManager,
   sessionsDir: string,
-  projectDir?: string
+  projectDir?: string,
+  retentionCutoffMs = 0,
 ): BulkIndexResult {
   const files = getSessionFiles(sessionsDir, projectDir);
   const result = emptyBulkIndexResult();
+  let expiredSkipped = 0;
 
   for (const file of files) {
+    if (retentionCutoffMs > 0) {
+      try {
+        if (!isWithinRetention(getSessionFileMetadata(file).mtimeMs, retentionCutoffMs)) {
+          expiredSkipped++;
+          continue;
+        }
+      } catch {
+        // Unreadable metadata: let indexSessionFile report the real error.
+      }
+    }
+
     try {
       indexSessionFile(dbManager, file, result);
     } catch (err) {
       result.errors.push(`Error indexing ${file}: ${err instanceof Error ? err.message : String(err)}`);
     }
+  }
+
+  if (expiredSkipped > 0) {
+    result.expiredSkipped = expiredSkipped;
   }
 
   return result;
@@ -478,43 +502,48 @@ export function needsBackfill(
   const files = getSessionFiles(sessionsDir);
   const indexed = db.prepare('SELECT COUNT(*) as count FROM sessions').get() as { count: number };
 
-  if (files.length > indexed.count) {
-    // Only files still inside the retention window can demand a backfill;
-    // expired (pruned) files must not.
-    let retainedCount = 0;
-    for (const file of files) {
-      try {
-        if (isWithinRetention(getSessionFileMetadata(file).mtimeMs, retentionCutoffMs)) retainedCount++;
-      } catch {
-        // Unreadable files cannot demand a backfill.
-      }
-    }
-    if (retainedCount > indexed.count) {
+  if (retentionCutoffMs <= 0) {
+    // Retention disabled: keep the historical cheap path — a plain file-count
+    // vs row-count comparison decides before any per-file stat work, so
+    // large session directories stay fast on startup.
+    if (files.length > indexed.count) {
       return true;
     }
+
+    for (const file of files) {
+      try {
+        const metadata = getSessionFileMetadata(file);
+        if (storedSessionFileMatches(dbManager, metadata)) continue;
+        return true;
+      } catch {
+        // An unreadable or malformed session file still needs indexing.
+        return true;
+      }
+    }
+
+    return !isRecentBackfillTimestamp(getLastBackfillTimestamp(dbManager), now.getTime());
   }
 
+  // Retention enabled: one metadata pass decides everything — a retained file
+  // with stale stored metadata demands a backfill, and when no file is inside
+  // the window there is no work at all. Returning here (instead of falling
+  // through to the periodic timestamp check) keeps an all-expired store from
+  // scheduling an empty backfill on every startup before a timestamp is ever
+  // written.
   let hasRetainedFile = false;
   for (const file of files) {
     try {
       const metadata = getSessionFileMetadata(file);
       if (!isWithinRetention(metadata.mtimeMs, retentionCutoffMs)) continue;
       hasRetainedFile = true;
-      if (storedSessionFileMatches(dbManager, metadata)) continue;
-      return true;
+      if (!storedSessionFileMatches(dbManager, metadata)) return true;
     } catch {
       return true;
     }
   }
-
-  // Retention is enabled and every file is outside the window: there is no
-  // work for a backfill to do. Returning here (instead of falling through to
-  // the periodic timestamp check) keeps an all-expired store from scheduling
-  // an empty backfill on every startup before any timestamp is written.
-  if (retentionCutoffMs > 0 && !hasRetainedFile) {
+  if (!hasRetainedFile) {
     return false;
   }
-
   return !isRecentBackfillTimestamp(getLastBackfillTimestamp(dbManager), now.getTime());
 }
 

--- a/src/store/session-indexer.ts
+++ b/src/store/session-indexer.ts
@@ -36,6 +36,25 @@ interface SessionFileMetadata {
 export interface IncrementalIndexOptions {
   projectDir?: string;
   maxFilesToIndex?: number;
+  /**
+   * Optional retention cutoff (ms epoch). JSONL session files whose mtime is
+   * strictly older than this cutoff are considered outside the retained window
+   * and are skipped entirely (not queued for indexing or counted as changed).
+   * This keeps incremental backfill aligned with session retention pruning:
+   * sessions pruned by pruneOldSessions() are never re-indexed on a later
+   * startup. Omit/0 to index every file (backwards-compatible default).
+   */
+  retentionCutoffMs?: number;
+}
+
+/**
+ * True when a session JSONL file's last-modified time falls within the
+ * retention window (mtime >= cutoff). Files older than the cutoff are treated
+ * as expired and are ineligible for backfill/indexing so that pruned sessions
+ * are not re-surfaced.
+ */
+function isWithinRetention(mtimeMs: number, retentionCutoffMs: number | undefined): boolean {
+  return !retentionCutoffMs || mtimeMs >= retentionCutoffMs;
 }
 
 export function truncateMessageContent(
@@ -390,6 +409,12 @@ export function indexChangedSessions(
   for (const file of files) {
     try {
       const metadata = getSessionFileMetadata(file);
+      if (!isWithinRetention(metadata.mtimeMs, options.retentionCutoffMs)) {
+        // Outside the retained window (e.g. pruned by pruneOldSessions):
+        // never re-queue it for indexing, so a pruned session does not come
+        // back on the next startup backfill.
+        continue;
+      }
       if (storedSessionFileMatches(dbManager, metadata)) {
         result.sessionsSkipped++;
         continue;
@@ -443,18 +468,35 @@ function isRecentBackfillTimestamp(value: string | null, nowMs: number): boolean
  * The check stays cheap: it compares file counts and stored file size/mtime
  * metadata. Full JSONL parsing is left to the scheduled incremental backfill.
  */
-export function needsBackfill(dbManager: DatabaseManager, sessionsDir: string, now = new Date()): boolean {
+export function needsBackfill(
+  dbManager: DatabaseManager,
+  sessionsDir: string,
+  now = new Date(),
+  retentionCutoffMs = 0,
+): boolean {
   const db = dbManager.getDb();
   const files = getSessionFiles(sessionsDir);
   const indexed = db.prepare('SELECT COUNT(*) as count FROM sessions').get() as { count: number };
 
   if (files.length > indexed.count) {
-    return true;
+    // Only files still inside the retention window can demand a backfill;
+    // expired (pruned) files must not.
+    const retainedFiles = files.filter((file) => {
+      try {
+        return isWithinRetention(getSessionFileMetadata(file).mtimeMs, retentionCutoffMs);
+      } catch {
+        return false;
+      }
+    });
+    if (retainedFiles.length > indexed.count) {
+      return true;
+    }
   }
 
   for (const file of files) {
     try {
       const metadata = getSessionFileMetadata(file);
+      if (!isWithinRetention(metadata.mtimeMs, retentionCutoffMs)) continue;
       if (storedSessionFileMatches(dbManager, metadata)) continue;
       return true;
     } catch {
@@ -511,8 +553,25 @@ export function getSessionStats(dbManager: DatabaseManager): {
 }
 
 /**
- * Delete sessions older than the given retention window, along with their
- * messages, to bound the growth of the session index database (see #183).
+ * Compute the retention cutoff (ms epoch) from a retention window in days.
+ * Returns 0 (no cutoff) when retention is undefined/zero/disabled.
+ */
+export function retentionCutoffMs(retentionDays: number | undefined): number {
+  if (!retentionDays || retentionDays <= 0) return 0;
+  return Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+}
+
+/**
+ * Delete sessions outside the retention window, along with their messages,
+ * to bound the growth of the session index database (see #183).
+ *
+ * A session is eligible for pruning when its session file's last-mod time is
+ * older than the window (falling back to started_at when no file metadata
+ * exists). This deliberately mirrors the backfill eligibility check in
+ * `needsBackfill`/`indexChangedSessions` (also keyed to file mtime), so a
+ * pruned session's on-disk JSONL file is never re-indexed by a later startup
+ * and never re-triggers a backfill. Retention and backfill therefore agree on
+ * the same eligible file set.
  *
  * `messages` and `session_files` reference `sessions`, but only `session_files`
  * is declared `ON DELETE CASCADE`. Orphaned `messages` rows are deleted
@@ -526,27 +585,41 @@ export function pruneOldSessions(
   retentionDays: number,
 ): { sessionsRemoved: number; messagesRemoved: number } {
   const db = dbManager.getDb();
-  const cutoffIso = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000).toISOString();
+  const cutoffMs = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+  const cutoffIso = new Date(cutoffMs).toISOString();
 
-  // Count what would be removed so we can report accurately even if a DELETE
-  // fails mid-way. Messages are counted upfront because SQLite does not
-  // surface cascade/orphan counts from DELETE ... RETURNING across tables.
-  const sessionCount = db.prepare(
-    'SELECT COUNT(*) as cnt FROM sessions WHERE started_at < ?',
-  ).get(cutoffIso) as { cnt: number };
-  if (sessionCount.cnt === 0) {
+  // A session is pruned when it falls outside the retention window. We use the
+  // same signal the backfill eligibility uses -- the session file's last-mod
+  // time -- so that a pruned session's on-disk JSONL file is not re-indexed on
+  // a later startup. Sessions without file metadata (e.g. indexed before files
+  // were tracked) fall back to started_at. Both must be strictly older than
+  // the cutoff.
+  const eligibleSessionIds = db.prepare(`
+    SELECT s.id
+    FROM sessions s
+    LEFT JOIN session_files sf ON sf.session_id = s.id
+    WHERE
+      (sf.path IS NOT NULL AND sf.mtime_ms < ?)
+      OR (sf.path IS NULL AND s.started_at < ?)
+  `).all(cutoffMs, cutoffIso) as Array<{ id: string }>;
+
+  if (eligibleSessionIds.length === 0) {
     return { sessionsRemoved: 0, messagesRemoved: 0 };
   }
 
+  // Count messages upfront because SQLite does not surface cascade/orphan
+  // counts from DELETE ... RETURNING across tables.
   const messageCount = db.prepare(
-    `SELECT COUNT(*) as cnt FROM messages WHERE session_id IN (SELECT id FROM sessions WHERE started_at < ?)`,
-  ).get(cutoffIso) as { cnt: number };
+    `SELECT COUNT(*) as cnt FROM messages WHERE session_id IN (${eligibleSessionIds.map(() => '?').join(',')})`,
+  ).get(...eligibleSessionIds.map((r) => r.id)) as { cnt: number };
 
   const prune = () => {
     const delMessages = db.prepare(
-      'DELETE FROM messages WHERE session_id IN (SELECT id FROM sessions WHERE started_at < ?)',
-    ).run(cutoffIso);
-    const delSessions = db.prepare('DELETE FROM sessions WHERE started_at < ?').run(cutoffIso);
+      `DELETE FROM messages WHERE session_id IN (${eligibleSessionIds.map(() => '?').join(',')})`,
+    ).run(...eligibleSessionIds.map((r) => r.id));
+    const delSessions = db.prepare(
+      `DELETE FROM sessions WHERE id IN (${eligibleSessionIds.map(() => '?').join(',')})`,
+    ).run(...eligibleSessionIds.map((r) => r.id));
     return { messagesRemoved: delMessages.changes, sessionsRemoved: delSessions.changes };
   };
 
@@ -554,7 +627,7 @@ export function pruneOldSessions(
   // Fall back to the pre-counted values if the transaction changed nothing
   // unexpectedly (defensive; DELETE should always affect the counted rows).
   return {
-    sessionsRemoved: result.sessionsRemoved || sessionCount.cnt,
+    sessionsRemoved: result.sessionsRemoved || eligibleSessionIds.length,
     messagesRemoved: result.messagesRemoved || messageCount.cnt,
   };
 }

--- a/src/store/session-search.ts
+++ b/src/store/session-search.ts
@@ -2,6 +2,7 @@ import { DatabaseManager } from './db.js';
 import {
   buildFallbackFts5Query,
   buildNaturalLanguageFallbackQuery,
+  collectLikeTerms,
   hasExplicitFts5Operator,
   isFts5QueryError,
   normalizeFts5Query,
@@ -38,28 +39,8 @@ type SearchMatch =
   | { type: 'fts'; query: string }
   | { type: 'like'; terms: string[] };
 
-const QUERY_TOKEN_PATTERN = /"([^"]*)"|(\S+)/g;
-const NATURAL_LANGUAGE_CONNECTORS = new Set(['and', 'or', 'not', 'near']);
-
 function escapeLikePattern(text: string): string {
   return text.replace(/[\\%_]/g, '\\$&');
-}
-
-function collectLikeTerms(query: string): string[] {
-  const terms: string[] = [];
-
-  for (const match of query.matchAll(QUERY_TOKEN_PATTERN)) {
-    const phrase = match[1];
-    const term = match[2];
-    if (phrase === undefined && term && NATURAL_LANGUAGE_CONNECTORS.has(term.toLowerCase())) {
-      continue;
-    }
-
-    const rawValue = phrase ?? term ?? '';
-    if (rawValue.length > 0) terms.push(rawValue);
-  }
-
-  return terms;
 }
 
 function mapRows(rows: Array<{
@@ -178,7 +159,12 @@ export function searchSessions(
 
   const normalizedQuery = normalizeFts5Query(query);
   if (normalizedQuery.length === 0) {
-    return [];
+    // Every term was a stop word or connector: nothing is left for FTS5 to
+    // match. Fall through to the scoped LIKE fallback instead of a hard [] so
+    // the query degrades to a literal substring search (the same fallback a
+    // normal query that matches nothing ends with).
+    const likeTerms = collectLikeTerms(query);
+    return executeSearch({ type: 'like', terms: likeTerms });
   }
 
   const exactResults = executeSearch({ type: 'fts', query: normalizedQuery });

--- a/src/store/sqlite-memory-store.ts
+++ b/src/store/sqlite-memory-store.ts
@@ -2,6 +2,7 @@ import { DatabaseManager } from './db.js';
 import {
   buildFallbackFts5Query,
   buildNaturalLanguageFallbackQuery,
+  collectLikeTerms,
   isFts5QueryError,
   normalizeFts5Query,
   normalizeNaturalLanguageFts5Query,
@@ -86,6 +87,15 @@ export interface MarkdownMemoryReconcileResult {
   inserted: number;
   existing: number;
   removed: number;
+  /**
+   * True when the scope was left un-reconciled because of a genuine FTS5
+   * search-index error. Markdown remains the source of truth and the write
+   * did not fail; search may be stale until /memory-sync-markdown rebuilds
+   * the index. Callers should surface that repair guidance to the user.
+   */
+  degraded?: boolean;
+  /** Human-readable reason for the degraded state, when degraded is true. */
+  degradedReason?: string;
 }
 
 export interface ParsedMarkdownMemoryEntry extends SqliteMemorySyncInput {}
@@ -508,10 +518,12 @@ export function reconcileMarkdownMemoryScope(
     if (isFts5QueryError(err)) {
       // A genuine FTS5 query/index error means the search index is stale or
       // broken, not that the database is corrupt. Markdown is the source of
-      // truth, so the write must not fail: warn the user and report a no-op
-      // sync. /memory-sync-markdown can rebuild the index afterwards.
-      console.warn(`[pi-hermes-memory] FTS5 search index error during markdown sync (search may be stale; run /memory-sync-markdown): ${err instanceof Error ? err.message : String(err)}`);
-      return { inserted: 0, existing: 0, removed: 0 };
+      // truth, so the write must not fail: warn in the log and report a
+      // DEGRADED result so the caller can surface the /memory-sync-markdown
+      // repair guidance to the user.
+      const detail = err instanceof Error ? err.message : String(err);
+      console.warn(`[pi-hermes-memory] FTS5 search index error during markdown sync (search may be stale; run /memory-sync-markdown): ${detail}`);
+      return { inserted: 0, existing: 0, removed: 0, degraded: true, degradedReason: detail };
     }
     throw err;
   }
@@ -555,6 +567,12 @@ export function reconcileMarkdownFailureScopes(
     total.inserted += result.inserted;
     total.existing += result.existing;
     total.removed += result.removed;
+    if (result.degraded) {
+      // Surface the first degraded scope: repair guidance applies to the whole
+      // sync run, and the first reason is the one to act on.
+      total.degraded = true;
+      total.degradedReason = result.degradedReason;
+    }
   }
 
   return total;
@@ -733,9 +751,6 @@ export function searchMemories(
 
   // FTS5 match via subquery with escaped query
   const normalizedQuery = normalizeFts5Query(query);
-  if (normalizedQuery.length === 0) {
-    return [];
-  }
 
   let ftsParseError = false;
 
@@ -843,6 +858,61 @@ export function searchMemories(
     }>;
     return rows.map(mapRow);
   };
+
+  // Every term a stop word or connector leaves FTS5 nothing to match.
+  // Degrade to a scoped literal substring search (OR over the raw terms) —
+  // the same fallback session search uses for this case — instead of a hard
+  // [].
+  const runLiteralLikeFallback = (): SqliteMemoryEntry[] => {
+    const terms = collectLikeTerms(query);
+    if (terms.length === 0) return [];
+
+    const conditions: string[] = [
+      `(${terms.map(() => "m.content LIKE ? ESCAPE '\\'").join(' OR ')})`,
+    ];
+    const params: unknown[] = terms.map((term) => `%${escapeLikePattern(term.trim())}%`);
+
+    if (project !== undefined) {
+      if (project === null) {
+        conditions.push('m.project IS NULL');
+      } else {
+        conditions.push('m.project = ?');
+        params.push(project);
+      }
+    }
+    if (target) {
+      conditions.push('m.target = ?');
+      params.push(target);
+    }
+    if (category) {
+      conditions.push('m.category = ?');
+      params.push(category);
+    }
+
+    const rows = db.prepare(`
+      SELECT ${MEMORY_SELECT_COLUMNS}
+      FROM memories m
+      WHERE ${conditions.join(' AND ')}
+      ORDER BY m.last_referenced DESC
+      LIMIT ?
+    `).all(...params, limit) as Array<{
+      id: number;
+      project: string | null;
+      target: string;
+      category: string | null;
+      content: string;
+      failure_reason: string | null;
+      tool_state: string | null;
+      corrected_to: string | null;
+      created: string;
+      last_referenced: string;
+    }>;
+    return rows.map(mapRow);
+  };
+
+  if (normalizedQuery.length === 0) {
+    return runLiteralLikeFallback();
+  }
 
   const exactResults = runSearch(normalizedQuery);
   if (exactResults.length > 0) {

--- a/src/store/sqlite-memory-store.ts
+++ b/src/store/sqlite-memory-store.ts
@@ -567,7 +567,7 @@ export function reconcileMarkdownFailureScopes(
     total.inserted += result.inserted;
     total.existing += result.existing;
     total.removed += result.removed;
-    if (result.degraded) {
+    if (result.degraded && !total.degraded) {
       // Surface the first degraded scope: repair guidance applies to the whole
       // sync run, and the first reason is the one to act on.
       total.degraded = true;

--- a/src/store/sqlite-memory-store.ts
+++ b/src/store/sqlite-memory-store.ts
@@ -9,6 +9,8 @@ import {
 import { normalizeMemoryLookupText } from './memory-lookup.js';
 import type { MemoryCategory } from '../types.js';
 
+export { isFts5QueryError };
+
 const MEMORY_SELECT_COLUMNS = `
   id,
   project,
@@ -438,12 +440,17 @@ export function reconcileMarkdownMemoryScope(
   target: 'memory' | 'user' | 'failure',
   project: string | null = null,
 ): MarkdownMemoryReconcileResult {
-  const db = dbManager.getDb();
   const normalizedProject = normalizeNullable(project);
 
+  // The full reconcile runs against the CURRENT database handle. It must fetch
+  // it via dbManager.getDb() rather than a pre-fetched handle: after corruption
+  // recovery quarantines the old file and rebuilds a fresh one, the retry has
+  // to run on the new handle.
   const reconcile = (): MarkdownMemoryReconcileResult => {
+    const db = dbManager.getDb();
     let inserted = 0;
     let existing = 0;
+    let removed = 0;
     const desiredIdentities = new Set<string>();
 
     for (const rawEntry of rawEntries) {
@@ -476,7 +483,6 @@ export function reconcileMarkdownMemoryScope(
       }
     }
 
-    let removed = 0;
     if (orphanIds.length > 0) {
       const placeholders = orphanIds.map(() => '?').join(', ');
       removed = db.prepare(`DELETE FROM memories WHERE id IN (${placeholders})`).run(...orphanIds).changes;
@@ -485,15 +491,26 @@ export function reconcileMarkdownMemoryScope(
     return { inserted, existing, removed };
   };
 
-  const transactional = db.transaction?.(reconcile);
-  try {
+  const run = (): MarkdownMemoryReconcileResult => {
+    const db = dbManager.getDb();
+    const transactional = db.transaction?.(reconcile);
     return transactional ? transactional() : reconcile();
+  };
+
+  try {
+    // Corruption errors (e.g. "database disk image is malformed") are NOT
+    // search-index problems: they must stay on the recovery path so
+    // DatabaseManager quarantines the corrupt file, rebuilds a fresh one, and
+    // retries this sync (#186). Swallowing them would hide corruption and
+    // leave a corrupt database in place.
+    return dbManager.withCorruptionRecovery(run);
   } catch (err) {
     if (isFts5QueryError(err)) {
-      // A broken FTS5 index must not fail the memory write itself. Persist the
-      // markdown entry and report a graceful no-op for the search sync so the
-      // user is not blocked or alarmed; a later /memory-sync-markdown can
-      // rebuild the search index.
+      // A genuine FTS5 query/index error means the search index is stale or
+      // broken, not that the database is corrupt. Markdown is the source of
+      // truth, so the write must not fail: warn the user and report a no-op
+      // sync. /memory-sync-markdown can rebuild the index afterwards.
+      console.warn(`[pi-hermes-memory] FTS5 search index error during markdown sync (search may be stale; run /memory-sync-markdown): ${err instanceof Error ? err.message : String(err)}`);
       return { inserted: 0, existing: 0, removed: 0 };
     }
     throw err;

--- a/src/store/sqlite-memory-store.ts
+++ b/src/store/sqlite-memory-store.ts
@@ -486,7 +486,18 @@ export function reconcileMarkdownMemoryScope(
   };
 
   const transactional = db.transaction?.(reconcile);
-  return transactional ? transactional() : reconcile();
+  try {
+    return transactional ? transactional() : reconcile();
+  } catch (err) {
+    if (isFts5QueryError(err)) {
+      // A broken FTS5 index must not fail the memory write itself. Persist the
+      // markdown entry and report a graceful no-op for the search sync so the
+      // user is not blocked or alarmed; a later /memory-sync-markdown can
+      // rebuild the search index.
+      return { inserted: 0, existing: 0, removed: 0 };
+    }
+    throw err;
+  }
 }
 
 function failureProject(rawEntry: string): string | null {

--- a/src/tools/memory-tool.ts
+++ b/src/tools/memory-tool.ts
@@ -239,24 +239,34 @@ async function reconcileStoreScope(
   if (!dbManager) return undefined;
   try {
     if (rawTarget === "failure") {
-      reconcileMarkdownFailureScopes(dbManager, entries);
-      return null;
+      return degradedRepairMessage(reconcileMarkdownFailureScopes(dbManager, entries));
     }
     const target = sqliteTargetFor(rawTarget);
-    reconcileMarkdownMemoryScope(
-      dbManager,
-      entries,
-      target,
-      sqliteProjectFor(rawTarget, projectName) ?? null,
+    return degradedRepairMessage(
+      reconcileMarkdownMemoryScope(
+        dbManager,
+        entries,
+        target,
+        sqliteProjectFor(rawTarget, projectName) ?? null,
+      ),
     );
-    return null;
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
     if (isFts5QueryError(err)) {
-      return `Saved to Markdown. Search may be temporarily unavailable (FTS5 index error: ${detail}). Run /memory-sync-markdown to rebuild the search index.`;
+      return degradedRepairMessage({ degraded: true, degradedReason: detail });
     }
     return `Saved to Markdown, but SQLite search reconciliation failed: ${detail}`;
   }
+}
+
+// A degraded reconcile result means the Markdown write succeeded but the
+// SQLite search mirror could not be updated (genuine FTS5 index error). The
+// caller must tell the user how to repair the index instead of looking like a
+// plain success.
+function degradedRepairMessage(result: { degraded?: boolean; degradedReason?: string }): string | null {
+  return result.degraded
+    ? `Saved to Markdown. Search may be temporarily unavailable (FTS5 index error: ${result.degradedReason}). Run /memory-sync-markdown to rebuild the search index.`
+    : null;
 }
 
 type MemoryAction = "add" | "replace" | "remove";

--- a/src/tools/memory-tool.ts
+++ b/src/tools/memory-tool.ts
@@ -250,7 +250,12 @@ async function reconcileStoreScope(
     );
     return null;
   } catch (err) {
-    return `Saved to Markdown, but SQLite search reconciliation failed: ${err instanceof Error ? err.message : String(err)}`;
+    const detail = err instanceof Error ? err.message : String(err);
+    const msg = detail.toLowerCase();
+    if (msg.includes('fts5') || msg.includes('malformed') || msg.includes('sql logic error') || msg.includes('unterminated')) {
+      return `Saved to Markdown. Search may be temporarily unavailable (FTS5 error); try /memory-sync-markdown to re-index.`;
+    }
+    return `Saved to Markdown, but SQLite search reconciliation failed: ${detail}`;
   }
 }
 

--- a/src/tools/memory-tool.ts
+++ b/src/tools/memory-tool.ts
@@ -17,6 +17,7 @@ import {
   removeSyncedMemories,
   replaceSyncedMemories,
   syncMemoryEntry,
+  isFts5QueryError,
 } from "../store/sqlite-memory-store.js";
 import { MEMORY_TOOL_DESCRIPTION } from "../constants.js";
 import { resolveProjectName, resolveProjectStore, type ProjectNameRef, type ProjectStoreRef } from "../project-context.js";
@@ -251,9 +252,8 @@ async function reconcileStoreScope(
     return null;
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
-    const msg = detail.toLowerCase();
-    if (msg.includes('fts5') || msg.includes('malformed') || msg.includes('sql logic error') || msg.includes('unterminated')) {
-      return `Saved to Markdown. Search may be temporarily unavailable (FTS5 error); try /memory-sync-markdown to re-index.`;
+    if (isFts5QueryError(err)) {
+      return `Saved to Markdown. Search may be temporarily unavailable (FTS5 index error: ${detail}). Run /memory-sync-markdown to rebuild the search index.`;
     }
     return `Saved to Markdown, but SQLite search reconciliation failed: ${detail}`;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,8 @@ export interface MemoryConfig {
   autoConsolidationWarnOnFailure: boolean;
   /** Inject pinned STANDING.md instructions into every session. Default: true */
   standingInstructionsEnabled: boolean;
+  /** Keep sessions from the last N days; older sessions are pruned on startup. Default: 180 */
+  sessionRetentionDays?: number;
 }
 
 export type MemoryCategory =

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,7 +88,12 @@ export interface MemoryConfig {
   autoConsolidationWarnOnFailure: boolean;
   /** Inject pinned STANDING.md instructions into every session. Default: true */
   standingInstructionsEnabled: boolean;
-  /** Keep sessions from the last N days; older sessions are pruned on startup. Default: 180 */
+  /**
+   * Session retention window in days. A positive value opts in to pruning
+   * sessions (and their messages) older than the window on startup; `0`/omitted
+   * disables pruning so no existing searchable history is silently deleted.
+   * Default: 0 (disabled).
+   */
   sessionRetentionDays?: number;
 }
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -41,6 +41,9 @@ describe("loadConfig", () => {
     assert.strictEqual(config.llmModelOverride, undefined);
     assert.strictEqual(config.llmThinkingOverride, undefined);
     assert.strictEqual(config.standingInstructionsEnabled, true);
+    // Retention is disabled by default so existing history is never silently
+    // deleted; a positive value opts in, 0/omitted disables.
+    assert.strictEqual(config.sessionRetentionDays, 0);
   });
 
   it("honors a configured consolidationTimeoutMs, warning only when it is below the default", () => {
@@ -104,6 +107,24 @@ describe("loadConfig", () => {
     // Unset values use defaults
     assert.strictEqual(config.userCharLimit, 5000);
     assert.strictEqual(config.reviewEnabled, true);
+  });
+
+  it("parses sessionRetentionDays as opt-in, accepting explicit 0 to disable", () => {
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+
+    // Positive value opts in to retention pruning.
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({ sessionRetentionDays: 45 }));
+    assert.strictEqual(loadConfig(TEST_CONFIG_PATH).sessionRetentionDays, 45);
+
+    // Explicit 0 disables retention (even after a prior positive value).
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({ sessionRetentionDays: 0 }));
+    assert.strictEqual(loadConfig(TEST_CONFIG_PATH).sessionRetentionDays, 0);
+
+    // Negative / non-numeric values are ignored, keeping the (disabled) default.
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({ sessionRetentionDays: -5 }));
+    assert.strictEqual(loadConfig(TEST_CONFIG_PATH).sessionRetentionDays, 0);
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({ sessionRetentionDays: "30" }));
+    assert.strictEqual(loadConfig(TEST_CONFIG_PATH).sessionRetentionDays, 0);
   });
 
   it("handles partial config (missing keys use defaults)", () => {

--- a/tests/handlers/session-backfill.test.ts
+++ b/tests/handlers/session-backfill.test.ts
@@ -189,4 +189,43 @@ describe('session backfill handler', () => {
 
     assert.equal(completed, false);
   });
+
+  it('propagates the retention cutoff to the backfill file set', async () => {
+    // Only an expired file exists (mtime older than the 30-day cutoff). Even
+    // with recent backfill timestamps, the backfill must not be scheduled
+    // because the file is outside the retained window.
+    writeJsonlSession(sessionsDir, 'project-a', 'old');
+    const oldFile = path.join(sessionsDir, 'project-a', 'old.jsonl');
+    const cutoffMs = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    const oldMtime = cutoffMs - 1000;
+    fs.utimesSync(oldFile, new Date(oldMtime), new Date(oldMtime));
+
+    touchBackfillTimestamp(dbManager);
+
+    let receivedCutoff: number | undefined;
+    let indexOptions: { retentionCutoffMs?: number } | undefined;
+    const state: SessionBackfillState = { inProgress: false, promise: null };
+
+    const scheduled = scheduleSessionBackfill(dbManager, sessionsDir, {
+      state,
+      retentionCutoffMs: cutoffMs,
+      setTimeoutFn: () => 0,
+      // Capture the cutoff that would be forwarded to the store so we prove
+      // the wiring reaches both the eligibility check and the indexer.
+      needsBackfillFn: (_db, _dir, _now, cutoff) => {
+        receivedCutoff = cutoff;
+        return false;
+      },
+      indexSessionsFn: (_db, _dir, options) => {
+        indexOptions = options;
+        return { sessionsProcessed: 0, sessionsIndexed: 0, sessionsSkipped: 0, messagesIndexed: 0, reachedLimit: undefined, errors: [] };
+      },
+    });
+
+    // needsBackfill ran and received the cutoff; because it returned false for
+    // an expired file set, no backfill pass was scheduled.
+    assert.equal(scheduled, false);
+    assert.equal(receivedCutoff, cutoffMs);
+    assert.equal(indexOptions, undefined);
+  });
 });

--- a/tests/integration/corruption-recovery-integration.test.ts
+++ b/tests/integration/corruption-recovery-integration.test.ts
@@ -8,16 +8,24 @@ import { isFts5QueryError } from '../../src/store/fts-query.js';
 import { reconcileMarkdownMemoryScope } from '../../src/store/sqlite-memory-store.js';
 
 /**
- * Reviewer request for PR #184: prove that restricting isFts5QueryError to
- * genuine FTS query/index errors does NOT break database corruption recovery.
+ * Behavior change under test (PR #184): reconcileMarkdownMemoryScope now
+ * runs its persistence inside DatabaseManager.withCorruptionRecovery().
+ * Before this change, corruption errors ("database disk image is malformed",
+ * SQLITE_CORRUPT, SQLITE_NOTADB) thrown during markdown reconciliation
+ * surfaced as raw failures on every memory write — corruption recovery was
+ * only wired into the session-indexing paths, so a corrupt sessions.db kept
+ * failing markdown syncs until repaired by hand. Now the markdown reconcile
+ * path participates in the same recovery: the corrupt database is
+ * quarantined, rebuilt, and the reconcile is retried on a fresh handle, so
+ * the memory entry is persisted instead of lost.
  *
- * Before the fix, "database disk image is malformed" and "SQL logic error"
- * were classified as FTS errors and swallowed by reconcileMarkdownMemoryScope
- * as a zero-count success after the transaction rolled back — hiding a corrupt
- * database and preventing quarantine/rebuild.
+ * The FTS5 soft fallback stays narrow: only genuine FTS query/index errors
+ * (isFts5QueryError) degrade to a warned, repair-guided result. Corruption
+ * signals never match that classifier, so they can never be swallowed into a
+ * zero-count success here.
  */
 describe('Corruption recovery during markdown sync', () => {
-  it('narrowed classifier does not treat corruption signals as FTS errors', () => {
+  it('keeps corruption signals out of the FTS5 fallback classifier', () => {
     // Corruption/recovery signals must propagate so DatabaseManager can
     // quarantine + rebuild, not be swallowed by the search-index fallback.
     assert.equal(isFts5QueryError(new Error('database disk image is malformed')), false);
@@ -28,7 +36,7 @@ describe('Corruption recovery during markdown sync', () => {
     assert.equal(isFts5QueryError(new Error('fts5: unterminated string')), true);
   });
 
-  it('quarantines a corrupt DB, rebuilds, and persists the entry (no swallowed success)', async () => {
+  it('withCorruptionRecovery quarantines a corrupt DB, rebuilds, and persists the entry', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-corruption-'));
     const dbManager = new DatabaseManager(tmpDir);
     const dbFile = path.join(tmpDir, 'sessions.db');

--- a/tests/integration/corruption-recovery-integration.test.ts
+++ b/tests/integration/corruption-recovery-integration.test.ts
@@ -1,0 +1,83 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { DatabaseManager } from '../../src/store/db.js';
+import { isFts5QueryError } from '../../src/store/fts-query.js';
+import { reconcileMarkdownMemoryScope } from '../../src/store/sqlite-memory-store.js';
+
+/**
+ * Reviewer request for PR #184: prove that restricting isFts5QueryError to
+ * genuine FTS query/index errors does NOT break database corruption recovery.
+ *
+ * Before the fix, "database disk image is malformed" and "SQL logic error"
+ * were classified as FTS errors and swallowed by reconcileMarkdownMemoryScope
+ * as a zero-count success after the transaction rolled back — hiding a corrupt
+ * database and preventing quarantine/rebuild.
+ */
+describe('Corruption recovery during markdown sync', () => {
+  it('narrowed classifier does not treat corruption signals as FTS errors', () => {
+    // Corruption/recovery signals must propagate so DatabaseManager can
+    // quarantine + rebuild, not be swallowed by the search-index fallback.
+    assert.equal(isFts5QueryError(new Error('database disk image is malformed')), false);
+    assert.equal(isFts5QueryError(new Error('SQL logic error')), false);
+    assert.equal(isFts5QueryError(new Error('file is not a database')), false);
+    // Genuine FTS5 query/index errors remain recoverable search-path failures.
+    assert.equal(isFts5QueryError(new Error('fts5: syntax error near "AND"')), true);
+    assert.equal(isFts5QueryError(new Error('fts5: unterminated string')), true);
+  });
+
+  it('quarantines a corrupt DB, rebuilds, and persists the entry (no swallowed success)', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-corruption-'));
+    const dbManager = new DatabaseManager(tmpDir);
+    const dbFile = path.join(tmpDir, 'sessions.db');
+
+    try {
+      // 1. Prime a healthy database with one memory.
+      const first = reconcileMarkdownMemoryScope(dbManager, ['first healthy entry'], 'memory', null);
+      assert.equal(first.inserted, 1);
+      await dbManager.waitForStartupIntegrityScan();
+
+      // 2. Close the handle and corrupt the DB file on disk.
+      dbManager.close();
+      fs.writeFileSync(dbFile, 'GARBAGE-NOT-A-SQLITE-DB'.repeat(32), 'utf-8');
+      assert.equal(isFts5QueryError(new Error('file is not a database')), false);
+
+      // 3. Reconcile a second entry. The corrupt file must be detected,
+      // quarantined, and a fresh database rebuilt — and the entry persisted
+      // on the healthy database instead of being swallowed as a zero-count
+      // "successful" reconcile.
+      const second = reconcileMarkdownMemoryScope(dbManager, ['second entry after corruption'], 'memory', null);
+
+      // 4. Recovery must have run (not a no-op reuse of the corrupt file).
+      const recovery = dbManager.getLastRecovery();
+      assert.ok(recovery, 'expected a corruption recovery to be recorded');
+      assert.notEqual(recovery.strategy, 'reused', 'the corrupt file must not have been reused');
+      assert.ok(recovery.backupPaths.length >= 1, 'the corrupt file must have been quarantined to a backup');
+      for (const backup of recovery.backupPaths) {
+        assert.ok(fs.existsSync(backup), `quarantined backup missing: ${backup}`);
+      }
+
+      // 5. The entry must actually be persisted in the rebuilt database —
+      // a swallowed zero-count success would leave the memory in markdown only.
+      assert.ok(second.inserted >= 1, `expected the entry to persist after recovery, got ${JSON.stringify(second)}`);
+      const rows = dbManager.getDb()
+        .prepare('SELECT content FROM memories WHERE target = ? ORDER BY id ASC')
+        .all('memory') as Array<{ content: string }>;
+      assert.ok(
+        rows.some((row) => row.content.includes('second entry after corruption')),
+        'the second entry must be present in the rebuilt database',
+      );
+
+      // 6. The original path must now hold a fresh, healthy database.
+      const header = fs.readFileSync(dbFile).subarray(0, 16).toString('utf-8');
+      assert.equal(header, 'SQLite format 3\x00', 'a fresh SQLite database must exist at the original path');
+    } finally {
+      try { dbManager.close(); } catch { /* best effort */ }
+      // Best-effort: on Windows the shared AtomicLockCoordinator keeps
+      // .pi-hermes-locks.sqlite open, so the directory may not be removable.
+      try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* OS cleans temp eventually */ }
+    }
+  });
+});

--- a/tests/store/fts-query.test.ts
+++ b/tests/store/fts-query.test.ts
@@ -72,8 +72,19 @@ describe('fts-query', () => {
 
   describe('natural language recovery', () => {
     it('normalizes uppercase operator words as natural language', () => {
-      const q = normalizeNaturalLanguageFts5Query('DO NOT USE FIND');
-      assert.ok(q.includes('"DO"') || !q.includes('OR ') || true); // only meaningful terms survive
+      // 'DO' is a stop word and 'NOT' a natural-language connector, so only
+      // the two meaningful terms survive, quoted for implicit AND matching.
+      assert.strictEqual(normalizeNaturalLanguageFts5Query('DO NOT USE FIND'), '"USE" "FIND"');
+    });
+
+    it('keeps intent-bearing words out of the stop list (can/need/off/like/get)', () => {
+      // These words frequently carry the actual search intent ("can the app
+      // start", "need to restart", "like this", "get the build passing"), so
+      // they must survive normalization rather than be silently dropped.
+      assert.strictEqual(
+        normalizeFts5Query('can need off like get'),
+        '"can" "need" "off" "like" "get"',
+      );
     });
 
     it('builds a natural language OR fallback ignoring operator detection', () => {

--- a/tests/store/fts-query.test.ts
+++ b/tests/store/fts-query.test.ts
@@ -1,0 +1,98 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  normalizeFts5Query,
+  buildFallbackFts5Query,
+  hasExplicitFts5Operator,
+  normalizeNaturalLanguageFts5Query,
+  buildNaturalLanguageFallbackQuery,
+  isFts5QueryError,
+} from '../../src/store/fts-query.js';
+
+describe('fts-query', () => {
+  describe('stop word filtering', () => {
+    it('filters filler words but keeps meaningful terms', () => {
+      const q = normalizeFts5Query('how to fix the authentication bug');
+      assert.ok(q.includes('"authentication"'), 'keeps meaningful term');
+      assert.ok(q.includes('"bug"'), 'keeps meaningful term');
+      assert.ok(!q.includes('"how"'), 'filters "how"');
+      assert.ok(!q.includes('"to"'), 'filters "to"');
+      assert.ok(!q.includes('"the"'), 'filters "the"');
+    });
+
+    it('returns empty string when every term is a stop word', () => {
+      assert.strictEqual(normalizeFts5Query('the a is was were'), '');
+      assert.strictEqual(normalizeFts5Query('for in on'), '');
+    });
+
+    it('keeps quoted phrases intact even when they contain stop words', () => {
+      const q = normalizeNaturalLanguageFts5Query('"the quick brown fox" jumps');
+      assert.ok(q.includes('"the quick brown fox"'));
+      assert.ok(q.includes('"jumps"'));
+    });
+
+    it('normalizes case-insensitively against the stop word list', () => {
+      const q = normalizeFts5Query('The QUICK brown Fox');
+      assert.ok(q.includes('"QUICK"'));
+      assert.ok(q.includes('"Fox"'));
+      assert.ok(!q.includes('"The"'));
+    });
+  });
+
+  describe('fallback queries', () => {
+    it('builds an OR fallback for multi-term natural language queries', () => {
+      const fb = buildFallbackFts5Query('authentication bug fix');
+      assert.ok(fb);
+      assert.ok(fb.includes('OR'));
+      assert.ok(fb.includes('"authentication"'));
+      assert.ok(fb.includes('"bug"'));
+    });
+
+    it('returns null when there are not enough meaningful terms', () => {
+      assert.strictEqual(buildFallbackFts5Query('auth'), null);
+      assert.strictEqual(buildFallbackFts5Query('the a'), null);
+    });
+
+    it('returns null for explicit operator queries', () => {
+      assert.strictEqual(buildFallbackFts5Query('auth OR database'), null);
+    });
+  });
+
+  describe('operator handling', () => {
+    it('detects explicit FTS5 operators', () => {
+      assert.ok(hasExplicitFts5Operator('auth OR database'));
+      assert.ok(hasExplicitFts5Operator('"auth bug" AND database'));
+      assert.ok(!hasExplicitFts5Operator('auth database'));
+    });
+
+    it('preserves explicit operator queries verbatim in normalizeFts5Query', () => {
+      assert.strictEqual(normalizeFts5Query('auth OR database'), 'auth OR database');
+    });
+  });
+
+  describe('natural language recovery', () => {
+    it('normalizes uppercase operator words as natural language', () => {
+      const q = normalizeNaturalLanguageFts5Query('DO NOT USE FIND');
+      assert.ok(q.includes('"DO"') || !q.includes('OR ') || true); // only meaningful terms survive
+    });
+
+    it('builds a natural language OR fallback ignoring operator detection', () => {
+      const fb = buildNaturalLanguageFallbackQuery('DO NOT USE FIND');
+      assert.ok(fb && fb.includes('OR'));
+    });
+  });
+
+  describe('isFts5QueryError', () => {
+    it('detects FTS5 and related SQLite failure messages', () => {
+      assert.ok(isFts5QueryError(new Error('fts5: syntax error near "AND"')), 'fts5');
+      assert.ok(isFts5QueryError(new Error('fts5: unterminated string')), 'unterminated string');
+      assert.ok(isFts5QueryError(new Error('database disk image is malformed')), 'malformed');
+      assert.ok(isFts5QueryError(new Error('SQL logic error')), 'sql logic error');
+    });
+
+    it('rejects unrelated errors', () => {
+      assert.ok(!isFts5QueryError(new Error('disk full')));
+      assert.ok(!isFts5QueryError('string, not an Error'));
+    });
+  });
+});

--- a/tests/store/fts-query.test.ts
+++ b/tests/store/fts-query.test.ts
@@ -83,11 +83,18 @@ describe('fts-query', () => {
   });
 
   describe('isFts5QueryError', () => {
-    it('detects FTS5 and related SQLite failure messages', () => {
+    it('detects genuine FTS5 query/index failure messages', () => {
       assert.ok(isFts5QueryError(new Error('fts5: syntax error near "AND"')), 'fts5');
       assert.ok(isFts5QueryError(new Error('fts5: unterminated string')), 'unterminated string');
-      assert.ok(isFts5QueryError(new Error('database disk image is malformed')), 'malformed');
-      assert.ok(isFts5QueryError(new Error('SQL logic error')), 'sql logic error');
+      assert.ok(isFts5QueryError(new Error('unterminated string constant in FTS5 query')), 'unterminated string constant');
+    });
+
+    it('rejects corruption signals so DatabaseManager recovery still runs (#186)', () => {
+      // These are corruption/recovery signals, NOT recoverable FTS query errors.
+      // Swallowing them would suppress quarantine/rebuild of a corrupt database.
+      assert.ok(!isFts5QueryError(new Error('database disk image is malformed')), 'malformed is corruption, not FTS');
+      assert.ok(!isFts5QueryError(new Error('SQL logic error')), 'sql logic error is too broad to swallow');
+      assert.ok(!isFts5QueryError(new Error('file is not a database')), 'notadb is corruption, not FTS');
     });
 
     it('rejects unrelated errors', () => {

--- a/tests/store/session-indexer.test.ts
+++ b/tests/store/session-indexer.test.ts
@@ -603,6 +603,91 @@ describe('session-indexer', () => {
     });
   });
 
+  describe('retention and backfill alignment', () => {
+    /** Write a session JSONL file and force its mtime to `ms` (ms epoch). */
+    function writeJsonlSessionAt(sessionsDir: string, sessionId: string, ms: number): string {
+      const filePath = path.join(sessionsDir, 'project-a', `${sessionId}.jsonl`);
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      const lines = [
+        JSON.stringify({ type: 'session', id: sessionId, timestamp: new Date(ms).toISOString(), cwd: `/test/${sessionId}` }),
+        JSON.stringify({ type: 'message', id: `${sessionId}-m1`, parentId: null, timestamp: new Date(ms + 1000).toISOString(), message: { role: 'user', content: [{ type: 'text', text: `Hello ${sessionId}` }], timestamp: Date.now() } }),
+      ];
+      fs.writeFileSync(filePath, lines.join('\n'));
+      fs.utimesSync(filePath, new Date(ms), new Date(ms));
+      return filePath;
+    }
+
+    const DAY = 24 * 60 * 60 * 1000;
+    const now = () => Date.now();
+    const cutoffFor = (days: number) => now() - days * DAY;
+
+    it('does not re-index a session file outside the retention cutoff after pruning', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      // A file last modified 60 days ago; retention window of 30 days => expired.
+      writeJsonlSessionAt(sessionsDir, 's1', cutoffFor(60));
+      const cutoff = cutoffFor(30);
+
+      // Fresh index (no cutoff) mirrors the pre-retention state, then retention
+      // pruning removes the session row; the on-disk file stays.
+      indexAllSessions(dbManager, sessionsDir);
+      const pruned = pruneOldSessions(dbManager, 30);
+      assert.strictEqual(pruned.sessionsRemoved, 1);
+      assert.strictEqual(dbManager.getStats().sessions, 0);
+
+      // A later startup backfill, given the same retention cutoff, must NOT
+      // re-queue the expired file -- otherwise the pruned session returns.
+      const result = indexChangedSessions(dbManager, sessionsDir, { retentionCutoffMs: cutoff });
+      assert.strictEqual(result.sessionsProcessed, 0);
+      assert.strictEqual(result.sessionsIndexed, 0);
+      assert.strictEqual(result.sessionsSkipped, 0);
+      assert.strictEqual(dbManager.getStats().sessions, 0);
+    });
+
+    it('does not schedule a startup backfill when only expired files remain', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      writeJsonlSessionAt(sessionsDir, 's1', cutoffFor(60));
+      const cutoff = cutoffFor(30);
+      indexAllSessions(dbManager, sessionsDir);
+      pruneOldSessions(dbManager, 30);
+      touchBackfillTimestamp(dbManager);
+
+      // With every file outside the window, needsBackfill must be false so no
+      // backfill is scheduled on the next startup (no repeated re-indexing).
+      assert.strictEqual(needsBackfill(dbManager, sessionsDir, new Date(), cutoff), false);
+    });
+
+    it('still indexes files within the retention cutoff even when others are expired', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      writeJsonlSessionAt(sessionsDir, 'old', cutoffFor(60));
+      writeJsonlSessionAt(sessionsDir, 'fresh', now());
+      const cutoff = cutoffFor(30);
+
+      const result = indexChangedSessions(dbManager, sessionsDir, { retentionCutoffMs: cutoff });
+      // Only the fresh file is eligible; the expired one is skipped.
+      assert.strictEqual(result.sessionsProcessed, 1);
+      assert.strictEqual(result.sessionsIndexed, 1);
+      const stats = getSessionStats(dbManager);
+      assert.deepStrictEqual(stats.projects[0].sessions, 1); // only the retained session
+      assert.strictEqual(needsBackfill(dbManager, sessionsDir, new Date(), cutoff), true);
+    });
+
+    it('prunes only sessions whose file mtime is outside the retention window', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      writeJsonlSessionAt(sessionsDir, 'old', cutoffFor(60));
+      writeJsonlSessionAt(sessionsDir, 'recent', now());
+      indexAllSessions(dbManager, sessionsDir);
+
+      const pruned = pruneOldSessions(dbManager, 30);
+      // 'old' has an expired file mtime and is pruned; 'recent' has a fresh
+      // file mtime and is kept, even though both were indexed.
+      assert.strictEqual(pruned.sessionsRemoved, 1);
+      const stats = getSessionStats(dbManager);
+      assert.strictEqual(stats.totalSessions, 1);
+      const remaining = dbManager.getDb().prepare('SELECT id FROM sessions').all() as { id: string }[];
+      assert.deepStrictEqual(remaining.map((r) => r.id), ['recent']);
+    });
+  });
+
   describe('pruneOldSessions', () => {
     it('removes nothing when the database is empty', () => {
       const result = pruneOldSessions(dbManager, 30);

--- a/tests/store/session-indexer.test.ts
+++ b/tests/store/session-indexer.test.ts
@@ -566,6 +566,54 @@ describe('session-indexer', () => {
       assert.strictEqual(needsBackfill(dbManager, sessionsDir, new Date('2026-05-03T01:00:00Z')), true);
     });
 
+    it('needsBackfill returns no work when retention is enabled and every file is expired, even without a backfill timestamp', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      writeJsonlSession(sessionsDir, 'project-a', 's1');
+      const filePath = path.join(sessionsDir, 'project-a', 's1.jsonl');
+
+      // Age the file beyond the retention window.
+      const old = new Date('2026-01-01T00:00:00Z');
+      fs.utimesSync(filePath, old, old);
+
+      const now = new Date('2026-05-03T01:00:00Z');
+      const cutoff = Date.parse('2026-03-01T00:00:00Z');
+      assert.ok(old.getTime() < cutoff, 'sanity: the file must be outside the window');
+
+      // Fresh DB: no indexed rows and no backfill timestamp, so the periodic
+      // timestamp check alone would demand a backfill. With retention enabled
+      // and no retained files, there is no work to do — this must return
+      // false instead of scheduling an empty backfill on every startup.
+      assert.strictEqual(needsBackfill(dbManager, sessionsDir, now, cutoff), false);
+    });
+
+    it('needsBackfill still schedules when a retained file exists without a backfill timestamp', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      writeJsonlSession(sessionsDir, 'project-a', 's1');
+      const filePath = path.join(sessionsDir, 'project-a', 's1.jsonl');
+
+      // File stays inside the retention window.
+      const recent = new Date('2026-04-15T00:00:00Z');
+      fs.utimesSync(filePath, recent, recent);
+
+      const now = new Date('2026-05-03T01:00:00Z');
+      const cutoff = Date.parse('2026-03-01T00:00:00Z');
+      assert.ok(recent.getTime() >= cutoff, 'sanity: the file must be inside the window');
+
+      assert.strictEqual(needsBackfill(dbManager, sessionsDir, now, cutoff), true);
+    });
+
+    it('needsBackfill keeps the periodic check active when retention is disabled', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      writeJsonlSession(sessionsDir, 'project-a', 's1');
+      const filePath = path.join(sessionsDir, 'project-a', 's1.jsonl');
+
+      // An old file is still eligible when retention is disabled (cutoff 0).
+      const old = new Date('2026-01-01T00:00:00Z');
+      fs.utimesSync(filePath, old, old);
+
+      assert.strictEqual(needsBackfill(dbManager, sessionsDir, new Date('2026-05-03T01:00:00Z')), true);
+    });
+
     it('touchBackfillTimestamp upserts the metadata row', () => {
       touchBackfillTimestamp(dbManager, new Date('2026-05-03T00:00:00Z'));
       touchBackfillTimestamp(dbManager, new Date('2026-05-03T01:00:00Z'));

--- a/tests/store/session-indexer.test.ts
+++ b/tests/store/session-indexer.test.ts
@@ -19,6 +19,7 @@ import {
   truncateMessageContent,
   upsertSessionFileMetadata,
   pruneEphemeralReviewSessions,
+  pruneOldSessions,
 } from '../../src/store/session-indexer.js';
 import { DEFAULT_MAX_MESSAGE_CONTENT_LENGTH } from '../../src/constants.js';
 import { parseSessionFile, type ParsedSession } from '../../src/store/session-parser.js';
@@ -599,6 +600,46 @@ describe('session-indexer', () => {
       assert.strictEqual(result.sessionsProcessed, 0);
       assert.strictEqual(result.sessionsSkipped, 1);
       assert.strictEqual(result.reachedLimit, undefined);
+    });
+  });
+
+  describe('pruneOldSessions', () => {
+    it('removes nothing when the database is empty', () => {
+      const result = pruneOldSessions(dbManager, 30);
+      assert.deepStrictEqual(result, { sessionsRemoved: 0, messagesRemoved: 0 });
+    });
+
+    it('removes sessions older than the retention window and their messages', () => {
+      indexSession(dbManager, createTestSession({ id: 'old', startedAt: '2020-01-01T00:00:00Z' }));
+      indexSession(dbManager, createTestSession({ id: 'recent', startedAt: new Date().toISOString() }));
+
+      const result = pruneOldSessions(dbManager, 30);
+      assert.strictEqual(result.sessionsRemoved, 1);
+      assert.strictEqual(result.messagesRemoved, 2); // old session has 2 messages
+
+      const stats = getSessionStats(dbManager);
+      assert.strictEqual(stats.totalSessions, 1);
+      assert.strictEqual(stats.totalMessages, 2);
+      const remaining = dbManager.getDb().prepare('SELECT id FROM sessions').all() as { id: string }[];
+      assert.deepStrictEqual(remaining.map((r) => r.id), ['recent']);
+    });
+
+    it('leaves sessions exactly at the retention boundary (not strictly older) untouched', () => {
+      const now = Date.now();
+      const justWithin = new Date(now - 10 * 24 * 60 * 60 * 1000).toISOString(); // 10 days ago
+      indexSession(dbManager, createTestSession({ id: 'within', startedAt: justWithin }));
+
+      const result = pruneOldSessions(dbManager, 30);
+      assert.strictEqual(result.sessionsRemoved, 0);
+      assert.strictEqual(dbManager.getStats().sessions, 1);
+    });
+
+    it('is idempotent across repeated calls', () => {
+      indexSession(dbManager, createTestSession({ id: 'old', startedAt: '2020-01-01T00:00:00Z' }));
+
+      pruneOldSessions(dbManager, 30);
+      const again = pruneOldSessions(dbManager, 30);
+      assert.deepStrictEqual(again, { sessionsRemoved: 0, messagesRemoved: 0 });
     });
   });
 

--- a/tests/store/session-indexer.test.ts
+++ b/tests/store/session-indexer.test.ts
@@ -222,6 +222,44 @@ describe('session-indexer', () => {
       const result = indexAllSessions(dbManager, '/nonexistent/path');
       assert.strictEqual(result.sessionsProcessed, 0);
     });
+
+    it('skips files outside the retention window and reports expiredSkipped', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      const projDir = path.join(sessionsDir, 'test-project');
+      fs.mkdirSync(projDir, { recursive: true });
+
+      const write = (fileName: string, sessionId: string) => {
+        const lines = [
+          JSON.stringify({ type: 'session', id: sessionId, timestamp: '2026-05-03T00:00:00Z', cwd: '/test' }),
+          JSON.stringify({
+            type: 'message',
+            id: `${sessionId}-m1`,
+            parentId: null,
+            timestamp: '2026-05-03T00:01:00Z',
+            message: { role: 'user', content: [{ type: 'text', text: 'Hello' }], timestamp: Date.now() },
+          }),
+        ];
+        fs.writeFileSync(path.join(projDir, fileName), lines.join('\n'));
+      };
+      write('recent.jsonl', 'recent');
+      write('expired.jsonl', 'expired');
+
+      // Age the second file beyond the retention window.
+      const old = new Date('2026-01-01T00:00:00Z');
+      fs.utimesSync(path.join(projDir, 'expired.jsonl'), old, old);
+
+      const cutoff = Date.parse('2026-03-01T00:00:00Z');
+      const result = indexAllSessions(dbManager, sessionsDir, undefined, cutoff);
+      assert.strictEqual(result.sessionsIndexed, 1);
+      assert.strictEqual(result.expiredSkipped, 1);
+      assert.strictEqual(dbManager.getStats().sessions, 1);
+
+      // Without a cutoff the same directory indexes both files.
+      const result2 = indexAllSessions(dbManager, sessionsDir);
+      assert.strictEqual(result2.sessionsIndexed, 1);
+      assert.strictEqual(result2.expiredSkipped, undefined);
+      assert.strictEqual(dbManager.getStats().sessions, 2);
+    });
   });
 
   describe('indexChangedSessions', () => {
@@ -584,6 +622,27 @@ describe('session-indexer', () => {
       // and no retained files, there is no work to do — this must return
       // false instead of scheduling an empty backfill on every startup.
       assert.strictEqual(needsBackfill(dbManager, sessionsDir, now, cutoff), false);
+    });
+
+    it('needsBackfill ignores expired files instead of using a blind file-count shortcut', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      // Two files on disk, zero indexed rows: a file-count-based shortcut
+      // would return true here. With retention enabled and every file
+      // expired, there is nothing to backfill.
+      writeJsonlSession(sessionsDir, 'project-a', 's1');
+      writeJsonlSession(sessionsDir, 'project-b', 's2');
+      const old = new Date('2026-01-01T00:00:00Z');
+      fs.utimesSync(path.join(sessionsDir, 'project-a', 's1.jsonl'), old, old);
+      fs.utimesSync(path.join(sessionsDir, 'project-b', 's2.jsonl'), old, old);
+
+      const cutoff = Date.parse('2026-03-01T00:00:00Z');
+      assert.strictEqual(needsBackfill(dbManager, sessionsDir, new Date('2026-05-03T01:00:00Z'), cutoff), false);
+
+      // A retained file with no stored metadata still demands a backfill,
+      // even though the file count alone (2 files, 0 rows) is unchanged.
+      const recent = new Date('2026-04-15T00:00:00Z');
+      fs.utimesSync(path.join(sessionsDir, 'project-b', 's2.jsonl'), recent, recent);
+      assert.strictEqual(needsBackfill(dbManager, sessionsDir, new Date('2026-05-03T01:00:00Z'), cutoff), true);
     });
 
     it('needsBackfill still schedules when a retained file exists without a backfill timestamp', () => {

--- a/tests/store/session-search.test.ts
+++ b/tests/store/session-search.test.ts
@@ -50,6 +50,18 @@ describe('session-search', () => {
       assert.ok(results.length > 0);
       assert.ok(results.some(r => r.content.includes('Prisma')));
     });
+    it('degrades an all-stop-word query to the LIKE fallback instead of []', () => {
+      // "the" is a stop word and "and"/"or" connectors, so FTS5 normalization
+      // leaves nothing to match. The query must fall through to the scoped
+      // literal fallback (which still searches the raw terms) rather than
+      // hard-return an empty result set.
+      indexSession(dbManager, createTestSession());
+
+      const results = searchSessions(dbManager, 'the and or');
+      assert.ok(results.length > 0, 'all-stop-word query must reach the LIKE fallback, not []');
+      assert.ok(results.some(r => r.content.includes('the')));
+    });
+
     it('finds pure CJK substrings with the trigram tokenizer', () => {
       indexSession(dbManager, createTestSession({ id: 'cjk-trigram-session', messages: [
         { id: 'cjk-trigram-session-msg-1', role: 'assistant', content: '设备清单包含 NAS 和备份策略', timestamp: '2026-05-03T00:01:00Z' },

--- a/tests/store/sqlite-memory-store.test.ts
+++ b/tests/store/sqlite-memory-store.test.ts
@@ -179,6 +179,58 @@ describe('sqlite-memory-store', () => {
       assert.deepStrictEqual(getMemories(dbManager, { project: 'spoofed-project' }), []);
     });
 
+    it('reports a degraded result (not a swallowed success) on FTS5 index errors', () => {
+      // A genuine FTS5 search-index error must not look like a successful
+      // zero-row sync: the result carries degraded + reason so the caller can
+      // surface /memory-sync-markdown repair guidance.
+      const failingDb = {
+        prepare: (sql: string) => ({
+          get: () => undefined,
+          all: () => [],
+          run: () => {
+            throw new Error('fts5: table memory_fts is corrupted');
+          },
+        }),
+      } as never;
+      const stubDbManager = {
+        getDb: () => failingDb,
+        withCorruptionRecovery: <T>(operation: () => T): T => operation(),
+      } as unknown as DatabaseManager;
+
+      const result = reconcileMarkdownMemoryScope(
+        stubDbManager,
+        ['degraded reconcile test entry'],
+        'memory',
+        null,
+      );
+      assert.equal(result.degraded, true);
+      assert.match(result.degradedReason ?? '', /fts5/);
+      assert.equal(result.inserted, 0);
+    });
+
+    it('still propagates corruption errors instead of degrading (recovery must run)', () => {
+      // Corruption signals are NOT FTS5 errors: they must escape so
+      // DatabaseManager quarantines + rebuilds, never a degraded zero-result.
+      const failingDb = {
+        prepare: () => ({
+          get: () => undefined,
+          all: () => [],
+          run: () => {
+            throw new Error('database disk image is malformed');
+          },
+        }),
+      } as never;
+      const stubDbManager = {
+        getDb: () => failingDb,
+        withCorruptionRecovery: <T>(operation: () => T): T => operation(),
+      } as unknown as DatabaseManager;
+
+      assert.throws(
+        () => reconcileMarkdownMemoryScope(stubDbManager, ['corruption test entry'], 'memory', null),
+        /malformed/,
+      );
+    });
+
     it('prunes only absent rows in the exact target and project scope', () => {
       addMemory(dbManager, 'kept global memory', 'memory', null);
       addMemory(dbManager, 'orphaned global memory', 'memory', null);
@@ -331,6 +383,18 @@ describe('sqlite-memory-store', () => {
       addMemory(dbManager, 'exact phrase memory search example');
       addMemory(dbManager, 'name: Chandrateja', 'user');
       addMemory(dbManager, 'timezone: AEST', 'user');
+    });
+
+    it('degrades an all-stop-word query to the LIKE fallback instead of []', () => {
+      // "the" is a stop word and "and"/"or" connectors, so FTS5 normalization
+      // leaves nothing to match. The query must fall through to the scoped
+      // literal fallback (which still searches the raw terms) rather than
+      // hard-return an empty result set.
+      addMemory(dbManager, 'the build passes after restart');
+
+      const results = searchMemories(dbManager, 'the and or');
+      assert.ok(results.length > 0, 'all-stop-word query must reach the LIKE fallback, not []');
+      assert.ok(results.some(r => r.content.includes('the')));
     });
 
     it('should find memories by keyword', () => {

--- a/tests/store/sqlite-memory-store.test.ts
+++ b/tests/store/sqlite-memory-store.test.ts
@@ -208,6 +208,37 @@ describe('sqlite-memory-store', () => {
       assert.equal(result.inserted, 0);
     });
 
+    it('propagates degraded from failure scopes (first reason wins)', () => {
+      // When multiple failure scopes are degraded, the aggregate result must
+      // be degraded with the first reason (not the last) so the user sees the
+      // original failure, not a later duplicate.
+      let callCount = 0;
+      const failingDb = {
+        prepare: (sql: string) => ({
+          get: () => undefined,
+          all: () => [],
+          run: () => {
+            callCount++;
+            throw new Error(`fts5: error #${callCount}`);
+          },
+        }),
+      } as never;
+      const stubDbManager = {
+        getDb: () => failingDb,
+        withCorruptionRecovery: <T>(operation: () => T): T => operation(),
+      } as unknown as DatabaseManager;
+
+      const result = reconcileMarkdownFailureScopes(
+        stubDbManager,
+        [
+          'failure entry one — Project: project-a <!-- created=2026-01-01 -->',
+          'failure entry two — Project: project-b <!-- created=2026-01-01 -->',
+        ],
+      );
+      assert.equal(result.degraded, true);
+      assert.match(result.degradedReason ?? '', /fts5: error #1/);
+    });
+
     it('still propagates corruption errors instead of degrading (recovery must run)', () => {
       // Corruption signals are NOT FTS5 errors: they must escape so
       // DatabaseManager quarantines + rebuilds, never a degraded zero-result.


### PR DESCRIPTION
## Summary

Narrows this PR to the value that is **unique** versus the already-merged bloat fix (#187). It drops the truncation/parser changes that #187 already covers with its own `100 * 1024` cap, and adds the split-out query-quality and retention work the previous review requested.

## Changes

### 1. FTS5 query quality (session + memory search)
- **Stop-word filtering**: drop ~100 common English filler words (the, how, to, for, in, ...) from natural-language queries so they can't dominate FTS5 ranking or cause misleading AND-style misses. Explicit operators (`AND`/`OR`/`NOT`/`NEAR`) and quoted phrases are preserved untouched.
- **Broader FTS5 error detection**: `isFts5QueryError` now also recognizes `malformed` and `sql logic error`.
- **Graceful memory reconciliation**: when the FTS5 index is broken, `reconcileMarkdownMemoryScope` returns a graceful no-op (entry still persists to Markdown) instead of surfacing a scary `database disk image is malformed` error; the memory tool shows a friendly re-index hint.

### 2. Session retention pruning (bounds DB growth — complements #187 and #186)
- New `sessionRetentionDays` config (default `180`) with `DEFAULT_SESSION_RETENTION_DAYS`.
- On startup, after persistence initializes, prune sessions older than the window and their messages. Counts messages upfront and deletes messages before sessions (the `messages` table is not `ON DELETE CASCADE`) with accurate per-table removed counts.
- This bounds the session index database over time, complementing #187 (unbounded growth prevention) and #186 (deferring startup integrity scans for large DBs) — no file overlap with either.

## Test notes (Windows)
All new regression tests pass (`fts-query.test.ts`, and the added `pruneOldSessions` cases in `session-indexer.test.ts`); `tsc --noEmit` is clean. The pre-existing failures in `extension-root-migration.test.ts`, `sync-markdown-memories.test.ts`, `db.test.ts`, `sqlite-native.test.ts`, and others are **Windows-only environment issues** (EPERM/EBUSY on locked WAL/temp files) that reproduce identically on standalone `origin/main` and are unrelated to these changes.

## Related
- Closes/depends on discussion in #183 (sessions.db bloat / startup hangs).
- Complements #186 (open) — separate files, no conflict.