### PR TITLE
fix: prevent unbounded session database growth

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,12 @@ export const DEFAULT_USER_CHAR_LIMIT = 5000;
 
 // ─── Learning loop defaults ───
 export const DEFAULT_PROJECT_CHAR_LIMIT = 5000;
+/**
+ * Largest session message stored in SQLite. Tool results are excluded during
+ * parsing, but this cap also protects the database from unexpected large text
+ * blocks in future Pi content formats.
+ */
+export const DEFAULT_MAX_MESSAGE_CONTENT_LENGTH = 100 * 1024;
 
 export const DEFAULT_NUDGE_INTERVAL = 10;
 export const DEFAULT_FLUSH_MIN_TURNS = 6;

--- a/src/store/session-indexer.ts
+++ b/src/store/session-indexer.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { DEFAULT_MAX_MESSAGE_CONTENT_LENGTH } from '../constants.js';
 import { DatabaseManager } from './db.js';
 import { parseSessionFile, getSessionFiles, type ParsedSession } from './session-parser.js';
 
@@ -35,6 +36,20 @@ interface SessionFileMetadata {
 export interface IncrementalIndexOptions {
   projectDir?: string;
   maxFilesToIndex?: number;
+}
+
+export function truncateMessageContent(
+  content: string,
+  maxLength = DEFAULT_MAX_MESSAGE_CONTENT_LENGTH,
+): string {
+  if (content.length <= maxLength) return content;
+
+  const notice = `\n... (truncated, ${content.length} chars total)\n`;
+  const retainedLength = Math.max(0, maxLength - notice.length);
+  const prefixLength = Math.ceil(retainedLength / 2);
+  const suffixLength = Math.floor(retainedLength / 2);
+  const suffix = suffixLength > 0 ? content.slice(-suffixLength) : '';
+  return `${content.slice(0, prefixLength)}${notice}${suffix}`;
 }
 
 /**
@@ -86,7 +101,7 @@ function indexSessionOnce(dbManager: DatabaseManager, session: ParsedSession): I
         msg.id,
         session.id,
         msg.role,
-        msg.content,
+        truncateMessageContent(msg.content),
         msg.timestamp,
         msg.toolCalls ? JSON.stringify(msg.toolCalls) : null
       );
@@ -138,16 +153,9 @@ function extractTextContent(content: unknown): string {
         if (typeof b.text === 'string') parts.push(b.text);
         break;
       case 'tool_result':
-        if (typeof b.content === 'string') {
-          parts.push(b.content);
-        } else if (Array.isArray(b.content)) {
-          for (const item of b.content) {
-            if (item && typeof item === 'object' && (item as Record<string, unknown>).type === 'text') {
-              const text = (item as Record<string, unknown>).text;
-              if (typeof text === 'string') parts.push(text);
-            }
-          }
-        }
+        // Tool results can contain unbounded file or command output. Tool
+        // calls are indexed separately, so retaining their output adds bloat
+        // without improving session search.
         break;
     }
   }

--- a/src/store/session-parser.ts
+++ b/src/store/session-parser.ts
@@ -65,16 +65,8 @@ function extractTextContent(content: unknown): string {
         // Skip tool_use blocks — we track tool calls separately
         break;
       case 'tool_result':
-        // Include tool result text if present
-        if (typeof b.content === 'string') {
-          parts.push(b.content);
-        } else if (Array.isArray(b.content)) {
-          for (const item of b.content) {
-            if (item && typeof item === 'object' && (item as Record<string, unknown>).type === 'text') {
-              parts.push((item as Record<string, unknown>).text as string);
-            }
-          }
-        }
+        // Tool results commonly contain full file or command output. They are
+        // ephemeral and can be very large; tool names are indexed separately.
         break;
     }
   }

--- a/tests/store/session-indexer.test.ts
+++ b/tests/store/session-indexer.test.ts
@@ -16,8 +16,10 @@ import {
   indexCurrentSession,
   indexLiveSession,
   parseSessionManagerSnapshot,
+  truncateMessageContent,
   upsertSessionFileMetadata,
 } from '../../src/store/session-indexer.js';
+import { DEFAULT_MAX_MESSAGE_CONTENT_LENGTH } from '../../src/constants.js';
 import { parseSessionFile, type ParsedSession } from '../../src/store/session-parser.js';
 
 describe('session-indexer', () => {
@@ -79,6 +81,22 @@ describe('session-indexer', () => {
       const msg = db.prepare('SELECT tool_calls FROM messages WHERE id = ?').get('session-1-msg-2') as { tool_calls: string | null };
       assert.ok(msg.tool_calls);
       assert.deepStrictEqual(JSON.parse(msg.tool_calls), ['read']);
+    });
+
+    it('should cap oversized message content while retaining both ends', () => {
+      const content = `begin-${'x'.repeat(DEFAULT_MAX_MESSAGE_CONTENT_LENGTH)}-end`;
+      const session = createTestSession({
+        messages: [{ id: 'oversized-message', role: 'assistant', content, timestamp: '2026-05-03T00:01:00Z' }],
+      });
+
+      indexSession(dbManager, session);
+
+      const stored = dbManager.getDb().prepare('SELECT content FROM messages WHERE id = ?').get('oversized-message') as { content: string };
+      assert.ok(stored.content.length <= DEFAULT_MAX_MESSAGE_CONTENT_LENGTH);
+      assert.match(stored.content, /^begin-/);
+      assert.match(stored.content, /-end$/);
+      assert.match(stored.content, /truncated, \d+ chars total/);
+      assert.strictEqual(truncateMessageContent('short content'), 'short content');
     });
 
     it('should skip already-indexed sessions with no new messages', () => {
@@ -354,6 +372,26 @@ describe('session-indexer', () => {
       assert.strictEqual(parsed.project, 'live-project');
       assert.strictEqual(parsed.messages.length, 2);
       assert.deepStrictEqual(parsed.messages[1].toolCalls, ['read']);
+    });
+
+    it('parseSessionManagerSnapshot skips embedded tool result content', () => {
+      const parsed = parseSessionManagerSnapshot(createSessionManagerSnapshot([
+        {
+          type: 'message',
+          id: 'entry-1',
+          timestamp: '2026-05-03T00:01:00Z',
+          message: {
+            role: 'assistant',
+            content: [
+              { type: 'text', text: 'Summary of the result.' },
+              { type: 'tool_result', content: [{ type: 'text', text: 'unbounded output' }] },
+            ],
+          },
+        },
+      ]));
+
+      assert.ok(parsed);
+      assert.strictEqual(parsed.messages[0].content, 'Summary of the result.');
     });
 
     it('indexLiveSession prefers the persisted JSONL file when available', () => {

--- a/tests/store/session-parser.test.ts
+++ b/tests/store/session-parser.test.ts
@@ -205,7 +205,7 @@ describe('session-parser', () => {
       assert.strictEqual(result, null);
     });
 
-    it('should extract text from tool_result content', () => {
+    it('should skip tool_result content while retaining assistant text', () => {
       const filePath = path.join(tmpDir, 'test.jsonl');
       const lines = [
         JSON.stringify({ type: 'session', id: 's1', timestamp: '2026-05-03T00:00:00Z', cwd: '/test' }),
@@ -215,11 +215,12 @@ describe('session-parser', () => {
           parentId: null,
           timestamp: '2026-05-03T00:01:00Z',
           message: {
-            role: 'user',
+            role: 'assistant',
             content: [
+              { type: 'text', text: 'I inspected the file.' },
               {
                 type: 'tool_result',
-                content: [{ type: 'text', text: 'file contents here' }],
+                content: [{ type: 'text', text: 'large file contents must not be indexed' }],
               },
             ],
             timestamp: Date.now(),
@@ -230,7 +231,7 @@ describe('session-parser', () => {
 
       const result = parseSessionFile(filePath);
       assert.ok(result);
-      assert.strictEqual(result.messages[0].content, 'file contents here');
+      assert.strictEqual(result.messages[0].content, 'I inspected the file.');
     });
   });
 

--- a/tests/tools/session-search-tool.test.ts
+++ b/tests/tools/session-search-tool.test.ts
@@ -135,19 +135,31 @@ describe("registerSessionSearchTool", () => {
     const oversizedContent = `needle ${"x".repeat(6_000_000)}`;
 
     try {
-      indexSession(dbManager, {
-        id: "oversized-session",
-        project: "oversized-project",
-        cwd: "/work/oversized",
-        startedAt: "2026-07-11T00:00:00.000Z",
-        endedAt: null,
-        messages: [{
-          id: "oversized-message",
-          role: "assistant",
-          content: oversizedContent,
-          timestamp: "2026-07-11T00:01:00.000Z",
-        }],
-      });
+      // Seed a pre-cap database row directly. New ingestion paths must cap
+      // message content, but search output still needs to stay bounded for
+      // oversized rows written by older extension versions.
+      const db = dbManager.getDb();
+      db.prepare(`
+        INSERT INTO sessions (id, project, cwd, started_at, ended_at, message_count)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `).run(
+        "oversized-session",
+        "oversized-project",
+        "/work/oversized",
+        "2026-07-11T00:00:00.000Z",
+        null,
+        1,
+      );
+      db.prepare(`
+        INSERT INTO messages (id, session_id, role, content, timestamp)
+        VALUES (?, ?, ?, ?, ?)
+      `).run(
+        "oversized-message",
+        "oversized-session",
+        "assistant",
+        oversizedContent,
+        "2026-07-11T00:01:00.000Z",
+      );
       registerSessionSearchTool(mockPi, dbManager);
 
       const result = await captured.execute("tc-oversized", { query: "needle" });


### PR DESCRIPTION
Fixes #183

## Summary
- exclude `tool_result` payloads from both JSONL and live-session parsing paths
- apply a hard 100 KiB cap to every session message written to SQLite, retaining a bounded prefix and suffix with original-length metadata
- add regression coverage for tool-result exclusion and oversized message storage

## Verification
- `npx tsx --test tests/store/session-parser.test.ts tests/store/session-indexer.test.ts`
- `npm run check`
- `npm test`