### PR TITLE
chore(release): bump version to 0.9.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hermes-memory",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-tui": "^0.80.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hermes-memory",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "🧠 Persistent memory + 🔍 session search + 🛡️ secret scanning for Pi. Token-aware policy-only memory by default, SQLite FTS5 search, auto-consolidation, procedural skills. 732 tests. Ported from Hermes agent.",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary
- bump package version from `0.9.5` to `0.9.6`
- synchronize the root package-lock metadata

## Verification
- `npm ci`
- `npm run check`

No npm publication, Git tag, or GitHub release is included in this PR.