### PR TITLE
fix(review): support header-only OAuth auth

### DIFF
--- a/src/handlers/review-memory-ops.ts
+++ b/src/handlers/review-memory-ops.ts
@@ -92,7 +92,7 @@ type ReviewModelRegistry = ExtensionContext["modelRegistry"];
 /** Derived from the installed SDK so headers/baseUrl track ProviderHeaders instead of a local mirror. */
 export type ResolvedRequestAuth = Awaited<ReturnType<ReviewModelRegistry["getApiKeyAndHeaders"]>>;
 
-type DirectReviewAuth = Omit<Extract<ResolvedRequestAuth, { ok: true }>, "ok"> & { apiKey: string };
+type DirectReviewAuth = Omit<Extract<ResolvedRequestAuth, { ok: true }>, "ok">;
 
 export function buildDirectReviewCompletionOptions(
   model: Model<Api>,
@@ -141,6 +141,54 @@ const AUTH_REJECTION_PATTERN = new RegExp([
 
 export function isAuthRejection(message: string): boolean {
   return AUTH_REJECTION_PATTERN.test(message);
+}
+
+const CREDENTIAL_HEADER_NAMES = new Set(["authorization", "x-api-key", "cf-aig-authorization"]);
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function hasRequestAuth(auth: DirectReviewAuth): boolean {
+  if (isNonEmptyString(auth.apiKey)) return true;
+  return Object.entries(auth.headers ?? {}).some(
+    ([key, value]) => CREDENTIAL_HEADER_NAMES.has(key.toLowerCase()) && isNonEmptyString(value),
+  );
+}
+
+function sameStringRecord(
+  left: Record<string, string> | undefined,
+  right: Record<string, string> | undefined,
+): boolean {
+  const leftEntries = Object.entries(left ?? {});
+  const rightKeys = Object.keys(right ?? {});
+  return leftEntries.length === rightKeys.length
+    && leftEntries.every(([key, value]) => right?.[key] === value);
+}
+
+function headerPairs(headers: DirectReviewAuth["headers"]): Array<[string, string | null]> {
+  return Object.entries(headers ?? {}).map(([key, value]) => [key.toLowerCase(), value]);
+}
+
+function sameHeaders(
+  left: DirectReviewAuth["headers"],
+  right: DirectReviewAuth["headers"],
+): boolean {
+  const remaining = headerPairs(right);
+  const leftPairs = headerPairs(left);
+  if (leftPairs.length !== remaining.length) return false;
+  for (const [key, value] of leftPairs) {
+    const index = remaining.findIndex((pair) => pair[0] === key && pair[1] === value);
+    if (index === -1) return false;
+    remaining.splice(index, 1);
+  }
+  return true;
+}
+
+function sameRequestAuth(left: DirectReviewAuth, right: DirectReviewAuth): boolean {
+  return left.apiKey === right.apiKey
+    && sameHeaders(left.headers, right.headers)
+    && sameStringRecord(left.env, right.env);
 }
 
 /**
@@ -404,12 +452,12 @@ export async function runDirectMemoryCompletion(
   }
 
   const auth = await resolveRequestAuth(ctx.modelRegistry, model);
-  if (!auth.ok || !auth.apiKey) {
+  if (!auth.ok || !hasRequestAuth(auth)) {
     return {
       ok: false,
       appliedCount: 0,
       fallbackReason: "no_auth",
-      error: auth.ok ? `No API key for ${model.provider}` : auth.error,
+      error: auth.ok ? `No request authentication for ${model.provider}` : auth.error,
     };
   }
   let requestAuth: DirectReviewAuth = { apiKey: auth.apiKey, headers: auth.headers, env: auth.env };
@@ -430,31 +478,36 @@ export async function runDirectMemoryCompletion(
 
   const request = { systemPrompt: options.systemPrompt, messages: [userMessage] };
 
+  const completeOnce = async () => {
+    const response = await complete(
+      model,
+      request,
+      buildDirectReviewCompletionOptions(model, requestAuth, thinking, controller.signal),
+    );
+    if (response.stopReason === "error" && isAuthRejection(response.errorMessage ?? "")) {
+      throw new Error(response.errorMessage ?? "error");
+    }
+    return response;
+  };
+
   try {
     let response;
     try {
-      response = await complete(
-        model,
-        request,
-        buildDirectReviewCompletionOptions(model, requestAuth, thinking, controller.signal),
-      );
+      response = await completeOnce();
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       if (controller.signal.aborted || !isAuthRejection(message)) throw err;
 
-      // The provider rejected the key mid-flight. A rotation tool may have
-      // re-resolve through Pi and retry once only if it returns a different
-      // key; otherwise this is a real auth problem and the subprocess
-      // fallback should handle it (#139).
+      // Thrown failures and error assistant responses share this path. API keys
+      // and OAuth headers can both rotate, so re-resolve through Pi and retry
+      // once only when the effective request auth actually changed; otherwise
+      // this is a real auth problem and the subprocess fallback should handle
+      // it (#139).
       const rotated = await resolveRequestAuth(ctx.modelRegistry, model);
-      if (!rotated.ok || !rotated.apiKey || rotated.apiKey === requestAuth.apiKey) throw err;
+      if (!rotated.ok || !hasRequestAuth(rotated) || sameRequestAuth(rotated, requestAuth)) throw err;
 
       requestAuth = { apiKey: rotated.apiKey, headers: rotated.headers, env: rotated.env };
-      response = await complete(
-        model,
-        request,
-        buildDirectReviewCompletionOptions(model, requestAuth, thinking, controller.signal),
-      );
+      response = await completeOnce();
     }
 
     if (response.stopReason === "aborted") {

--- a/tests/handlers/review-memory-ops.test.ts
+++ b/tests/handlers/review-memory-ops.test.ts
@@ -90,6 +90,19 @@ describe("provider auth resolution", () => {
     return { usedKeys, complete };
   }
 
+  function registryWithHeaderAuth(...headers: Array<Record<string, string | null>>) {
+    let authCalls = 0;
+    return {
+      getApiKeyAndHeaders: async () => ({
+        ok: true as const,
+        headers: headers[Math.min(authCalls++, headers.length - 1)],
+      }),
+      getAll: () => [mockModel(false)],
+      getAvailable: () => [mockModel(false)],
+      get authCalls() { return authCalls; },
+    };
+  }
+
   const emptyOperations = {
     stopReason: "stop",
     content: [{ type: "text", text: JSON.stringify({ operations: [] }) }],
@@ -97,6 +110,18 @@ describe("provider auth resolution", () => {
 
   function directOptions() {
     return { userPrompt: "u", systemPrompt: "s", config: {} };
+  }
+
+  async function runReview(modelRegistry: unknown, complete: unknown) {
+    return runDirectMemoryCompletion(
+      { model: mockModel(false), modelRegistry } as never,
+      null as never,
+      null,
+      directOptions(),
+      null,
+      null,
+      { completeSimple: complete as never },
+    );
   }
 
   it("resolves credentials through the public registry API", async () => {
@@ -117,6 +142,44 @@ describe("provider auth resolution", () => {
     assert.strictEqual(registry.authCalls, 1);
     assert.deepStrictEqual(usedKeys, ["current-key"]);
   });
+
+  it("runs direct review with header-only OAuth request auth", async () => {
+    const headers = {
+      Authorization: "Bearer kimi-oauth-token",
+      "User-Agent": "pi-coding-agent",
+      "X-Drop": null,
+    };
+    const usedHeaders: Array<Record<string, string | null> | undefined> = [];
+    const complete = async (_model: unknown, _request: unknown, options: { headers?: Record<string, string | null> }) => {
+      usedHeaders.push(options.headers);
+      return emptyOperations;
+    };
+
+    const result = await runReview(registryWithHeaderAuth(headers), complete);
+
+    assert.strictEqual(result.ok, true);
+    assert.deepStrictEqual(usedHeaders, [headers]);
+  });
+
+  for (const { name, headers } of [
+    { name: "empty headers", headers: {} },
+    { name: "User-Agent-only headers", headers: { "User-Agent": "pi-coding-agent" } },
+    { name: "null credential headers", headers: { Authorization: null, "x-api-key": null } },
+  ]) {
+    it(`rejects ${name} as missing request authentication`, async () => {
+      let completionCalls = 0;
+      const complete = async () => {
+        completionCalls++;
+        return emptyOperations;
+      };
+
+      const result = await runReview(registryWithHeaderAuth(headers), complete);
+
+      assert.strictEqual(result.ok, false);
+      assert.strictEqual(result.fallbackReason, "no_auth");
+      assert.strictEqual(completionCalls, 0);
+    });
+  }
 
   it("re-resolves credentials after a provider auth rejection", async () => {
     const { modelRegistry } = registryWithAuthResponses("revoked-key", "rotated-key");
@@ -139,6 +202,35 @@ describe("provider auth resolution", () => {
     assert.deepStrictEqual(usedKeys, ["revoked-key", "rotated-key"]);
   });
 
+  it("re-resolves rotated header-only OAuth credentials after rejection", async () => {
+    const usedHeaders: Array<Record<string, string> | undefined> = [];
+    const complete = async (_model: unknown, _request: unknown, options: { headers?: Record<string, string> }) => {
+      usedHeaders.push(options.headers);
+      if (usedHeaders.length === 1) throw new Error("HTTP 401 Unauthorized: token expired");
+      return emptyOperations;
+    };
+    const modelRegistry = registryWithHeaderAuth(
+      { Authorization: "Bearer stale-token" },
+      { Authorization: "Bearer fresh-token" },
+    );
+
+    const result = await runDirectMemoryCompletion(
+      { model: mockModel(false), modelRegistry } as never,
+      null as never,
+      null,
+      directOptions(),
+      null,
+      null,
+      { completeSimple: complete as never },
+    );
+
+    assert.strictEqual(result.ok, true);
+    assert.deepStrictEqual(usedHeaders, [
+      { Authorization: "Bearer stale-token" },
+      { Authorization: "Bearer fresh-token" },
+    ]);
+  });
+
   it("does not retry when the refreshed key is the same one the provider rejected", async () => {
     const { modelRegistry } = registryWithAuthResponses("only-key");
     const { usedKeys, complete } = completionStub(() => new Error("HTTP 401 Unauthorized"));
@@ -156,6 +248,129 @@ describe("provider auth resolution", () => {
     assert.strictEqual(result.ok, false);
     assert.strictEqual(result.fallbackReason, "provider_error");
     assert.strictEqual(usedKeys.length, 1, "an unchanged key means a real auth problem, not a rotation race");
+  });
+
+  it("does not retry an unchanged header-only OAuth credential", async () => {
+    let completionCalls = 0;
+    const complete = async () => {
+      completionCalls++;
+      throw new Error("HTTP 401 Unauthorized");
+    };
+    const modelRegistry = registryWithHeaderAuth({ Authorization: "Bearer unchanged-token" });
+
+    const result = await runDirectMemoryCompletion(
+      { model: mockModel(false), modelRegistry } as never,
+      null as never,
+      null,
+      directOptions(),
+      null,
+      null,
+      { completeSimple: complete as never },
+    );
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.fallbackReason, "provider_error");
+    assert.strictEqual(completionCalls, 1);
+  });
+
+  it("rotates header-only auth after an error assistant 401 response", async () => {
+    const usedHeaders: Array<Record<string, string | null> | undefined> = [];
+    const complete = async (_model: unknown, _request: unknown, options: { headers?: Record<string, string | null> }) => {
+      usedHeaders.push(options.headers);
+      if (usedHeaders.length === 1) {
+        return { stopReason: "error", errorMessage: "HTTP 401 Unauthorized: token expired" };
+      }
+      return emptyOperations;
+    };
+    const modelRegistry = registryWithHeaderAuth(
+      { Authorization: "Bearer stale-token" },
+      { Authorization: "Bearer fresh-token" },
+    );
+
+    const result = await runDirectMemoryCompletion(
+      { model: mockModel(false), modelRegistry } as never,
+      null as never,
+      null,
+      directOptions(),
+      null,
+      null,
+      { completeSimple: complete as never },
+    );
+
+    assert.strictEqual(result.ok, true);
+    assert.deepStrictEqual(usedHeaders, [
+      { Authorization: "Bearer stale-token" },
+      { Authorization: "Bearer fresh-token" },
+    ]);
+  });
+
+  it("does not retry when only the credential header name casing changed", async () => {
+    let completionCalls = 0;
+    const complete = async () => {
+      completionCalls++;
+      throw new Error("HTTP 401 Unauthorized");
+    };
+    const modelRegistry = registryWithHeaderAuth(
+      { Authorization: "Bearer same-token" },
+      { authorization: "Bearer same-token" },
+    );
+
+    const result = await runDirectMemoryCompletion(
+      { model: mockModel(false), modelRegistry } as never,
+      null as never,
+      null,
+      directOptions(),
+      null,
+      null,
+      { completeSimple: complete as never },
+    );
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.fallbackReason, "provider_error");
+    assert.strictEqual(completionCalls, 1);
+  });
+
+  it("retries once when a duplicate-case credential header value changes", async () => {
+    const stale = { Authorization: "Bearer stale", authorization: "Bearer shared" };
+    const fresh = { Authorization: "Bearer fresh", authorization: "Bearer shared" };
+    const usedHeaders: Array<Record<string, string | null> | undefined> = [];
+    const complete = async (_model: unknown, _request: unknown, options: { headers?: Record<string, string | null> }) => {
+      usedHeaders.push(options.headers);
+      if (usedHeaders.length === 1) {
+        return { stopReason: "error", errorMessage: "HTTP 401 Unauthorized: token expired" };
+      }
+      return emptyOperations;
+    };
+    const modelRegistry = registryWithHeaderAuth(stale, fresh);
+
+    const result = await runReview(modelRegistry, complete);
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(modelRegistry.authCalls, 2);
+    assert.deepStrictEqual(usedHeaders, [stale, fresh]);
+  });
+
+  it("returns provider_error after a second auth failure without a third completion", async () => {
+    let completionCalls = 0;
+    const complete = async () => {
+      completionCalls++;
+      if (completionCalls <= 2) {
+        return { stopReason: "error", errorMessage: "HTTP 401 Unauthorized" };
+      }
+      return emptyOperations;
+    };
+    const modelRegistry = registryWithHeaderAuth(
+      { Authorization: "Bearer stale-token" },
+      { Authorization: "Bearer still-bad-token" },
+      { Authorization: "Bearer should-not-be-used" },
+    );
+
+    const result = await runReview(modelRegistry, complete);
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.fallbackReason, "provider_error");
+    assert.strictEqual(completionCalls, 2);
+    assert.strictEqual(modelRegistry.authCalls, 2);
   });
 
   it("classifies provider auth rejections without swallowing other failures", () => {


### PR DESCRIPTION
## Summary

- accept request authentication supplied through provider headers, not only `apiKey`, in direct memory completions
- recognize only credential-bearing headers (`Authorization`, `x-api-key`, and `cf-aig-authorization`) while forwarding all resolved headers unchanged
- normalize thrown 401/403 failures and assistant `stopReason: "error"` responses through the same one-retry auth-rotation path
- compare header names case-insensitively without collapsing duplicate-case entries, and tolerate `ProviderHeaders` null values
- retain Pi's SDK-derived auth types and public `modelRegistry.getApiKeyAndHeaders()` API

## Root cause

Pi OAuth-backed providers can resolve request auth entirely through headers. The direct review path originally required `apiKey`, and the first PR revision still assumed provider auth failures were thrown. In production, `completeSimple()` normally returns an assistant message with `stopReason: "error"` and `errorMessage`; static headers could also be mistaken for credentials.

The updated path accepts header-owned auth, distinguishes credential headers from ordinary provider headers, and re-resolves effective request auth once after either form of 401/403 failure. If the credentials did not change, or the retry also fails, it returns `provider_error` without a third completion.

## Verification

- `node --test --import tsx tests/handlers/review-memory-ops.test.ts` — 31/31 passed
- `npm run check`
- `npm test` — all 50 test files passed
- `npm run check:min-sdk` — source type-checks against Pi SDK 0.80.6
- `git diff --check`
- regressions cover error assistant responses, `User-Agent`-only auth, null credential values, casing-only changes, duplicate-case header entries, and the strict one-retry ceiling
