### PR TITLE
fix(session-index): exclude ephemeral review sessions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { MemoryStore } from "./store/memory-store.js";
 import { SkillStore } from "./store/skill-store.js";
 import { DatabaseManager } from "./store/db.js";
-import { indexSession, upsertSessionFileMetadata } from "./store/session-indexer.js";
+import { indexSession, upsertSessionFileMetadata, pruneEphemeralReviewSessions } from "./store/session-indexer.js";
 import { scheduleSessionBackfill, waitForSessionBackfill, SESSION_BACKFILL_SHUTDOWN_TIMEOUT_MS } from "./handlers/session-backfill.js";
 import { scheduleLiveSessionIndex, waitForLiveSessionIndex, SESSION_LIVE_INDEX_SHUTDOWN_TIMEOUT_MS } from "./handlers/session-live-index.js";
 import { parseSessionFile } from "./store/session-parser.js";
@@ -208,18 +208,25 @@ export default function (pi: ExtensionAPI) {
       if (standingStore) await standingStore.load();
     });
 
-    if (persistenceInitialized) scheduleSessionBackfill(dbManager, sessionsDir, {
-      notify: (message, level) => {
-        const ui = (ctx as { ui?: { notify?: (message: string, level?: string) => void } }).ui;
-        if (ui?.notify) {
-          ui.notify(message, level);
-        } else if (level === "error" || level === "warning") {
-          console.warn(message);
-        } else {
-          console.info(message);
-        }
-      },
-    });
+    if (persistenceInitialized) {
+      try {
+        pruneEphemeralReviewSessions(dbManager);
+      } catch (err) {
+        console.warn(`⚠️ Ephemeral session cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      scheduleSessionBackfill(dbManager, sessionsDir, {
+        notify: (message, level) => {
+          const ui = (ctx as { ui?: { notify?: (message: string, level?: string) => void } }).ui;
+          if (ui?.notify) {
+            ui.notify(message, level);
+          } else if (level === "error" || level === "warning") {
+            console.warn(message);
+          } else {
+            console.info(message);
+          }
+        },
+      });
+    }
   });
 
   registerProjectSkillDiscoveryHandler(pi, skillStore, config.projectsMemoryDir);

--- a/src/store/session-indexer.ts
+++ b/src/store/session-indexer.ts
@@ -227,6 +227,7 @@ export function indexLiveSession(dbManager: DatabaseManager, sessionManager: Ses
 
 function indexLiveSessionOnce(dbManager: DatabaseManager, sessionManager: SessionManagerSnapshot): IndexResult | null {
   const sessionFile = sessionManager.getSessionFile?.();
+  if (sessionManager.getSessionFile && !sessionFile) return null;
   if (sessionFile && fs.existsSync(sessionFile)) {
     const session = parseSessionFile(sessionFile);
     if (session) {
@@ -237,6 +238,41 @@ function indexLiveSessionOnce(dbManager: DatabaseManager, sessionManager: Sessio
   }
 
   return indexCurrentSession(dbManager, sessionManager);
+}
+
+/**
+ * Remove rows created by background review subprocesses that ran with
+ * `--no-session` before live indexing rejected ephemeral sessions.
+ */
+export function pruneEphemeralReviewSessions(dbManager: DatabaseManager): number {
+  return dbManager.withCorruptionRecovery(() => {
+    const db = dbManager.getDb();
+    const candidates = db.prepare(`
+      SELECT s.id
+      FROM sessions s
+      WHERE NOT EXISTS (
+        SELECT 1 FROM session_files sf WHERE sf.session_id = s.id
+      )
+        AND (SELECT COUNT(*) FROM messages m WHERE m.session_id = s.id) = 1
+        AND EXISTS (
+          SELECT 1
+          FROM messages m
+          WHERE m.session_id = s.id
+            AND m.content LIKE ?
+        )
+    `).all('<file name="/tmp/pi-hermes-prompt-%') as Array<{ id: string }>;
+
+    if (candidates.length === 0) return 0;
+
+    const placeholders = candidates.map(() => '?').join(', ');
+    const ids = candidates.map(({ id }) => id);
+    const remove = () => {
+      db.prepare(`DELETE FROM messages WHERE session_id IN (${placeholders})`).run(...ids);
+      return db.prepare(`DELETE FROM sessions WHERE id IN (${placeholders})`).run(...ids).changes;
+    };
+
+    return db.transaction ? db.transaction(remove)() : remove();
+  });
 }
 
 function getSessionFileMetadata(filePath: string): SessionFileMetadata {

--- a/tests/store/session-indexer.test.ts
+++ b/tests/store/session-indexer.test.ts
@@ -18,6 +18,7 @@ import {
   parseSessionManagerSnapshot,
   truncateMessageContent,
   upsertSessionFileMetadata,
+  pruneEphemeralReviewSessions,
 } from '../../src/store/session-indexer.js';
 import { DEFAULT_MAX_MESSAGE_CONTENT_LENGTH } from '../../src/constants.js';
 import { parseSessionFile, type ParsedSession } from '../../src/store/session-parser.js';
@@ -410,6 +411,43 @@ describe('session-indexer', () => {
       assert.strictEqual(result.messagesIndexed, 1);
       const indexed = dbManager.getDb().prepare('SELECT id, cwd FROM sessions WHERE id = ?').get('file-session-1') as { id: string; cwd: string };
       assert.strictEqual(indexed.cwd, '/work/file-project');
+    });
+
+    it('does not index a session without persisted file provenance', () => {
+      const result = indexLiveSession(dbManager, {
+        getHeader: () => ({ id: 'ephemeral-review', timestamp: '2026-05-03T00:00:00Z', cwd: '/tmp/review' }),
+        getEntries: () => [{
+          type: 'message',
+          id: 'review-message',
+          timestamp: '2026-05-03T00:01:00Z',
+          message: { role: 'user', content: [{ type: 'text', text: 'review prompt' }] },
+        }],
+        getSessionFile: () => undefined,
+      });
+
+      assert.strictEqual(result, null);
+      assert.strictEqual(dbManager.getStats().sessions, 0);
+      assert.strictEqual(dbManager.getStats().messages, 0);
+    });
+
+    it('removes existing file-less background review sessions', () => {
+      indexSession(dbManager, {
+        id: 'old-background-review',
+        project: 'review',
+        cwd: '/tmp/review',
+        startedAt: '2026-05-03T00:00:00Z',
+        endedAt: null,
+        messages: [{
+          id: 'review-message',
+          role: 'user',
+          content: '<file name="/tmp/pi-hermes-prompt-abc123/prompt.md">\nReview the conversation above.',
+          timestamp: '2026-05-03T00:01:00Z',
+        }],
+      });
+
+      assert.strictEqual(pruneEphemeralReviewSessions(dbManager), 1);
+      assert.strictEqual(dbManager.getStats().sessions, 0);
+      assert.strictEqual(dbManager.getStats().messages, 0);
     });
 
     it('indexCurrentSession indexes missing live messages idempotently', () => {


### PR DESCRIPTION
## Why

Background review runs Pi with `--no-session`. That child still exposes an in-memory session header and message. Live indexing falls back to that snapshot and stores the review prompt in session search. This change keeps ephemeral review work out of the session index.

## Scope

- `indexLiveSession()` now rejects an explicit session manager with no session file.
- `pruneEphemeralReviewSessions()` removes old one-message rows with no `session_files` record and the `/tmp/pi-hermes-prompt-` marker.
- Startup calls the cleanup after persistence initializes.
- Tests cover the live-index guard and cleanup behavior.

## Blast Radius

Persisted sessions keep the existing JSONL indexing path. Explicit `indexCurrentSession()` callers keep their current behavior. Cleanup matches only file-less, one-message rows with the background prompt marker. It does not remove normal one-message sessions.

## Verification

- `node --test --import tsx tests/store/session-indexer.test.ts` passed 33 tests.
- `npm run check` passed.
- `git diff --check` passed.
