### PR TITLE
fix: skip reload flush and add lifecycle timings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Opt-in memory lifecycle timings**: `PI_TIMING=1` now reports startup synchronization and loading, backfill and live-index callbacks, shutdown flush/index/wait/close, and database open/integrity-check/checkpoint durations. Normal runs produce no timing output.
+
 ### Fixed
 
+- **Reload no longer waits for an unnecessary LLM memory flush**: Pi preserves the current session during `/reload`, but the shutdown handler ignored `event.reason` and awaited direct completion plus possible subprocess fallback after six user turns. Reload now skips both transports; quit and session-replacement reasons keep the existing flush policy.
 - **Portable child extension sources were discarded before Pi could resolve them**: `childExtensionPaths` ran every configured value through Node's cwd-relative `path.resolve()` and required that resulting local path to already exist. This silently dropped Pi-native `~/...`, `git:...`, and `npm:...` extension sources, forcing machine-specific absolute paths for custom providers in isolated subprocesses. Configured sources are now passed unchanged to Pi's standard `-e` resolver, while Hermes-discovered auth adapter paths retain their local existence checks.
 
 ## [0.9.4] - 2026-08-08

--- a/README.md
+++ b/README.md
@@ -558,6 +558,24 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 | `flushMinTurns` | `6` | Minimum turns before flush triggers |
 | `flushRecentMessages` | `0` | Recent messages included in session flush (`0` = all) |
 
+## Diagnosing lifecycle latency
+
+Run Pi with timing enabled to see which memory lifecycle step is slow:
+
+```bash
+PI_TIMING=1 pi
+```
+
+`pi-hermes-memory` writes these spans to stderr only when timing is enabled:
+
+- `session-start.persistence-sync` and `session-start.load`
+- `session-backfill.check` and `session-backfill.callback`
+- `live-index.callback`
+- `shutdown.flush`, `shutdown.active-index`, `shutdown.index-waits`, and `shutdown.database-close`
+- `database.open`, `database.quick-check`, and `database.checkpoint`
+
+The deferred backfill, live-index, and integrity-check spans may appear after startup spans because they run on later timer turns. `/reload` does not run `shutdown.flush`; other shutdown reasons keep the configured direct completion and subprocess fallback. Use the measured spans before changing indexing, checkpoint, or synchronization policy.
+
 ## Where Data Lives
 
 ```

--- a/src/handlers/session-backfill.ts
+++ b/src/handlers/session-backfill.ts
@@ -1,3 +1,4 @@
+import { measureLifecycleSync } from '../lifecycle-timing.js';
 import type { DatabaseManager } from '../store/db.js';
 import {
   indexChangedSessions,
@@ -74,7 +75,10 @@ export function scheduleSessionBackfill(
   }
 
   try {
-    if (!needsBackfillFn(dbManager, sessionsDir)) {
+    if (!measureLifecycleSync(
+      'session-backfill.check',
+      () => needsBackfillFn(dbManager, sessionsDir),
+    )) {
       return false;
     }
   } catch (err) {
@@ -89,21 +93,23 @@ export function scheduleSessionBackfill(
   state.inProgress = true;
   state.promise = new Promise<void>((resolve) => {
     setTimeoutFn(() => {
-      try {
-        const result = indexSessionsFn(dbManager, sessionsDir, { maxFilesToIndex });
-        if (!result.reachedLimit) touchBackfillTimestampFn(dbManager);
-        notifyBestEffort(options.notify, formatBackfillResult(result), result.errors.length > 0 || result.reachedLimit ? 'warning' : 'info');
-      } catch (err) {
-        notifyBestEffort(
-          options.notify,
-          `⚠️ Session backfill failed: ${err instanceof Error ? err.message : String(err)}`,
-          'warning',
-        );
-      } finally {
-        state.inProgress = false;
-        state.promise = null;
-        resolve();
-      }
+      measureLifecycleSync('session-backfill.callback', () => {
+        try {
+          const result = indexSessionsFn(dbManager, sessionsDir, { maxFilesToIndex });
+          if (!result.reachedLimit) touchBackfillTimestampFn(dbManager);
+          notifyBestEffort(options.notify, formatBackfillResult(result), result.errors.length > 0 || result.reachedLimit ? 'warning' : 'info');
+        } catch (err) {
+          notifyBestEffort(
+            options.notify,
+            `⚠️ Session backfill failed: ${err instanceof Error ? err.message : String(err)}`,
+            'warning',
+          );
+        } finally {
+          state.inProgress = false;
+          state.promise = null;
+          resolve();
+        }
+      });
     }, 0);
   });
 

--- a/src/handlers/session-flush.ts
+++ b/src/handlers/session-flush.ts
@@ -18,6 +18,7 @@ import {
   FLUSH_PROMPT,
 } from "../constants.js";
 import type { MemoryConfig } from "../types.js";
+import { measureLifecycle } from "../lifecycle-timing.js";
 import { collectMessageParts } from "./message-parts.js";
 import { execChildPrompt, resolveChildPiModel } from "./pi-child-process.js";
 import { runDirectMemoryCompletion, usesDirectTransport } from "./review-memory-ops.js";
@@ -143,8 +144,8 @@ export function setupSessionFlush(
 
   // Flush before session shutdown. Pi awaits async session_shutdown handlers
   // before invalidating the session, so await the bounded flush here.
-  pi.on("session_shutdown", async (_event, ctx) => {
-    if (!config.flushOnShutdown) return;
-    await flush(ctx, undefined, 10000);
+  pi.on("session_shutdown", async (event, ctx) => {
+    if (!config.flushOnShutdown || event.reason === "reload") return;
+    await measureLifecycle("shutdown.flush", () => flush(ctx, undefined, 10000));
   });
 }

--- a/src/handlers/session-live-index.ts
+++ b/src/handlers/session-live-index.ts
@@ -1,3 +1,4 @@
+import { measureLifecycleSync } from '../lifecycle-timing.js';
 import type { DatabaseManager } from '../store/db.js';
 import { indexLiveSession } from '../store/session-indexer.js';
 
@@ -51,17 +52,19 @@ export function scheduleLiveSessionIndex(
   state.inProgress = true;
   state.promise = new Promise<void>((resolve) => {
     setTimeoutFn(() => {
-      try {
-        dbManager.withCorruptionRecovery(() => {
-          indexLiveSessionFn(dbManager, sessionManager);
-        });
-      } catch (err) {
-        try { options.onError?.(err); } catch { /* best effort */ }
-      } finally {
-        state.inProgress = false;
-        state.promise = null;
-        resolve();
-      }
+      measureLifecycleSync('live-index.callback', () => {
+        try {
+          dbManager.withCorruptionRecovery(() => {
+            indexLiveSessionFn(dbManager, sessionManager);
+          });
+        } catch (err) {
+          try { options.onError?.(err); } catch { /* best effort */ }
+        } finally {
+          state.inProgress = false;
+          state.promise = null;
+          resolve();
+        }
+      });
     }, delayMs);
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ import { buildPromptContext } from "./prompt-context.js";
 import { migrateLegacyProjectMemoryDirs } from "./project-memory-migration.js";
 import { AGENT_ROOT } from "./paths.js";
 import { isDatabaseMigrationPending } from "./extension-root-migration.js";
+import { measureLifecycle, measureLifecycleSync } from "./lifecycle-timing.js";
 
 export function resolveProjectSkillDiscovery(
   skillStore: SkillStore,
@@ -167,41 +168,45 @@ export default function (pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     if (!persistenceInitialized) {
       try {
-        await migrateThenSyncMarkdownMemories(
-          dbManager,
-          shouldMigrateExtensionRoot ? legacyGlobalDir : null,
-          globalDir,
-          config.projectsMemoryDir,
-          agentRoot,
-          {
-            onMigrationSucceeded: () => {
-              databaseMigrationPending = false;
-              dbManager.setOpenGuard(null);
+        await measureLifecycle("session-start.persistence-sync", async () => {
+          await migrateThenSyncMarkdownMemories(
+            dbManager,
+            shouldMigrateExtensionRoot ? legacyGlobalDir : null,
+            globalDir,
+            config.projectsMemoryDir,
+            agentRoot,
+            {
+              onMigrationSucceeded: () => {
+                databaseMigrationPending = false;
+                dbManager.setOpenGuard(null);
+              },
             },
-          },
-        );
+          );
+        });
         persistenceInitialized = true;
       } catch {
         // Best-effort only: migration or SQLite backfill must not block startup.
       }
     }
 
-    const nextProject = detectProject(config.projectsMemoryDir, ctx.cwd);
-    const nextProjectMemoryDir = nextProject.memoryDir ?? null;
-    if (nextProjectMemoryDir !== projectMemoryDir) {
-      projectMemoryDir = nextProjectMemoryDir;
-      projectStore = createProjectStore(nextProject);
-      configureProjectStore(projectStore);
-      configureMemoryToolProjectStore(projectStore);
-    }
-    project = nextProject;
-    projectName = nextProject.name ?? "";
-    refreshSkillProjectContext(ctx.cwd);
-    await skillStore.migrateLegacySkills();
-    await skillStore.ensureDiscoveredRoots();
-    await store.loadFromDisk();
-    if (projectStore) await projectStore.loadFromDisk();
-    if (standingStore) await standingStore.load();
+    await measureLifecycle("session-start.load", async () => {
+      const nextProject = detectProject(config.projectsMemoryDir, ctx.cwd);
+      const nextProjectMemoryDir = nextProject.memoryDir ?? null;
+      if (nextProjectMemoryDir !== projectMemoryDir) {
+        projectMemoryDir = nextProjectMemoryDir;
+        projectStore = createProjectStore(nextProject);
+        configureProjectStore(projectStore);
+        configureMemoryToolProjectStore(projectStore);
+      }
+      project = nextProject;
+      projectName = nextProject.name ?? "";
+      refreshSkillProjectContext(ctx.cwd);
+      await skillStore.migrateLegacySkills();
+      await skillStore.ensureDiscoveredRoots();
+      await store.loadFromDisk();
+      if (projectStore) await projectStore.loadFromDisk();
+      if (standingStore) await standingStore.load();
+    });
 
     if (persistenceInitialized) scheduleSessionBackfill(dbManager, sessionsDir, {
       notify: (message, level) => {
@@ -319,32 +324,36 @@ export default function (pi: ExtensionAPI) {
   // close() and silently no-op.
   pi.on("session_shutdown", async (_event, ctx) => {
     try {
-      const sessionFile = ctx.sessionManager.getSessionFile();
-      if (sessionFile && require("node:fs").existsSync(sessionFile)) {
-        const sessionData = parseSessionFile(sessionFile);
-        if (sessionData) {
-          dbManager.withCorruptionRecovery(() => {
-            indexSession(dbManager, sessionData);
-            // Keep session_files metadata in sync with the final on-disk state.
-            // Pi appends the closing session entry on shutdown after the last
-            // message_end, so without this upsert the stored size/mtime would be
-            // stale and the next startup would re-parse this file unnecessarily.
-            upsertSessionFileMetadata(dbManager, sessionFile, sessionData.id);
-          });
+      measureLifecycleSync("shutdown.active-index", () => {
+        const sessionFile = ctx.sessionManager.getSessionFile();
+        if (sessionFile && require("node:fs").existsSync(sessionFile)) {
+          const sessionData = parseSessionFile(sessionFile);
+          if (sessionData) {
+            dbManager.withCorruptionRecovery(() => {
+              indexSession(dbManager, sessionData);
+              // Keep session_files metadata in sync with the final on-disk state.
+              // Pi appends the closing session entry on shutdown after the last
+              // message_end, so without this upsert the stored size/mtime would be
+              // stale and the next startup would re-parse this file unnecessarily.
+              upsertSessionFileMetadata(dbManager, sessionFile, sessionData.id);
+            });
+          }
         }
-      }
+      });
     } catch {
       // Silent fail — don't block shutdown
     } finally {
       try {
-        await Promise.all([
+        await measureLifecycle("shutdown.index-waits", () => Promise.all([
           waitForSessionBackfill(SESSION_BACKFILL_SHUTDOWN_TIMEOUT_MS),
           waitForLiveSessionIndex(SESSION_LIVE_INDEX_SHUTDOWN_TIMEOUT_MS),
-        ]);
+        ]));
       } catch {
         // Best effort only — shutdown should not be held up by indexing errors.
       }
-      try { dbManager.close(); } catch { /* best effort — never block shutdown */ }
+      try {
+        measureLifecycleSync("shutdown.database-close", () => dbManager.close());
+      } catch { /* best effort — never block shutdown */ }
     }
   });
 }

--- a/src/lifecycle-timing.ts
+++ b/src/lifecycle-timing.ts
@@ -1,0 +1,54 @@
+export interface LifecycleTimingOptions {
+  enabled?: boolean;
+  now?: () => number;
+  log?: (line: string) => void;
+}
+
+function isEnabled(options: LifecycleTimingOptions): boolean {
+  return options.enabled ?? process.env.PI_TIMING === "1";
+}
+
+function recordDuration(
+  label: string,
+  startedAt: number,
+  options: LifecycleTimingOptions,
+): void {
+  try {
+    const now = options.now ?? Date.now;
+    const log = options.log ?? ((line: string) => console.error(line));
+    const durationMs = Math.max(0, Math.round(now() - startedAt));
+    log(`[pi-hermes-memory timing] ${label}: ${durationMs}ms`);
+  } catch {
+    // Profiling must not alter lifecycle behavior.
+  }
+}
+
+export function measureLifecycleSync<T>(
+  label: string,
+  operation: () => T,
+  options: LifecycleTimingOptions = {},
+): T {
+  if (!isEnabled(options)) return operation();
+  const now = options.now ?? Date.now;
+  const startedAt = now();
+  try {
+    return operation();
+  } finally {
+    recordDuration(label, startedAt, options);
+  }
+}
+
+export async function measureLifecycle<T>(
+  label: string,
+  operation: () => Promise<T>,
+  options: LifecycleTimingOptions = {},
+): Promise<T> {
+  if (!isEnabled(options)) return operation();
+  const now = options.now ?? Date.now;
+  const startedAt = now();
+  try {
+    return await operation();
+  } finally {
+    recordDuration(label, startedAt, options);
+  }
+}

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -5,6 +5,7 @@ import { SCHEMA_SQL } from './schema.js';
 import { AtomicLockCoordinator } from './atomic-lock-coordinator.js';
 import { canonicalStoragePathSync } from './canonical-storage-path.js';
 import { isBunRuntime, loadBetterSqlite3 } from './sqlite-native.js';
+import { measureLifecycleSync } from '../lifecycle-timing.js';
 
 type StatementLike = {
   run: (...args: any[]) => any;
@@ -263,36 +264,38 @@ export class DatabaseManager {
    * Open the database and initialize schema.
    */
   private open(): DatabaseLike {
-    const dir = path.dirname(this.dbPath);
-    if (!fs.existsSync(dir)) {
-      fs.mkdirSync(dir, { recursive: true });
-    }
-
-    let opened: DatabaseLike;
-    try {
-      opened = this.openUnchecked();
-    } catch (err) {
-      if (!DatabaseManager.isCorruptionError(err)) {
-        throw err;
+    return measureLifecycleSync('database.open', () => {
+      const dir = path.dirname(this.dbPath);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
       }
 
-      let recoveredDb: DatabaseLike | null = null;
-      let recovery: DatabaseRecoveryResult;
+      let opened: DatabaseLike;
       try {
-        recovery = this.recoverDatabaseFile(err, () => {
-          recoveredDb = this.openUnchecked();
-        });
-      } catch (error) {
-        if (recoveredDb) this.safeClose(recoveredDb);
-        throw error;
-      }
-      this.lastRecovery = recovery;
-      if (!recoveredDb) throw new Error(`SQLite recovery verification did not open ${this.displayDbPath}`);
-      return recoveredDb;
-    }
+        opened = this.openUnchecked();
+      } catch (err) {
+        if (!DatabaseManager.isCorruptionError(err)) {
+          throw err;
+        }
 
-    this.scheduleOpenIntegrityScan(opened);
-    return opened;
+        let recoveredDb: DatabaseLike | null = null;
+        let recovery: DatabaseRecoveryResult;
+        try {
+          recovery = this.recoverDatabaseFile(err, () => {
+            recoveredDb = this.openUnchecked();
+          });
+        } catch (error) {
+          if (recoveredDb) this.safeClose(recoveredDb);
+          throw error;
+        }
+        this.lastRecovery = recovery;
+        if (!recoveredDb) throw new Error(`SQLite recovery verification did not open ${this.displayDbPath}`);
+        return recoveredDb;
+      }
+
+      this.scheduleOpenIntegrityScan(opened);
+      return opened;
+    });
   }
 
   /**
@@ -310,14 +313,18 @@ export class DatabaseManager {
             // scan, so skip to avoid a stale-handle recovery.
             return;
           }
-          this.assertIntegrityOk(db, 'quick_check', 'after open');
-        } catch (err) {
-          try {
-            this.recoverFromCorruption(err);
-          } catch {
-            // Best-effort here; at-operation withCorruptionRecovery still
-            // quarantines and rebuilds if a later statement hits the corruption.
-          }
+          measureLifecycleSync('database.quick-check', () => {
+            try {
+              this.assertIntegrityOk(db, 'quick_check', 'after open');
+            } catch (err) {
+              try {
+                this.recoverFromCorruption(err);
+              } catch {
+                // Best-effort here; at-operation withCorruptionRecovery still
+                // quarantines and rebuilds if a later statement hits the corruption.
+              }
+            }
+          });
         } finally {
           if (this.pendingOpenIntegrityScan === scan) {
             this.pendingOpenIntegrityScan = null;
@@ -1131,9 +1138,12 @@ export class DatabaseManager {
    * Close the database connection.
    */
   close(): void {
-    if (this.db) {
-      try { this.db.exec('PRAGMA wal_checkpoint(TRUNCATE)'); } catch { /* best effort */ }
-      try { this.db.close(); } catch { /* best effort — close may throw on a corrupt handle */ }
+    const db = this.db;
+    if (db) {
+      try {
+        measureLifecycleSync('database.checkpoint', () => db.exec('PRAGMA wal_checkpoint(TRUNCATE)'));
+      } catch { /* best effort */ }
+      try { db.close(); } catch { /* best effort — close may throw on a corrupt handle */ }
       this.db = null;
     }
     this.pendingOpenIntegrityScan = null;

--- a/tests/handlers/session-flush.test.ts
+++ b/tests/handlers/session-flush.test.ts
@@ -83,7 +83,7 @@ async function emitShutdownAndAwaitFlush(
       resolve();
     }
   };
-  await emit(handlers, "session_shutdown", {}, ctx);
+  await emit(handlers, "session_shutdown", { type: "session_shutdown", reason: "quit" }, ctx);
   await promise;
 }
 
@@ -521,6 +521,30 @@ describe("direct transport", () => {
   beforeEach(() => {
     mockPi = createMockPi();
     directCalls = [];
+  });
+
+  it("session_shutdown skips direct and subprocess flush on reload", async () => {
+    const config = defaultConfig({ reviewTransport: "direct" });
+    setupSessionFlush(
+      mockPi.pi,
+      mockStore,
+      null,
+      config,
+      null,
+      null,
+      makeDirectDeps({ ok: true, appliedCount: 1 }),
+    );
+
+    await primeFlushReady(mockPi.handlers);
+    await emit(
+      mockPi.handlers,
+      "session_shutdown",
+      { type: "session_shutdown", reason: "reload" },
+      defaultFlushCtx(),
+    );
+
+    assert.equal(directCalls.length, 0, "reload must not use direct completion");
+    assert.equal(mockPi.execCalls.length, 0, "reload must not spawn a subprocess");
   });
 
   it("session_before_compact uses direct transport without subprocess when direct returns ok", async () => {

--- a/tests/lifecycle-timing.test.ts
+++ b/tests/lifecycle-timing.test.ts
@@ -1,0 +1,76 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  measureLifecycle,
+  measureLifecycleSync,
+  type LifecycleTimingOptions,
+} from "../src/lifecycle-timing.js";
+
+function timingOptions(
+  times: number[],
+  lines: string[],
+  enabled?: boolean,
+): LifecycleTimingOptions {
+  return {
+    ...(enabled === undefined ? {} : { enabled }),
+    now: () => {
+      const value = times.shift();
+      assert.notEqual(value, undefined);
+      return value;
+    },
+    log: (line) => lines.push(line),
+  };
+}
+
+describe("lifecycle timing", () => {
+  it("is silent and avoids reading the clock when disabled", () => {
+    const lines: string[] = [];
+    const result = measureLifecycleSync(
+      "session-start.load",
+      () => 42,
+      timingOptions([], lines, false),
+    );
+
+    assert.equal(result, 42);
+    assert.deepEqual(lines, []);
+  });
+
+  it("records labeled sync and async durations when PI_TIMING is enabled", async () => {
+    const previous = process.env.PI_TIMING;
+    process.env.PI_TIMING = "1";
+    try {
+      const lines: string[] = [];
+      const options = timingOptions([10, 22, 30, 49], lines);
+
+      assert.equal(measureLifecycleSync("database.open", () => "ok", options), "ok");
+      assert.equal(await measureLifecycle("shutdown.flush", async () => "done", options), "done");
+      assert.deepEqual(lines, [
+        "[pi-hermes-memory timing] database.open: 12ms",
+        "[pi-hermes-memory timing] shutdown.flush: 19ms",
+      ]);
+    } finally {
+      if (previous === undefined) delete process.env.PI_TIMING;
+      else process.env.PI_TIMING = previous;
+    }
+  });
+
+  it("preserves sync and async errors while recording their durations", async () => {
+    const lines: string[] = [];
+    const options = timingOptions([1, 3, 5, 8], lines, true);
+    const syncError = new Error("sync failure");
+    const asyncError = new Error("async failure");
+
+    assert.throws(
+      () => measureLifecycleSync("backfill.callback", () => { throw syncError; }, options),
+      syncError,
+    );
+    await assert.rejects(
+      measureLifecycle("live-index.callback", async () => { throw asyncError; }, options),
+      asyncError,
+    );
+    assert.deepEqual(lines, [
+      "[pi-hermes-memory timing] backfill.callback: 2ms",
+      "[pi-hermes-memory timing] live-index.callback: 3ms",
+    ]);
+  });
+});


### PR DESCRIPTION
## What changed

- Skip the shutdown memory flush when Pi reports `reason: "reload"`.
- Keep direct completion and subprocess fallback unchanged for other shutdown reasons.
- Add opt-in `PI_TIMING=1` measurements for startup, indexing, shutdown, and SQLite work.
- Document the timing labels and reload behavior.

## Verification

- `npm run check:min-sdk && npm run check && npm test`
- All 48 test files passed.
- A live Pi 0.84.2 smoke test reloaded the local extension without a `shutdown.flush` span and exited with code 0.

Fixes #199
