### PR TITLE
fix: skip full-DB integrity scans at startup

### DIFF
--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -162,6 +162,7 @@ export class DatabaseManager {
   private readonly recoveryOptions: ResolvedDatabaseRecoveryOptions;
   private lastRecovery: DatabaseRecoveryResult | null = null;
   private openGuard: (() => void) | null = null;
+  private pendingOpenIntegrityScan: Promise<void> | null = null;
   private activeRecoveryLease: { coordinator: AtomicLockCoordinator; key: string; token: string } | null = null;
 
   constructor(memoryDir: string, recoveryOptions: DatabaseRecoveryOptions = {}) {
@@ -267,8 +268,9 @@ export class DatabaseManager {
       fs.mkdirSync(dir, { recursive: true });
     }
 
+    let opened: DatabaseLike;
     try {
-      return this.openUnchecked();
+      opened = this.openUnchecked();
     } catch (err) {
       if (!DatabaseManager.isCorruptionError(err)) {
         throw err;
@@ -288,21 +290,57 @@ export class DatabaseManager {
       if (!recoveredDb) throw new Error(`SQLite recovery verification did not open ${this.displayDbPath}`);
       return recoveredDb;
     }
+
+    this.scheduleOpenIntegrityScan(opened);
+    return opened;
+  }
+
+  /**
+   * quick_check walks the whole DB, so open() never pays that cost: the scan
+   * runs after open returns and failures go through the same recovery used
+   * at operation time.
+   */
+  private scheduleOpenIntegrityScan(db: DatabaseLike): void {
+    if (this.pendingOpenIntegrityScan) return;
+    const scan = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        try {
+          if (this.db !== db) {
+            // Manager closed or reopened; the newest open schedules its own
+            // scan, so skip to avoid a stale-handle recovery.
+            return;
+          }
+          this.assertIntegrityOk(db, 'quick_check', 'after open');
+        } catch (err) {
+          try {
+            this.recoverFromCorruption(err);
+          } catch {
+            // Best-effort here; at-operation withCorruptionRecovery still
+            // quarantines and rebuilds if a later statement hits the corruption.
+          }
+        } finally {
+          if (this.pendingOpenIntegrityScan === scan) {
+            this.pendingOpenIntegrityScan = null;
+          }
+          resolve();
+        }
+      }, 0);
+    });
+    this.pendingOpenIntegrityScan = scan;
+  }
+
+  /** Test aid. */
+  async waitForStartupIntegrityScan(): Promise<void> {
+    await this.pendingOpenIntegrityScan;
   }
 
   private openUnchecked(): DatabaseLike {
-    const existed = this.hasExistingMainDatabaseFile();
     const db = new (getDatabaseCtor())(this.dbPath);
     let ok = false;
 
     try {
-      if (existed) {
-        this.assertIntegrityOk(db, 'quick_check', 'before schema initialization');
-      }
-
       this.configureConnection(db);
       this.initializeSchema(db);
-      this.assertIntegrityOk(db, 'quick_check', 'after schema initialization');
       ok = true;
       return db;
     } finally {
@@ -1098,6 +1136,7 @@ export class DatabaseManager {
       try { this.db.close(); } catch { /* best effort — close may throw on a corrupt handle */ }
       this.db = null;
     }
+    this.pendingOpenIntegrityScan = null;
   }
 
   /**

--- a/tests/store/db.test.ts
+++ b/tests/store/db.test.ts
@@ -842,7 +842,7 @@ describe('DatabaseManager', () => {
       assert.doesNotThrow(() => dbManager.getDb());
     });
 
-    it('repairs recoverable corruption on open and preserves readable rows', () => {
+    it('repairs recoverable corruption on open and preserves readable rows', async () => {
       const db = dbManager.getDb();
       db.prepare(`
         INSERT INTO sessions (id, project, cwd, started_at)
@@ -866,6 +866,8 @@ describe('DatabaseManager', () => {
       corruptRecoverableIndexPage(path.join(tmpDir, 'sessions.db'), 'idx_messages_timestamp');
 
       dbManager = new DatabaseManager(tmpDir);
+      assert.doesNotThrow(() => dbManager.getDb());
+      await dbManager.waitForStartupIntegrityScan();
       const repairedDb = dbManager.getDb();
 
       assert.strictEqual(dbManager.getLastRecovery()?.strategy, 'rebuilt');
@@ -880,6 +882,26 @@ describe('DatabaseManager', () => {
       const memory = repairedDb.prepare('SELECT content FROM memories WHERE content = ?').get('recoverable memory') as { content: string } | undefined;
       assert.ok(memory);
       assertQuickCheckOk(repairedDb as InstanceType<typeof Database>);
+      assert.ok(fs.readdirSync(tmpDir).some((name) => name.startsWith('sessions.db.corrupt-')), 'corrupt DB should be quarantined');
+    });
+
+    it('reopened manager runs a fresh integrity scan after close()', async () => {
+      const db = dbManager.getDb();
+      db.prepare(`
+        INSERT INTO sessions (id, project, cwd, started_at)
+        VALUES (?, ?, ?, ?)
+      `).run('reopen-session', 'reopen-project', '/work/reopen', '2026-05-03T00:00:00Z');
+      dbManager.close();
+
+      corruptRecoverableIndexPage(path.join(tmpDir, 'sessions.db'), 'idx_messages_timestamp');
+
+      const reopenedDb = dbManager.getDb();
+      await dbManager.waitForStartupIntegrityScan();
+      const recoveredDb = dbManager.getDb();
+
+      assert.strictEqual(dbManager.getLastRecovery()?.strategy, 'rebuilt');
+      assert.deepStrictEqual(dbManager.getStats(), { sessions: 1, messages: 0, memories: 0 });
+      assertQuickCheckOk(recoveredDb as InstanceType<typeof Database>);
       assert.ok(fs.readdirSync(tmpDir).some((name) => name.startsWith('sessions.db.corrupt-')), 'corrupt DB should be quarantined');
     });
 


### PR DESCRIPTION
Startup cost grows linearly with the extension DB (~8 s at 1.1 GiB, paid twice per session): openUnchecked ran two full-DB PRAGMA quick_check scans on every process start.

Open without the scans and schedule a single deferred quick_check on the next event-loop turn (once per open). A failure funnels into the existing quarantine-and-rebuild recovery, so a recoverably-corrupt file is still repaired on open (getLastRecovery() reflects it) without adding scan time to the startup path.