### PR TITLE
fix(review): scope background cancellation to session

### DIFF
--- a/src/handlers/background-review.ts
+++ b/src/handlers/background-review.ts
@@ -122,7 +122,6 @@ const SESSION_REVIEW_SHUTDOWN_GRACE_MS = 1000;
 function awaitUpTo(promise: Promise<void>, ms: number): Promise<void> {
   return new Promise((resolve) => {
     const timer = setTimeout(resolve, ms);
-    timer.unref();
     promise.then(
       () => {
         clearTimeout(timer);

--- a/src/handlers/background-review.ts
+++ b/src/handlers/background-review.ts
@@ -31,9 +31,11 @@ export interface BackgroundReviewDeps {
   runDirectReview?: typeof runDirectMemoryCompletion;
   execChildPrompt?: typeof execChildPrompt;
   /** Test-only hook: called once runReview() has fully settled (after the
-   * fire-and-forget review work completes and reviewInProgress resets),
+   * fire-and-forget review work completes and activeReview clears),
    * since production callers never await runReview() directly. */
   onReviewSettled?: () => void;
+  /** Test-only override for session_shutdown's wait bound. */
+  shutdownGraceMs?: number;
 }
 
 export interface ReviewPromptInput {
@@ -113,17 +115,41 @@ function diagnosticDetail(value: unknown): string {
   return detail.replace(/\s+/g, " ").slice(0, 300);
 }
 
+/** Shutdown wait only. Review still uses its own 120s timeout; 1s covers abort
+ * listener + cancel-file write without hanging Pi's awaited session_shutdown. */
+const SESSION_REVIEW_SHUTDOWN_GRACE_MS = 1000;
+
+function awaitUpTo(promise: Promise<void>, ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref();
+    promise.then(
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+    );
+  });
+}
+
 async function runSubprocessReview(
   pi: ExtensionAPI,
   prompt: string,
   config: MemoryConfig,
   execChild: typeof execChildPrompt,
-  ctx: Pick<ExtensionContext, "cwd" | "model" | "signal">,
+  ctx: Pick<ExtensionContext, "cwd" | "model">,
+  signal: AbortSignal,
 ): Promise<{ code: number; stdout?: string; stderr?: string }> {
   return execChild(pi, prompt, config, {
     cwd: ctx.cwd,
     model: resolveChildPiModel(ctx.model),
-    signal: ctx.signal,
+    // Session-scoped signal only. The turn signal belongs to the interactive
+    // agent run; forwarding it cancels unrelated review on a later user abort.
+    signal,
     timeoutMs: 120000,
   });
 }
@@ -140,11 +166,27 @@ export function setupBackgroundReview(
   const runDirectReview = options.deps?.runDirectReview ?? runDirectMemoryCompletion;
   const execChild = options.deps?.execChildPrompt ?? execChildPrompt;
   const onReviewSettled = options.deps?.onReviewSettled;
+  const shutdownGraceMs = options.deps?.shutdownGraceMs ?? SESSION_REVIEW_SHUTDOWN_GRACE_MS;
 
   let turnsSinceReview = 0;
   let toolCallsSinceReview = 0;
   let userTurnCount = 0;
-  let reviewInProgress = false;
+  let activeReview: Promise<void> | undefined;
+  const sessionAbort = new AbortController();
+  let shutdownPromise: Promise<void> | undefined;
+
+  const sessionCancelled = () => sessionAbort.signal.aborted;
+
+  const shutdownReview = (): Promise<void> => {
+    shutdownPromise ??= (async () => {
+      sessionAbort.abort();
+      const inFlight = activeReview;
+      if (inFlight) await awaitUpTo(inFlight, shutdownGraceMs);
+    })();
+    return shutdownPromise;
+  };
+
+  pi.on("session_shutdown", () => shutdownReview());
 
   pi.on("message_end", async (event, _ctx) => {
     if (event.message.role === "user") {
@@ -156,7 +198,8 @@ export function setupBackgroundReview(
     turnsSinceReview++;
 
     if (!config.reviewEnabled) return;
-    if (reviewInProgress) return;
+    if (sessionCancelled()) return;
+    if (activeReview) return;
 
     try {
       const msg = event.message;
@@ -179,49 +222,52 @@ export function setupBackgroundReview(
 
     if (!turnThresholdMet && !toolCallThresholdMet) return;
     if (userTurnCount < 3) return;
+    if (sessionCancelled()) return;
 
     turnsSinceReview = 0;
     toolCallsSinceReview = 0;
-    reviewInProgress = true;
-
-    let allParts: string[] = [];
-    try {
-      const entries = ctx.sessionManager.getBranch();
-      allParts = collectMessageParts(entries);
-    } catch {
-      reviewInProgress = false;
-      return;
-    }
-    if (allParts.length < 4) {
-      reviewInProgress = false;
-      return;
-    }
-
-    const parts = applyRecentMessageLimit(allParts, config.reviewRecentMessages);
-    const activeProjectStore = resolveProjectStore(projectStore);
-    const activeProjectName = resolveProjectName(projectName);
-    const promptInput: ReviewPromptInput = {
-      parts,
-      currentMemory: store.getMemoryEntries().join("\n§\n"),
-      currentUser: store.getUserEntries().join("\n§\n"),
-      currentProject: activeProjectStore ? activeProjectStore.getMemoryEntries().join("\n§\n") : null,
-    };
-
-    const subprocessPrompt = buildSubprocessReviewPrompt(promptInput);
-    const directPrompt = buildDirectReviewUserPrompt(promptInput);
-
-    const finishReview = () => {
-      reviewInProgress = false;
-      onReviewSettled?.();
-    };
 
     const notifyIfSaved = (saved: boolean) => {
+      if (sessionCancelled()) return;
       if (saved) {
         ctx.ui.notify("💾 Memory auto-reviewed and updated", "info");
       }
     };
 
+    const notifyTransportFailure = (directFailure: string, subprocessDetail: unknown) => {
+      if (sessionCancelled()) return;
+      ctx.ui.notify(
+        `Memory auto-review failed in both transports. Direct: ${diagnosticDetail(directFailure)}. `
+          + `Subprocess: ${diagnosticDetail(subprocessDetail)}. Check the active model/provider or set llmModelOverride.`,
+        "warning",
+      );
+    };
+
     const runReview = async (): Promise<void> => {
+      if (sessionCancelled()) return;
+
+      let allParts: string[] = [];
+      try {
+        const entries = ctx.sessionManager.getBranch();
+        allParts = collectMessageParts(entries);
+      } catch {
+        return;
+      }
+      if (allParts.length < 4) return;
+      if (sessionCancelled()) return;
+
+      const parts = applyRecentMessageLimit(allParts, config.reviewRecentMessages);
+      const activeProjectStore = resolveProjectStore(projectStore);
+      const activeProjectName = resolveProjectName(projectName);
+      const promptInput: ReviewPromptInput = {
+        parts,
+        currentMemory: store.getMemoryEntries().join("\n§\n"),
+        currentUser: store.getUserEntries().join("\n§\n"),
+        currentProject: activeProjectStore ? activeProjectStore.getMemoryEntries().join("\n§\n") : null,
+      };
+      const subprocessPrompt = buildSubprocessReviewPrompt(promptInput);
+      const directPrompt = buildDirectReviewUserPrompt(promptInput);
+
       let directFailure: string | undefined;
 
       if (usesDirectTransport(config)) {
@@ -239,17 +285,20 @@ export function setupBackgroundReview(
               ].join("\n"),
               config,
               timeoutMs: 120000,
+              signal: sessionAbort.signal,
             },
             dbManager,
             activeProjectName,
           );
+
+          if (sessionCancelled()) return;
 
           if (directResult.ok) {
             notifyIfSaved(shouldNotifyDirect(directResult));
             return;
           }
 
-          if (directResult.fallbackReason === "empty") {
+          if (directResult.fallbackReason === "empty" || directResult.fallbackReason === "aborted") {
             return;
           }
           directFailure = [
@@ -257,41 +306,51 @@ export function setupBackgroundReview(
             directResult.error,
           ].filter(Boolean).join(": ");
         } catch (error) {
+          if (sessionCancelled()) return;
           directFailure = diagnosticDetail(error);
         }
       }
 
+      if (sessionCancelled()) return;
+
       let subprocessResult: { code: number; stdout?: string; stderr?: string };
       try {
-        subprocessResult = await runSubprocessReview(pi, subprocessPrompt, config, execChild, ctx);
+        subprocessResult = await runSubprocessReview(
+          pi,
+          subprocessPrompt,
+          config,
+          execChild,
+          ctx,
+          sessionAbort.signal,
+        );
       } catch (error) {
         if (directFailure) {
-          ctx.ui.notify(
-            `Memory auto-review failed in both transports. Direct: ${diagnosticDetail(directFailure)}. `
-              + `Subprocess: ${diagnosticDetail(error)}. Check the active model/provider or set llmModelOverride.`,
-            "warning",
-          );
+          notifyTransportFailure(directFailure, error);
         }
         return;
       }
+
+      if (sessionCancelled()) return;
 
       if (subprocessResult.code === 0) {
         notifyIfSaved(shouldNotifySubprocess(subprocessResult.stdout));
       } else if (directFailure) {
         const subprocessDetail = subprocessResult.stderr?.trim() || subprocessResult.stdout?.trim()
           || `exit code ${subprocessResult.code}`;
-        ctx.ui.notify(
-          `Memory auto-review failed in both transports. Direct: ${diagnosticDetail(directFailure)}. `
-            + `Subprocess: ${diagnosticDetail(subprocessDetail)}. Check the active model/provider or set llmModelOverride.`,
-          "warning",
-        );
+        notifyTransportFailure(directFailure, subprocessDetail);
       }
     };
 
-    runReview()
+    // Occupy the in-flight slot before runReview's synchronous preamble so a
+    // nested turn_end cannot start a second review.
+    activeReview = Promise.resolve()
+      .then(() => runReview())
       .catch(() => {
         // Best-effort only; transport failures are diagnosed after both paths settle.
       })
-      .finally(finishReview);
+      .finally(() => {
+        activeReview = undefined;
+        onReviewSettled?.();
+      });
   });
 }

--- a/src/handlers/review-memory-ops.ts
+++ b/src/handlers/review-memory-ops.ts
@@ -22,6 +22,7 @@ export interface ApplyReviewOperationsResult {
   appliedCount: number;
   skippedCount: number;
   error?: string;
+  aborted?: boolean;
 }
 
 export interface DirectReviewResult {
@@ -246,6 +247,7 @@ export async function applyReviewOperations(
   options: {
     requireAtomicShrink?: boolean;
     expectedTarget?: ReviewMemoryOperation["target"];
+    signal?: AbortSignal;
   } = {},
 ): Promise<ApplyReviewOperationsResult> {
   if (options.requireAtomicShrink) {
@@ -280,6 +282,9 @@ export async function applyReviewOperations(
       };
     }
 
+    if (options.signal?.aborted) {
+      return { appliedCount: 0, skippedCount: operations.length, aborted: true };
+    }
     const activeStore = target === "project" ? projectStore! : store;
     const memoryTarget = target === "project" ? "memory" : target;
     const mutationOperations = operations.map((operation) => ({
@@ -290,7 +295,13 @@ export async function applyReviewOperations(
       failureReason: operation.failure_reason,
       project: target === "failure" ? projectName ?? undefined : undefined,
     }));
-    const result = await activeStore.applyMutationPlan(memoryTarget, mutationOperations, { requireShrink: true });
+    const result = await activeStore.applyMutationPlan(memoryTarget, mutationOperations, {
+      requireShrink: true,
+      signal: options.signal,
+    });
+    if (options.signal?.aborted && !result.success) {
+      return { appliedCount: 0, skippedCount: operations.length, aborted: true };
+    }
     return result.success
       ? { appliedCount: operations.length, skippedCount: 0 }
       : {
@@ -303,7 +314,12 @@ export async function applyReviewOperations(
   let appliedCount = 0;
   let skippedCount = 0;
 
-  for (const op of operations) {
+  for (let i = 0; i < operations.length; i++) {
+    if (options.signal?.aborted) {
+      skippedCount += operations.length - i;
+      return { appliedCount, skippedCount, aborted: appliedCount === 0 };
+    }
+    const op = operations[i];
     if (op.target === "project" && !projectStore) {
       skippedCount++;
       continue;
@@ -326,6 +342,7 @@ export async function applyReviewOperations(
             category,
             failureReason: op.failure_reason,
             project: projectName ?? undefined,
+            signal: options.signal,
           });
           if (result.success) {
             appliedCount++;
@@ -333,7 +350,7 @@ export async function applyReviewOperations(
             skippedCount++;
           }
         } else {
-          result = await activeStore.add(memoryTarget, op.content);
+          result = await activeStore.add(memoryTarget, op.content, options.signal);
           if (result.success) {
             appliedCount++;
           } else {
@@ -347,7 +364,7 @@ export async function applyReviewOperations(
           skippedCount++;
           continue;
         }
-        result = await activeStore.replace(memoryTarget, op.old_text, op.content);
+        result = await activeStore.replace(memoryTarget, op.old_text, op.content, options.signal);
         if (result.success) {
           appliedCount++;
         } else {
@@ -360,7 +377,7 @@ export async function applyReviewOperations(
           skippedCount++;
           continue;
         }
-        result = await activeStore.remove(memoryTarget, op.old_text);
+        result = await activeStore.remove(memoryTarget, op.old_text, options.signal);
         if (result.success) {
           appliedCount++;
         } else {
@@ -373,6 +390,10 @@ export async function applyReviewOperations(
         continue;
     }
 
+    if (options.signal?.aborted) {
+      skippedCount += operations.length - i - 1;
+      return { appliedCount, skippedCount, aborted: appliedCount === 0 };
+    }
   }
 
   return { appliedCount, skippedCount };
@@ -398,12 +419,16 @@ export async function runDirectMemoryCompletion(
   deps: { completeSimple?: typeof completeSimple } = {},
 ): Promise<DirectReviewResult> {
   const complete = deps.completeSimple ?? completeSimple;
+  const aborted = (): DirectReviewResult => ({ ok: false, appliedCount: 0, fallbackReason: "aborted" });
+  if (options.signal?.aborted) return aborted();
+
   const model = resolveReviewModel(ctx.model, ctx.modelRegistry, options.config);
   if (!model) {
     return { ok: false, appliedCount: 0, fallbackReason: "no_model" };
   }
 
   const auth = await resolveRequestAuth(ctx.modelRegistry, model);
+  if (options.signal?.aborted) return aborted();
   if (!auth.ok || !auth.apiKey) {
     return {
       ok: false,
@@ -417,8 +442,10 @@ export async function runDirectMemoryCompletion(
   const controller = new AbortController();
   const timeoutMs = options.timeoutMs ?? 120000;
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const onExternalAbort = () => controller.abort();
   if (options.signal) {
-    options.signal.addEventListener("abort", () => controller.abort(), { once: true });
+    options.signal.addEventListener("abort", onExternalAbort, { once: true });
+    if (options.signal.aborted) controller.abort();
   }
 
   const thinking = effectiveThinkingOverride(options.config);
@@ -457,8 +484,8 @@ export async function runDirectMemoryCompletion(
       );
     }
 
-    if (response.stopReason === "aborted") {
-      return { ok: false, appliedCount: 0, fallbackReason: "aborted" };
+    if (response.stopReason === "aborted" || controller.signal.aborted || options.signal?.aborted) {
+      return aborted();
     }
 
     const text = responseText(response.content);
@@ -468,6 +495,9 @@ export async function runDirectMemoryCompletion(
     }
     if (operations.length === 0) {
       return { ok: true, appliedCount: 0, fallbackReason: "empty" };
+    }
+    if (controller.signal.aborted || options.signal?.aborted) {
+      return aborted();
     }
 
     const applied = await applyReviewOperations(
@@ -479,8 +509,12 @@ export async function runDirectMemoryCompletion(
       {
         requireAtomicShrink: options.requireAtomicShrink,
         expectedTarget: options.expectedTarget,
+        signal: options.signal,
       },
     );
+    if (applied.aborted && applied.appliedCount === 0) {
+      return aborted();
+    }
     if (applied.error) {
       return {
         ok: false,
@@ -491,8 +525,8 @@ export async function runDirectMemoryCompletion(
     }
     return { ok: true, appliedCount: applied.appliedCount };
   } catch (err) {
-    if (controller.signal.aborted) {
-      return { ok: false, appliedCount: 0, fallbackReason: "aborted" };
+    if (controller.signal.aborted || options.signal?.aborted) {
+      return aborted();
     }
     return {
       ok: false,
@@ -502,5 +536,6 @@ export async function runDirectMemoryCompletion(
     };
   } finally {
     clearTimeout(timeout);
+    options.signal?.removeEventListener("abort", onExternalAbort);
   }
 }

--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -190,10 +190,11 @@ export class MemoryStore {
     toolState?: string;
     correctedTo?: string;
     project?: string;
+    signal?: AbortSignal;
   }): Promise<MemoryResult> {
     const failureText = this.buildFailureMemoryText(content, options);
     return this.addWithConsolidation(
-      "failure", failureText, undefined, 1, "Failure memory saved: " + options.category, options.project,
+      "failure", failureText, options.signal, 1, "Failure memory saved: " + options.category, options.project,
     );
   }
 
@@ -276,6 +277,7 @@ export class MemoryStore {
     const result = await this.runTargetMutation(
       target,
       (markMutation) => this._add(target, content, signal, addedMessage, project, markMutation),
+      signal,
     );
     if (
       result.success
@@ -374,7 +376,7 @@ export class MemoryStore {
   async applyMutationPlan(
     target: "memory" | "user" | "failure",
     operations: MemoryMutationOperation[],
-    options: { requireShrink?: boolean } = {},
+    options: { requireShrink?: boolean; signal?: AbortSignal } = {},
   ): Promise<MemoryResult> {
     return this.runTargetMutation(target, async (markMutation) => {
       await this.syncTargetFromDiskIfChanged(target);
@@ -457,13 +459,14 @@ export class MemoryStore {
       await this.saveToDisk(target);
       markMutation();
       return this.successResponse(target, `Applied ${operations.length} memory operations atomically.`);
-    });
+    }, options.signal);
   }
 
-  async replace(target: "memory" | "user" | "failure", oldText: string, newContent: string): Promise<MemoryResult> {
+  async replace(target: "memory" | "user" | "failure", oldText: string, newContent: string, signal?: AbortSignal): Promise<MemoryResult> {
     return this.runTargetMutation(
       target,
       (markMutation) => this.replaceUnlocked(target, oldText, newContent, markMutation),
+      signal,
     );
   }
 
@@ -520,10 +523,11 @@ export class MemoryStore {
     return this.successResponse(target, "Entry replaced.");
   }
 
-  async remove(target: "memory" | "user" | "failure", oldText: string): Promise<MemoryResult> {
+  async remove(target: "memory" | "user" | "failure", oldText: string, signal?: AbortSignal): Promise<MemoryResult> {
     return this.runTargetMutation(
       target,
       (markMutation) => this.removeUnlocked(target, oldText, markMutation),
+      signal,
     );
   }
 
@@ -839,10 +843,14 @@ export class MemoryStore {
   private async runTargetMutation(
     target: "memory" | "user" | "failure",
     mutation: (markMutation: () => void) => Promise<MemoryResult>,
+    signal?: AbortSignal,
   ): Promise<MemoryResult> {
     const storagePath = await this.resolveStoragePath(target);
     return withMarkdownMutationLock(storagePath, async () => {
       for (let attempt = 0; ; attempt++) {
+        if (signal?.aborted) {
+          return { success: false, error: "Memory mutation cancelled." };
+        }
         let mutated = false;
         try {
           const result = await mutation(() => {

--- a/tests/handlers/background-review.test.ts
+++ b/tests/handlers/background-review.test.ts
@@ -771,7 +771,7 @@ describe("setupBackgroundReview", () => {
     assert.strictEqual(directCalls.length, 1, "direct review should be attempted first");
     assert.strictEqual(execCalls.length, 1, "subprocess should run as fallback");
   });
-  it("inherits the active session model and execution context for subprocess fallback", async () => {
+  it("inherits the active session model and cwd without coupling fallback to the agent run signal", async () => {
     const pi = createMockPi();
     setupWithDirectDeps(pi, { ok: false, appliedCount: 0, fallbackReason: "no_auth" }, {
       ...defaultConfig,
@@ -781,14 +781,15 @@ describe("setupBackgroundReview", () => {
     fireMessageEnd("user");
     fireMessageEnd("user");
     fireMessageEnd("user");
-    const signal = new AbortController().signal;
+    const controller = new AbortController();
     for (let i = 0; i < 10; i++) {
       fireTurnEnd(makeBranch(10), {
         cwd: "/tmp/local-session",
         model: { provider: "local-llama", id: "local-9b" },
-        signal,
+        signal: controller.signal,
       });
     }
+    controller.abort();
     await reviewSettledSignal.promise;
 
     assert.deepStrictEqual(logicalChildArgs(0).slice(0, 5), [
@@ -917,6 +918,161 @@ describe("setupBackgroundReview", () => {
     assert.doesNotMatch(directPrompt, /save using memory_add/i);
     assert.ok(subprocessPrompt.includes("uses pnpm"));
     assert.ok(directPrompt.includes("monorepo layout"));
+  });
+
+  it("does not forward the turn abort signal to the child review", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    const childGate = Promise.withResolvers<void>();
+    const pi = createMockPi();
+    setup(pi, defaultConfig, {
+      execChildPrompt: async (_api, _prompt, _config, options) => {
+        capturedSignal = options.signal;
+        await childGate.promise;
+        return { code: 0, stdout: "Saved memory", stderr: "" };
+      },
+    });
+
+    fireMessageEnd("user");
+    fireMessageEnd("user");
+    fireMessageEnd("user");
+    const turnAbort = new AbortController();
+    for (let i = 0; i < 10; i++) {
+      fireTurnEnd(makeBranch(10), { signal: turnAbort.signal });
+    }
+    await settle(5);
+
+    assert.ok(capturedSignal, "child review must receive a session signal");
+    assert.notStrictEqual(capturedSignal, turnAbort.signal);
+    turnAbort.abort();
+    await settle(5);
+    assert.equal(capturedSignal.aborted, false, "turn abort must not cancel session review");
+
+    childGate.resolve();
+    await reviewSettledSignal.promise;
+  });
+
+  it("session_shutdown aborts the child signal, waits for review, and stays silent", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    const childGate = Promise.withResolvers<void>();
+    let childStarted = 0;
+    const pi = createMockPi();
+    setup(pi, defaultConfig, {
+      execChildPrompt: async (_api, _prompt, _config, options) => {
+        childStarted++;
+        capturedSignal = options.signal;
+        await childGate.promise;
+        return { code: 0, stdout: "Saved memory", stderr: "" };
+      },
+    });
+
+    fireMessageEnd("user");
+    fireMessageEnd("user");
+    fireMessageEnd("user");
+    for (let i = 0; i < 10; i++) {
+      fireTurnEnd();
+    }
+    await settle(5);
+    assert.ok(capturedSignal);
+    assert.equal(capturedSignal.aborted, false);
+
+    const shutdownHandlers = handlers["session_shutdown"];
+    assert.ok(shutdownHandlers?.length, "session_shutdown handler must be registered");
+    const first = shutdownHandlers[0]({}, makeCtx());
+    const second = shutdownHandlers[0]({}, makeCtx());
+    assert.strictEqual(first, second, "repeated session_shutdown must reuse the same promise");
+    assert.equal(capturedSignal.aborted, true);
+
+    let shutdownDone = false;
+    void Promise.resolve(first).then(() => {
+      shutdownDone = true;
+    });
+    await settle(5);
+    assert.equal(shutdownDone, false, "shutdown must wait for the in-flight review");
+
+    childGate.resolve();
+    await first;
+    await reviewSettledSignal.promise;
+    assert.equal(shutdownDone, true);
+    assert.equal(
+      notifyCalls.some((n) => n.msg.includes("Memory auto-reviewed") || n.level === "warning"),
+      false,
+      "cancelled review must not notify success or failure",
+    );
+
+    resetReviewSettledSignal();
+    for (let i = 0; i < 10; i++) {
+      fireTurnEnd();
+    }
+    await settle(10);
+    assert.equal(childStarted, 1, "cancelled session must not start another review");
+  });
+
+  it("does not start fallback after session cancellation", async () => {
+    const directGate = Promise.withResolvers<void>();
+    let childStarted = 0;
+    const pi = createMockPi();
+    setup(pi, { ...defaultConfig, reviewTransport: "direct" } as MemoryConfig, {
+      runDirectReview: async () => {
+        await directGate.promise;
+        return { ok: true, appliedCount: 1 };
+      },
+      execChildPrompt: async () => {
+        childStarted++;
+        return { code: 0, stdout: "Saved memory", stderr: "" };
+      },
+    });
+
+    fireMessageEnd("user");
+    fireMessageEnd("user");
+    fireMessageEnd("user");
+    for (let i = 0; i < 10; i++) {
+      fireTurnEnd();
+    }
+    await settle(5);
+
+    const shutdown = handlers["session_shutdown"][0]({}, makeCtx());
+    directGate.resolve();
+    await shutdown;
+    await reviewSettledSignal.promise;
+
+    assert.equal(childStarted, 0, "cancelled session must not start subprocess fallback");
+    assert.equal(
+      notifyCalls.some((n) => n.msg.includes("Memory auto-reviewed") || n.level === "warning"),
+      false,
+    );
+  });
+
+  it("session_shutdown resolves after the grace bound when review ignores abort", async () => {
+    let started = false;
+    const pi = createMockPi();
+    setup(pi, { ...defaultConfig, reviewTransport: "direct" } as MemoryConfig, {
+      shutdownGraceMs: 20,
+      runDirectReview: async () => {
+        started = true;
+        await new Promise(() => {});
+        return { ok: true, appliedCount: 1 };
+      },
+    });
+
+    fireMessageEnd("user");
+    fireMessageEnd("user");
+    fireMessageEnd("user");
+    for (let i = 0; i < 10; i++) {
+      fireTurnEnd();
+    }
+    await settle(5);
+    assert.equal(started, true);
+
+    const first = handlers["session_shutdown"][0]({}, makeCtx());
+    const second = handlers["session_shutdown"][0]({}, makeCtx());
+    assert.strictEqual(first, second);
+    const startedAt = Date.now();
+    await first;
+    assert.ok(Date.now() - startedAt < 200, "shutdown must not wait for a review that ignores abort");
+    assert.equal(
+      notifyCalls.some((n) => n.msg.includes("Memory auto-reviewed") || n.level === "warning"),
+      false,
+    );
   });
 
   it("falls back gracefully if getBranch throws", async () => {

--- a/tests/handlers/review-memory-ops.test.ts
+++ b/tests/handlers/review-memory-ops.test.ts
@@ -14,6 +14,8 @@ import {
 } from "../../src/handlers/review-memory-ops.js";
 import { DatabaseManager } from "../../src/store/db.js";
 import { getMemories, reconcileMarkdownMemoryScope } from "../../src/store/sqlite-memory-store.js";
+import { acquireMarkdownMutationLock } from "../../src/store/markdown-mutation-lock.js";
+import { MEMORY_FILE } from "../../src/constants.js";
 
 function mockModel(reasoning: boolean): Model<Api> {
   return {
@@ -573,6 +575,160 @@ describe("applyReviewOperations", () => {
     assert.strictEqual(result.appliedCount, 0);
     assert.match(result.error ?? "", /No entry matched 'missing later entry'/);
     assert.deepStrictEqual(store.getMemoryEntries(), beforeEntries);
+  });
+
+  it("skips auth, provider, and store work when the external signal is already aborted", async () => {
+    let authCalls = 0;
+    let completeCalls = 0;
+    let mutated = false;
+    const controller = new AbortController();
+    controller.abort();
+    const store = {
+      add: async () => {
+        mutated = true;
+        return { success: true };
+      },
+    };
+    const modelRegistry = {
+      getApiKeyAndHeaders: async () => {
+        authCalls++;
+        return { ok: true as const, apiKey: "test-key" };
+      },
+      getAll: () => [mockModel(false)],
+      getAvailable: () => [mockModel(false)],
+    };
+
+    const result = await runDirectMemoryCompletion(
+      { model: mockModel(false), modelRegistry } as never,
+      store as never,
+      null,
+      {
+        userPrompt: "u",
+        systemPrompt: "s",
+        config: {},
+        signal: controller.signal,
+      },
+      null,
+      null,
+      {
+        completeSimple: (async () => {
+          completeCalls++;
+          return {
+            stopReason: "stop",
+            content: [{ type: "text", text: JSON.stringify({ operations: [{ action: "add", target: "memory", content: "late" }] }) }],
+          };
+        }) as never,
+      },
+    );
+
+    assert.deepStrictEqual(result, { ok: false, appliedCount: 0, fallbackReason: "aborted" });
+    assert.equal(authCalls, 0);
+    assert.equal(completeCalls, 0);
+    assert.equal(mutated, false);
+  });
+
+  it("does not apply operations when the provider ignores abort and returns success", async () => {
+    const store = new MemoryStore({
+      memoryDir: tmpDir,
+      memoryCharLimit: 5000,
+      userCharLimit: 5000,
+      autoConsolidate: true,
+    });
+    await store.loadFromDisk();
+    const controller = new AbortController();
+    const modelRegistry = {
+      getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: "test-key" }),
+      getAll: () => [mockModel(false)],
+      getAvailable: () => [mockModel(false)],
+    };
+    const complete = async () => {
+      controller.abort();
+      return {
+        stopReason: "stop",
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            operations: [{ action: "add", target: "memory", content: "should not persist after cancel" }],
+          }),
+        }],
+      };
+    };
+
+    const result = await runDirectMemoryCompletion(
+      { model: mockModel(false), modelRegistry } as never,
+      store,
+      null,
+      {
+        userPrompt: "u",
+        systemPrompt: "s",
+        config: {},
+        signal: controller.signal,
+      },
+      null,
+      null,
+      { completeSimple: complete as never },
+    );
+
+    assert.deepStrictEqual(result, { ok: false, appliedCount: 0, fallbackReason: "aborted" });
+    assert.equal(store.getMemoryEntries().some((entry) => entry.includes("should not persist after cancel")), false);
+  });
+
+  it("does not write after abort while waiting for the markdown mutation lock", async () => {
+    const store = new MemoryStore({
+      memoryDir: tmpDir,
+      memoryCharLimit: 5000,
+      userCharLimit: 5000,
+      autoConsolidate: true,
+    });
+    await store.loadFromDisk();
+    const controller = new AbortController();
+    const modelRegistry = {
+      getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: "test-key" }),
+      getAll: () => [mockModel(false)],
+      getAvailable: () => [mockModel(false)],
+    };
+    const completeEntered = Promise.withResolvers<void>();
+    const continueComplete = Promise.withResolvers<void>();
+    const complete = async () => {
+      completeEntered.resolve();
+      await continueComplete.promise;
+      return {
+        stopReason: "stop",
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            operations: [{ action: "add", target: "memory", content: "late-after-shutdown" }],
+          }),
+        }],
+      };
+    };
+    const lease = await acquireMarkdownMutationLock(path.join(tmpDir, MEMORY_FILE));
+    try {
+      const completion = runDirectMemoryCompletion(
+        { model: mockModel(false), modelRegistry } as never,
+        store,
+        null,
+        {
+          userPrompt: "u",
+          systemPrompt: "s",
+          config: {},
+          signal: controller.signal,
+        },
+        null,
+        null,
+        { completeSimple: complete as never },
+      );
+      await completeEntered.promise;
+      continueComplete.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      controller.abort();
+      lease.release();
+      const result = await completion;
+      assert.deepStrictEqual(result, { ok: false, appliedCount: 0, fallbackReason: "aborted" });
+      assert.equal(store.getMemoryEntries().some((entry) => entry.includes("late-after-shutdown")), false);
+    } finally {
+      lease.release();
+    }
   });
 
   it("uses the in-lock mutation observer as the sole SQLite reconciliation path", async () => {


### PR DESCRIPTION
## Summary

- decouple fire-and-forget memory review from the active interactive turn's abort signal
- give background review one session-scoped `AbortController` shared by direct and subprocess transports
- abort and boundedly await active review from an idempotent `session_shutdown` handler
- suppress fallback, stale memory writes, and stale UI notifications after session cancellation
- guard direct review before provider work and again at the memory mutation boundary

## Root cause

Background review deliberately outlives the interactive turn that triggered it, but its subprocess fallback forwarded `ctx.signal`. Aborting that turn therefore cancelled unrelated review work. Simply removing the signal fixed turn coupling but also removed session ownership, allowing old review work to survive reload, session replacement, fork, or shutdown.

The updated implementation uses a dedicated signal for the lifetime of the session. Shutdown aborts it and waits up to a local one-second cleanup grace; normal review execution retains its independent 120-second timeout. Cancellation is also rechecked after acquiring the Markdown mutation lock so an old session cannot begin a queued memory write after shutdown.

## Verification

- focused background-review, direct-completion, and MemoryStore tests passed
- `npm run check`
- `npm test` — all 50 test files passed
- `npm run check:min-sdk` — source type-checks against Pi SDK 0.80.6
- `git diff --check`
- regressions prove turn abort is ignored, session shutdown cancels and waits, shutdown remains bounded if a provider ignores abort, cancelled work stays silent, fallback does not start, and a queued memory mutation cannot write after cancellation
