### PR TITLE
fix: preserve child extension source specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Portable child extension sources were discarded before Pi could resolve them**: `childExtensionPaths` ran every configured value through Node's cwd-relative `path.resolve()` and required that resulting local path to already exist. This silently dropped Pi-native `~/...`, `git:...`, and `npm:...` extension sources, forcing machine-specific absolute paths for custom providers in isolated subprocesses. Configured sources are now passed unchanged to Pi's standard `-e` resolver, while Hermes-discovered auth adapter paths retain their local existence checks.
+
 ## [0.9.4] - 2026-08-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ Create `~/.pi/agent/hermes-memory-config.json`:
   "sessionSearch": { "variant": "legacy" },
   "llmModelOverride": "openrouter/deepseek/deepseek-v4-flash",
   "llmThinkingOverride": "off",
+  "childExtensionPaths": ["~/.pi/agent/git/github.com/example/custom-provider-extension/index.ts"],
   "nudgeInterval": 10,
   "nudgeToolCalls": 15,
   "reviewRecentMessages": 0,
@@ -533,7 +534,7 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 | `sessionSearch` | `{ "variant": "legacy" }` | Session search implementation: `legacy` keeps the existing SQLite/FTS snippet search; `anchors` uses the opt-in Markdown request surface and returns compact JSONL line-range anchors from `~/.pi/agent/sessions/` |
 | `llmModelOverride` | unset | Optional model override for background review (direct and subprocess), correction save, session flush, and consolidation |
 | `llmThinkingOverride` | unset | Optional thinking override for those LLM calls; valid values are `off`, `minimal`, `low`, `medium`, `high`, and `xhigh`. If `llmModelOverride` is set and this is omitted, review/child calls default to `off` |
-| `childExtensionPaths` | unset | Trusted provider/auth adapter entry paths explicitly allowed in isolated child Pi processes; sibling packages matching the `*-oauth-adapter`/`*-auth-adapter` naming convention (including scoped packages, via their `package.json` `pi.extensions` manifest) are detected automatically — this setting is only needed for adapters that don't match that convention. In-process direct transport (the default for review/flush/correction/consolidation) doesn't need this at all, since it reads whatever provider auth is already registered |
+| `childExtensionPaths` | unset | Trusted provider/auth extension sources explicitly allowed in isolated child Pi processes. Values are passed to Pi's standard `-e` resolver, so absolute paths, `~/...`, paths relative to the child working directory, and `git:`/`npm:` package sources are supported. Sibling packages matching the `*-oauth-adapter`/`*-auth-adapter` naming convention (including scoped packages, via their `package.json` `pi.extensions` manifest) are detected automatically. This setting is only needed for custom providers or adapters that are not detected. In-process direct transport (the default for review/flush/correction/consolidation) doesn't need it, since it reads whatever provider auth is already registered. |
 | `nudgeInterval` | `10` | Turns between auto-reviews |
 | `nudgeToolCalls` | `15` | Tool calls between auto-reviews (OR with turns) |
 | `reviewRecentMessages` | `0` | Recent messages included in background review (`0` = all) |

--- a/src/handlers/pi-child-process.ts
+++ b/src/handlers/pi-child-process.ts
@@ -226,31 +226,35 @@ export function detectAuthAdapterExtensionPaths(roots?: string[]): string[] {
   return detected;
 }
 
-function childExtensionPaths(config: ChildLlmConfig): string[] {
-  const candidates = [
-    OWN_EXTENSION_PATH,
-    ...(config.childExtensionPaths ?? []),
-    ...detectAuthAdapterExtensionPaths(),
-  ];
+function childExtensionSources(config: ChildLlmConfig): string[] {
   const seen = new Set<string>();
-  const paths: string[] = [];
-  for (const candidate of candidates) {
+  const sources: string[] = [];
+  const append = (candidate: string | undefined): void => {
     const trimmed = candidate?.trim();
-    if (!trimmed) continue;
-    const normalized = resolve(trimmed);
-    if (seen.has(normalized) || !existsSync(normalized)) continue;
-    seen.add(normalized);
-    paths.push(normalized);
+    if (!trimmed || seen.has(trimmed)) return;
+    seen.add(trimmed);
+    sources.push(trimmed);
+  };
+
+  // These paths are discovered by Hermes rather than explicitly trusted in
+  // configuration, so keep the local existence check before forwarding them.
+  if (OWN_EXTENSION_PATH && existsSync(OWN_EXTENSION_PATH)) append(OWN_EXTENSION_PATH);
+  for (const source of config.childExtensionPaths ?? []) append(source);
+  for (const adapterPath of detectAuthAdapterExtensionPaths()) {
+    const normalized = resolve(adapterPath);
+    if (existsSync(normalized)) append(normalized);
   }
-  return paths;
+  return sources;
 }
 
 function appendOwnExtensionArgs(args: string[], config: ChildLlmConfig): void {
   // Skip all packages from settings.json (--no-extensions) — the subprocess
-  // loads only Hermes and explicitly required provider adapters.
+  // loads only Hermes and explicitly trusted provider/auth sources. Leave
+  // configured sources untouched so Pi's -e resolver owns path expansion and
+  // package-source handling exactly as it does for normal CLI invocations.
   args.push("--no-extensions");
-  for (const extensionPath of childExtensionPaths(config)) {
-    args.push("-e", extensionPath);
+  for (const extensionSource of childExtensionSources(config)) {
+    args.push("-e", extensionSource);
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,7 +56,7 @@ export interface MemoryConfig {
   llmModelOverride?: string;
   /** Override thinking level used for child pi -p subprocess LLM calls. Default: unset */
   llmThinkingOverride?: ThinkingLevel;
-  /** Extra extension entry paths required by child Pi processes, such as provider auth adapters. */
+  /** Trusted Pi extension sources required by child processes, such as custom providers or auth adapters. */
   childExtensionPaths?: string[];
   /** Strategy when memory is full. Default: auto-consolidate */
   memoryOverflowStrategy?: MemoryOverflowStrategy;

--- a/tests/handlers/pi-child-process.test.ts
+++ b/tests/handlers/pi-child-process.test.ts
@@ -313,7 +313,7 @@ describe("buildChildPiPromptArgs", () => {
     );
   });
 
-  it("passes configured extensions but excludes unrelated inherited extensions", async () => {
+  it("passes configured extension sources through Pi's -e resolver and excludes inherited extensions", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-child-extensions-"));
     const configured = path.join(dir, "configured.ts");
     const inherited = path.join(dir, "inherited.ts");
@@ -322,12 +322,24 @@ describe("buildChildPiPromptArgs", () => {
     try {
       assert.deepStrictEqual(
         buildChildPiPromptArgs("hello", {
-          childExtensionPaths: [configured, configured, "/missing/adapter.ts", OWN_EXTENSION_PATH],
+          childExtensionPaths: [
+            configured,
+            configured,
+            "~/.pi/agent/extensions/provider.ts",
+            "./relative-provider.ts",
+            "git:github.com/example/provider-extension@v1",
+            "npm:@example/provider-extension@1.0.0",
+            OWN_EXTENSION_PATH,
+          ],
         }, ["-e", inherited, `--extension=${configured}`]),
         [
           "-p", "--no-session", "--no-extensions",
           "-e", OWN_EXTENSION_PATH,
           "-e", configured,
+          "-e", "~/.pi/agent/extensions/provider.ts",
+          "-e", "./relative-provider.ts",
+          "-e", "git:github.com/example/provider-extension@v1",
+          "-e", "npm:@example/provider-extension@1.0.0",
           ...DETECTED_ADAPTER_ARGS,
           "hello",
         ],


### PR DESCRIPTION
## Summary

- pass configured `childExtensionPaths` values unchanged to Pi's standard `-e` resolver
- support portable `~/...`, relative, `git:...`, and `npm:...` extension sources
- retain local existence checks for Hermes-discovered auth adapter paths

## Problem

Hermes currently calls cwd-relative `path.resolve()` and `existsSync()` on every configured child extension value before invoking Pi. That silently drops Pi-native package sources and home-relative paths, forcing machine-specific absolute paths for custom providers in isolated subprocesses.

Pi already owns this resolution contract: CLI `-e` values are passed through `resolveExtensionSources()`, which handles local paths and package sources. This change leaves configured values intact so the child Pi process uses that standard behavior while preserving the existing `--no-extensions` isolation boundary.

## Verification

- `npm run check`
- `npm run check:min-sdk` (Pi 0.80.1)
- `npm test` (all 47 test files passed)
- real Pi smoke test with a `~/.pi/agent/...` provider extension source
- remote cross-home validation: Dotdrop rendered the same config to `/root/...`, and isolated Hermes + provider loading resolved the expected models without `No models match` warnings