### PR TITLE
fix(store): sweep snapshot retention across dormant stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Snapshot retention converges for dormant memory stores** ([#202](https://github.com/chandra447/pi-hermes-memory/issues/202)): retention caps for `.recovery-*` / `.retired-*` sidecar files only ran inside `saveToDisk()`, so a project store that stopped being written kept its snapshots past the count, age, and byte limits forever (one reported store held 171 recovery snapshots against a cap of 32). Each `session_start` now sweeps the global store and every discovered project store with the identical per-file policy under the same mutation lock; enumeration skips symlinks, hidden directories, and nested paths.
+
 - **Reload no longer waits for an unnecessary LLM memory flush**: Pi preserves the current session during `/reload`, but the shutdown handler ignored `event.reason` and awaited direct completion plus possible subprocess fallback after six user turns. Reload now skips both transports; quit and session-replacement reasons keep the existing flush policy.
-- **Portable child extension sources were discarded before Pi could resolve them**: `childExtensionPaths` ran every configured value through Node's cwd-relative `path.resolve()` and required that resulting local path to already exist. This silently dropped Pi-native `~/...`, `git:...`, and `npm:...` extension sources, forcing machine-specific absolute paths for custom providers in isolated subprocesses. Configured sources are now passed unchanged to Pi's standard `-e` resolver, while Hermes-discovered auth adapter paths retain their local existence checks.
 
 ## [0.9.4] - 2026-08-08
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import { MemoryStore } from "./store/memory-store.js";
 import { SkillStore } from "./store/skill-store.js";
 import { DatabaseManager } from "./store/db.js";
 import { indexSession, upsertSessionFileMetadata, pruneEphemeralReviewSessions } from "./store/session-indexer.js";
+import { runRecoveryMaintenance } from "./store/recovery-maintenance.js";
 import { scheduleSessionBackfill, waitForSessionBackfill, SESSION_BACKFILL_SHUTDOWN_TIMEOUT_MS } from "./handlers/session-backfill.js";
 import { scheduleLiveSessionIndex, waitForLiveSessionIndex, SESSION_LIVE_INDEX_SHUTDOWN_TIMEOUT_MS } from "./handlers/session-live-index.js";
 import { parseSessionFile } from "./store/session-parser.js";
@@ -213,6 +214,11 @@ export default function (pi: ExtensionAPI) {
         pruneEphemeralReviewSessions(dbManager);
       } catch (err) {
         console.warn(`⚠️ Ephemeral session cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      try {
+        await runRecoveryMaintenance({ config, globalDir });
+      } catch (err) {
+        console.warn(`⚠️ Snapshot retention sweep failed: ${err instanceof Error ? err.message : String(err)}`);
       }
       scheduleSessionBackfill(dbManager, sessionsDir, {
         notify: (message, level) => {

--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -166,6 +166,18 @@ export class MemoryStore {
     };
   }
 
+  /**
+   * Enforce snapshot retention for every target of this store without a
+   * write (#202). A store that stops being written never reaches saveToDisk,
+   * so its .recovery-* and .retired-* artifacts only converge here.
+   */
+  async maintainRecoveryFiles(): Promise<void> {
+    for (const target of ["memory", "user", "failure"] as const) {
+      const filePath = await this.resolveStoragePath(target);
+      await withMarkdownMutationLock(filePath, () => this.pruneRecoveryFiles(filePath));
+    }
+  }
+
   // ─── CRUD ───
 
   async add(target: "memory" | "user" | "failure", content: string, signal?: AbortSignal): Promise<MemoryResult> {

--- a/src/store/recovery-maintenance.ts
+++ b/src/store/recovery-maintenance.ts
@@ -1,0 +1,66 @@
+/**
+ * One-shot snapshot retention sweep across every memory store on disk (#202).
+ *
+ * Snapshot pruning normally runs inside saveToDisk(), so a store that stops
+ * being written keeps its .recovery-* and .retired-* artifacts forever. This
+ * sweep applies the identical per-file policy to dormant stores once per
+ * session start. Enumeration never follows symlinks and never enters hidden
+ * or nested directories.
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { resolveProjectsRoot } from "../paths.js";
+import { MemoryStore } from "./memory-store.js";
+import type { MemoryConfig } from "../types.js";
+
+export interface RecoveryMaintenanceOptions {
+  config: MemoryConfig;
+  globalDir: string;
+}
+
+export interface RecoveryMaintenanceResult {
+  storesMaintained: number;
+  failedStores: string[];
+}
+
+// loadConfig only ever stores a single AGENT_ROOT-relative segment here; an
+// absolute value is a direct-injection seam for tests and embedding hosts.
+function resolveProjectsRootFor(projectsMemoryDir: MemoryConfig["projectsMemoryDir"]): string {
+  return projectsMemoryDir && path.isAbsolute(projectsMemoryDir)
+    ? projectsMemoryDir
+    : resolveProjectsRoot(projectsMemoryDir);
+}
+
+export async function listMemoryStoreDirs(options: RecoveryMaintenanceOptions): Promise<string[]> {
+  const dirs = [options.globalDir];
+  const projectsRoot = resolveProjectsRootFor(options.config.projectsMemoryDir);
+  let entries;
+  try {
+    entries = await fs.readdir(projectsRoot, { withFileTypes: true });
+  } catch {
+    return dirs;
+  }
+  for (const entry of entries) {
+    if (entry.isSymbolicLink() || !entry.isDirectory()) continue;
+    if (entry.name.startsWith(".") || entry.name === "skills") continue;
+    dirs.push(path.join(projectsRoot, entry.name));
+  }
+  return dirs;
+}
+
+export async function runRecoveryMaintenance(options: RecoveryMaintenanceOptions): Promise<RecoveryMaintenanceResult> {
+  const result: RecoveryMaintenanceResult = { storesMaintained: 0, failedStores: [] };
+  for (const memoryDir of await listMemoryStoreDirs(options)) {
+    // The constructor only assigns config; maintainRecoveryFiles touches
+    // sidecar files without loading or writing MEMORY.md/USER.md/failures.md.
+    const store = new MemoryStore({ ...options.config, memoryDir });
+    try {
+      await store.maintainRecoveryFiles();
+      result.storesMaintained++;
+    } catch {
+      result.failedStores.push(memoryDir);
+    }
+  }
+  return result;
+}

--- a/tests/store/recovery-maintenance.test.ts
+++ b/tests/store/recovery-maintenance.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Regression tests for the dormant-store snapshot retention sweep (#202).
+ *
+ * Seeds .recovery-* / .retired-* sidecar files directly on disk and proves
+ * caps converge without any MemoryStore write.
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+import * as assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { describe, it, beforeEach, afterEach } from "node:test";
+
+import {
+  listMemoryStoreDirs,
+  runRecoveryMaintenance,
+} from "../../src/store/recovery-maintenance.js";
+import { DEFAULT_MEMORY_CHAR_LIMIT, DEFAULT_USER_CHAR_LIMIT } from "../../src/constants.js";
+import type { MemoryConfig } from "../../src/types.js";
+
+const TEST_MARKER = "[RECOVERY-MAINTENANCE-TEST]";
+let tmpDir = "";
+let globalDir = "";
+let projectsRoot = "";
+
+function makeConfig(overrides?: Partial<MemoryConfig>): MemoryConfig {
+  return {
+    memoryMode: "legacy-inject",
+    memoryCharLimit: DEFAULT_MEMORY_CHAR_LIMIT,
+    userCharLimit: DEFAULT_USER_CHAR_LIMIT,
+    projectCharLimit: 5000,
+    nudgeInterval: 10,
+    reviewEnabled: false,
+    flushOnCompact: false,
+    flushOnShutdown: false,
+    flushMinTurns: 6,
+    autoConsolidate: false,
+    correctionDetection: false,
+    failureInjectionEnabled: true,
+    failureInjectionMaxAgeDays: 7,
+    failureInjectionMaxEntries: 5,
+    nudgeToolCalls: 15,
+    consolidationTimeoutMs: 30000,
+    memoryDir: globalDir,
+    projectsMemoryDir: projectsRoot,
+    ...overrides,
+  };
+}
+
+function recoveryPathFor(memoryDir: string, basename = "MEMORY.md"): string {
+  return path.join(memoryDir, `.${basename}.recovery-${Date.now()}-${randomUUID()}`);
+}
+
+function retiredPathFor(memoryDir: string, basename = "MEMORY.md"): string {
+  return path.join(memoryDir, `.${basename}.retired-${Date.now()}-${randomUUID()}`);
+}
+
+async function writeRaw(filePath: string, content: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content, "utf-8");
+}
+
+async function countFiles(dir: string, prefix: string): Promise<number> {
+  const names = await fs.readdir(dir);
+  return names.filter((name) => name.startsWith(prefix)).length;
+}
+
+describe("recovery maintenance sweep", () => {
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "recovery-maintenance-test-"));
+    globalDir = path.join(tmpDir, "global");
+    projectsRoot = path.join(tmpDir, "projects-memory");
+    await fs.mkdir(globalDir, { recursive: true });
+    await fs.mkdir(projectsRoot, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("bounds dormant recovery snapshots by count without a write", async () => {
+    const projectDir = path.join(projectsRoot, "project-a");
+    for (let index = 0; index < 40; index++) {
+      await writeRaw(recoveryPathFor(projectDir), `${TEST_MARKER} recovery ${index}`);
+    }
+
+    const result = await runRecoveryMaintenance({ config: makeConfig(), globalDir });
+    assert.equal(result.storesMaintained, 2);
+    assert.deepEqual(result.failedStores, []);
+
+    const recoveryCount = await countFiles(projectDir, ".MEMORY.md.recovery-");
+    assert.ok(recoveryCount <= 32, `expected <= 32 recovery files, found ${recoveryCount}`);
+    assert.ok(recoveryCount > 0, "newest active recovery must be retained");
+
+    const retiredCount = await countFiles(projectDir, ".MEMORY.md.retired-");
+    assert.ok(retiredCount <= 32, `expected <= 32 retired files, found ${retiredCount}`);
+
+    const sizes = await Promise.all(
+      (await fs.readdir(projectDir))
+        .filter((name) => name.startsWith(".MEMORY.md.recovery-"))
+        .map((name) => fs.stat(path.join(projectDir, name))),
+    );
+    const totalBytes = sizes.reduce((total, stat) => total + stat.size, 0);
+    assert.ok(totalBytes <= 64 * 1024 * 1024);
+  });
+
+  it("removes retired snapshots past the age cap in a dormant store", async () => {
+    const staleRetiredPath = retiredPathFor(globalDir);
+    await writeRaw(staleRetiredPath, `${TEST_MARKER} stale retired`);
+    const stale = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000);
+    await fs.utimes(staleRetiredPath, stale, stale);
+
+    const freshPath = retiredPathFor(globalDir);
+    await writeRaw(freshPath, `${TEST_MARKER} fresh retired`);
+
+    await runRecoveryMaintenance({ config: makeConfig(), globalDir });
+
+    await assert.rejects(
+      fs.stat(staleRetiredPath),
+      (error: NodeJS.ErrnoException) => error.code === "ENOENT",
+    );
+    assert.equal(await fs.readFile(freshPath, "utf-8"), `${TEST_MARKER} fresh retired`);
+  });
+
+  it("sweeps every enumerated store directory", async () => {
+    const dirs = [
+      path.join(projectsRoot, "project-one"),
+      path.join(projectsRoot, "project-two"),
+    ];
+    for (const dir of dirs) {
+      for (let index = 0; index < 35; index++) {
+        await writeRaw(recoveryPathFor(dir, "USER.md"), `${TEST_MARKER} user recovery`);
+      }
+    }
+
+    const discovered = await listMemoryStoreDirs({ config: makeConfig(), globalDir });
+    assert.deepEqual(discovered.sort(), [globalDir, ...dirs].sort());
+
+    await runRecoveryMaintenance({ config: makeConfig(), globalDir });
+    for (const dir of dirs) {
+      const userRecoveryCount = await countFiles(dir, ".USER.md.recovery-");
+      assert.ok(userRecoveryCount <= 32, `expected <= 32 in ${dir}, found ${userRecoveryCount}`);
+    }
+  });
+
+  it("never follows symlinked project directories", async () => {
+    if (process.platform === "win32") return;
+    const outsideDir = path.join(tmpDir, "outside");
+    await fs.mkdir(outsideDir, { recursive: true });
+    await writeRaw(recoveryPathFor(outsideDir), `${TEST_MARKER} outside decoy`);
+
+    await fs.symlink(outsideDir, path.join(projectsRoot, "linked-project"));
+
+    const discovered = await listMemoryStoreDirs({ config: makeConfig(), globalDir });
+    assert.deepEqual(discovered, [globalDir]);
+  });
+
+  it("is idempotent across repeated sweeps", async () => {
+    const resultA = await runRecoveryMaintenance({ config: makeConfig(), globalDir });
+    assert.deepEqual(resultA.failedStores, []);
+    const siblingsAfterFirst = (await fs.readdir(globalDir)).length;
+
+    const resultB = await runRecoveryMaintenance({ config: makeConfig(), globalDir });
+    assert.deepEqual(resultB.failedStores, []);
+    const siblingsAfterSecond = (await fs.readdir(globalDir)).length;
+
+    assert.equal(siblingsAfterSecond, siblingsAfterFirst);
+  });
+});


### PR DESCRIPTION
## Why

Snapshot retention for `.recovery-*` and `.retired-*` files only ran inside `saveToDisk()`. A store whose `MEMORY.md` stopped being written kept snapshots past the count, age, and byte caps forever. #202 measured 171 recovery snapshots in one dormant store against a cap of 32.

## Scope

- New public `MemoryStore.maintainRecoveryFiles()` runs the existing per-file pruner over all three targets under the standard markdown mutation lock. The pruner body is untouched.
- New `src/store/recovery-maintenance.ts` enumerates the global store plus depth-one project directories and sweeps each with a throwaway store instance; the constructor only assigns config, so no memory content is loaded or written.
- Startup calls the sweep once persistence initializes, before the backfill schedule. Failures warn without blocking startup.
- Enumeration uses `readdir` dirents: symlinks, hidden directories, nested paths, and `skills/` are skipped.
- CHANGELOG documents the fix.

Out of scope: configurable retention knobs (#202 listed them as optional).

## Tradeoffs

The sweep is awaited inside `session_start` rather than deferred. A no-op sweep costs one `readdir` per projects root; convergence at session start beats an extra timer to tear down.

## Blast Radius

Active stores keep identical write-time pruning. Dormant stores converge once any Pi session starts on the machine. Deletion still matches only generated sidecar name patterns beside known store basenames.

## Verification

- `node --test --import tsx tests/store/recovery-maintenance.test.ts`: 5 passed (count cap on dormant store, retired age cap, multi-store enumeration, symlink skip, idempotence).
- `node --test --import tsx tests/store/memory-store.test.ts`: 91 passed (write-time pruning behavior unchanged).
- `npm run check` clean.
- `git diff --check` clean.

Fixes #202
