### PR TITLE
feat: llmFallbackModels chain for memory reviews

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -157,6 +157,28 @@ export function loadConfig(configPath = DEFAULT_CONFIG_PATH): MemoryConfig {
         const trimmed = parsed.llmModelOverride.trim();
         if (trimmed.length > 0) config.llmModelOverride = trimmed;
       }
+      // Support array form for primary override too (e.g. llmModelOverride: ["a/b","c/d"]) — first entry is primary, rest are fallbacks
+      if (Array.isArray(parsed.llmModelOverride) && parsed.llmModelOverride.every((v: unknown) => typeof v === "string")) {
+        const cleaned = (parsed.llmModelOverride as string[]).map((s) => s.trim()).filter(Boolean);
+        if (cleaned.length > 0) {
+          config.llmModelOverride = cleaned[0];
+          const fallbacks = cleaned.slice(1);
+          if (fallbacks.length > 0) config.llmFallbackModels = fallbacks;
+        }
+      }
+      if (isStringArray(parsed.llmFallbackModels)) {
+        const cleaned = (parsed.llmFallbackModels as string[]).map((s) => s.trim()).filter(Boolean);
+        if (cleaned.length > 0) config.llmFallbackModels = [...new Set(cleaned)];
+      }
+      // Backward-compat alias: llmModelFallbacks / fallbackModels
+      if (isStringArray((parsed as Record<string, unknown>).llmModelFallbacks)) {
+        const cleaned = ((parsed as Record<string, unknown>).llmModelFallbacks as string[]).map((s: string) => s.trim()).filter(Boolean);
+        if (cleaned.length > 0) config.llmFallbackModels = [...new Set([...(config.llmFallbackModels ?? []), ...cleaned])];
+      }
+      if (isStringArray((parsed as Record<string, unknown>).fallbackModels)) {
+        const cleaned = ((parsed as Record<string, unknown>).fallbackModels as string[]).map((s: string) => s.trim()).filter(Boolean);
+        if (cleaned.length > 0) config.llmFallbackModels = [...new Set([...(config.llmFallbackModels ?? []), ...cleaned])];
+      }
       if (isThinkingLevel(parsed.llmThinkingOverride)) config.llmThinkingOverride = parsed.llmThinkingOverride;
       if (isStringArray(parsed.childExtensionPaths)) {
         const childExtensionPaths = [...new Set<string>(

--- a/src/handlers/review-memory-ops.ts
+++ b/src/handlers/review-memory-ops.ts
@@ -48,7 +48,7 @@ export function usesDirectTransport(config: Pick<MemoryConfig, "reviewTransport"
   return (config.reviewTransport ?? "direct") === "direct";
 }
 
-type ReviewLlmConfig = Pick<MemoryConfig, "llmModelOverride" | "llmThinkingOverride">;
+type ReviewLlmConfig = Pick<MemoryConfig, "llmModelOverride" | "llmFallbackModels" | "llmThinkingOverride">;
 
 function findExactModelReferenceMatch(modelReference: string, availableModels: Model<Api>[]): Model<Api> | undefined {
   const trimmedReference = modelReference.trim();
@@ -81,6 +81,22 @@ function findExactModelReferenceMatch(modelReference: string, availableModels: M
 function normalizedModelOverride(config: ReviewLlmConfig): string | undefined {
   const trimmed = config.llmModelOverride?.trim();
   return trimmed ? trimmed : undefined;
+}
+
+function collectFallbackOverrides(config: ReviewLlmConfig): string[] {
+  const out: string[] = [];
+  for (const raw of config.llmFallbackModels ?? []) {
+    const t = raw.trim();
+    if (t) out.push(t);
+  }
+  return out;
+}
+
+function allModelOverrides(config: ReviewLlmConfig): string[] {
+  const primary = normalizedModelOverride(config);
+  const fallbacks = collectFallbackOverrides(config);
+  const chain = primary ? [primary, ...fallbacks] : fallbacks;
+  return [...new Set(chain)];
 }
 
 function effectiveThinkingOverride(config: ReviewLlmConfig): ThinkingLevel | undefined {
@@ -123,6 +139,28 @@ export function resolveReviewModel(
     if (matched) return matched;
   }
   return ctxModel;
+}
+
+export function resolveReviewModels(
+  ctxModel: Model<Api> | undefined,
+  modelRegistry: ReviewModelRegistry,
+  config: ReviewLlmConfig,
+): Model<Api>[] {
+  const chain = allModelOverrides(config);
+  if (chain.length === 0) return ctxModel ? [ctxModel] : [];
+  const all = modelRegistry.getAll();
+  const resolved: Model<Api>[] = [];
+  for (const ref of chain) {
+    const m = findExactModelReferenceMatch(ref, all);
+    if (m) resolved.push(m);
+  }
+  // If none of the chain resolved, fall back to active model so we still try something
+  if (resolved.length === 0 && ctxModel) resolved.push(ctxModel);
+  return resolved;
+}
+
+export function getReviewModelChain(config: ReviewLlmConfig): string[] {
+  return allModelOverrides(config);
 }
 
 /**
@@ -398,109 +436,126 @@ export async function runDirectMemoryCompletion(
   deps: { completeSimple?: typeof completeSimple } = {},
 ): Promise<DirectReviewResult> {
   const complete = deps.completeSimple ?? completeSimple;
-  const model = resolveReviewModel(ctx.model, ctx.modelRegistry, options.config);
-  if (!model) {
+  const models = resolveReviewModels(ctx.model, ctx.modelRegistry, options.config);
+  if (models.length === 0) {
     return { ok: false, appliedCount: 0, fallbackReason: "no_model" };
   }
 
-  const auth = await resolveRequestAuth(ctx.modelRegistry, model);
-  if (!auth.ok || !auth.apiKey) {
-    return {
-      ok: false,
-      appliedCount: 0,
-      fallbackReason: "no_auth",
-      error: auth.ok ? `No API key for ${model.provider}` : auth.error,
-    };
-  }
-  let requestAuth: DirectReviewAuth = { apiKey: auth.apiKey, headers: auth.headers, env: auth.env };
-
-  const controller = new AbortController();
-  const timeoutMs = options.timeoutMs ?? 120000;
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  if (options.signal) {
-    options.signal.addEventListener("abort", () => controller.abort(), { once: true });
-  }
-
-  const thinking = effectiveThinkingOverride(options.config);
-  const userMessage: Message = {
-    role: "user",
-    content: [{ type: "text", text: options.userPrompt }],
-    timestamp: Date.now(),
-  };
-
-  const request = { systemPrompt: options.systemPrompt, messages: [userMessage] };
-
-  try {
-    let response;
-    try {
-      response = await complete(
-        model,
-        request,
-        buildDirectReviewCompletionOptions(model, requestAuth, thinking, controller.signal),
-      );
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (controller.signal.aborted || !isAuthRejection(message)) throw err;
-
-      // The provider rejected the key mid-flight. A rotation tool may have
-      // re-resolve through Pi and retry once only if it returns a different
-      // key; otherwise this is a real auth problem and the subprocess
-      // fallback should handle it (#139).
-      const rotated = await resolveRequestAuth(ctx.modelRegistry, model);
-      if (!rotated.ok || !rotated.apiKey || rotated.apiKey === requestAuth.apiKey) throw err;
-
-      requestAuth = { apiKey: rotated.apiKey, headers: rotated.headers, env: rotated.env };
-      response = await complete(
-        model,
-        request,
-        buildDirectReviewCompletionOptions(model, requestAuth, thinking, controller.signal),
-      );
-    }
-
-    if (response.stopReason === "aborted") {
-      return { ok: false, appliedCount: 0, fallbackReason: "aborted" };
-    }
-
-    const text = responseText(response.content);
-    const operations = parseReviewOperations(text);
-    if (operations === null) {
-      return { ok: false, appliedCount: 0, fallbackReason: "parse_error" };
-    }
-    if (operations.length === 0) {
-      return { ok: true, appliedCount: 0, fallbackReason: "empty" };
-    }
-
-    const applied = await applyReviewOperations(
-      store,
-      projectStore,
-      operations,
-      dbManager,
-      projectName,
-      {
-        requireAtomicShrink: options.requireAtomicShrink,
-        expectedTarget: options.expectedTarget,
-      },
-    );
-    if (applied.error) {
-      return {
+  // Try each model in chain: primary + llmFallbackModels. Only retry on
+  // provider/auth/transport failures; parse errors are prompt-specific so we
+  // still try the next model as it may have better instruction following.
+  let lastResult: DirectReviewResult | undefined;
+  for (let mi = 0; mi < models.length; mi++) {
+    const model = models[mi]!;
+    const auth = await resolveRequestAuth(ctx.modelRegistry, model);
+    if (!auth.ok || !auth.apiKey) {
+      lastResult = {
         ok: false,
         appliedCount: 0,
-        fallbackReason: "provider_error",
-        error: applied.error,
+        fallbackReason: "no_auth",
+        error: auth.ok ? `No API key for ${model.provider}` : auth.error,
       };
+      if (mi < models.length - 1) continue;
+      return lastResult;
     }
-    return { ok: true, appliedCount: applied.appliedCount };
-  } catch (err) {
-    if (controller.signal.aborted) {
-      return { ok: false, appliedCount: 0, fallbackReason: "aborted" };
+    let requestAuth: DirectReviewAuth = { apiKey: auth.apiKey, headers: auth.headers, env: auth.env };
+
+  const controller = new AbortController();
+    const timeoutMs = options.timeoutMs ?? 120000;
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    if (options.signal) {
+      options.signal.addEventListener("abort", () => controller.abort(), { once: true });
     }
-    return {
-      ok: false,
-      appliedCount: 0,
-      fallbackReason: "provider_error",
-      error: err instanceof Error ? err.message : String(err),
+
+    const thinking = effectiveThinkingOverride(options.config);
+    const userMessage: Message = {
+      role: "user",
+      content: [{ type: "text", text: options.userPrompt }],
+      timestamp: Date.now(),
     };
-  } finally {
-    clearTimeout(timeout);
+
+    const request = { systemPrompt: options.systemPrompt, messages: [userMessage] };
+
+    try {
+      let response;
+      try {
+        response = await complete(
+          model,
+          request,
+          buildDirectReviewCompletionOptions(model, requestAuth, thinking, controller.signal),
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (controller.signal.aborted || !isAuthRejection(message)) throw err;
+
+        const rotated = await resolveRequestAuth(ctx.modelRegistry, model);
+        if (!rotated.ok || !rotated.apiKey || rotated.apiKey === requestAuth.apiKey) throw err;
+
+        requestAuth = { apiKey: rotated.apiKey, headers: rotated.headers, env: rotated.env };
+        response = await complete(
+          model,
+          request,
+          buildDirectReviewCompletionOptions(model, requestAuth, thinking, controller.signal),
+        );
+      }
+
+      if (response.stopReason === "aborted") {
+        lastResult = { ok: false, appliedCount: 0, fallbackReason: "aborted" };
+        if (mi < models.length - 1) { clearTimeout(timeout); continue; }
+        return lastResult;
+      }
+
+      const text = responseText(response.content);
+      const operations = parseReviewOperations(text);
+      if (operations === null) {
+        lastResult = { ok: false, appliedCount: 0, fallbackReason: "parse_error" };
+        if (mi < models.length - 1) { clearTimeout(timeout); continue; }
+        return lastResult;
+      }
+      if (operations.length === 0) {
+        clearTimeout(timeout);
+        return { ok: true, appliedCount: 0, fallbackReason: "empty" };
+      }
+
+      const applied = await applyReviewOperations(
+        store,
+        projectStore,
+        operations,
+        dbManager,
+        projectName,
+        {
+          requireAtomicShrink: options.requireAtomicShrink,
+          expectedTarget: options.expectedTarget,
+        },
+      );
+      if (applied.error) {
+        lastResult = {
+          ok: false,
+          appliedCount: 0,
+          fallbackReason: "provider_error",
+          error: applied.error,
+        };
+        if (mi < models.length - 1) { clearTimeout(timeout); continue; }
+        return lastResult;
+      }
+      clearTimeout(timeout);
+      return { ok: true, appliedCount: applied.appliedCount };
+    } catch (err) {
+      if (controller.signal.aborted) {
+        lastResult = { ok: false, appliedCount: 0, fallbackReason: "aborted" };
+      } else {
+        lastResult = {
+          ok: false,
+          appliedCount: 0,
+          fallbackReason: "provider_error",
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+      if (mi < models.length - 1) { clearTimeout(timeout); continue; }
+      return lastResult!;
+    } finally {
+      clearTimeout(timeout);
+    }
   }
+  return lastResult ?? { ok: false, appliedCount: 0, fallbackReason: "provider_error", error: "All fallback models failed" };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,8 @@ export interface MemoryConfig {
   sessionSearch?: SessionSearchConfig;
   /** Override model used for child pi -p subprocess LLM calls. Default: unset */
   llmModelOverride?: string;
+  /** Fallback model chain tried in order when the primary review model fails (rate limit, 401/403, 404, 500/503, invalid response). Default: unset */
+  llmFallbackModels?: string[];
   /** Override thinking level used for child pi -p subprocess LLM calls. Default: unset */
   llmThinkingOverride?: ThinkingLevel;
   /** Trusted Pi extension sources required by child processes, such as custom providers or auth adapters. */


### PR DESCRIPTION
## Summary
Memory reviews (`background review`, `flush`, `consolidation`, `correction`) currently use a single `llmModelOverride`. If that model is disabled/401/429/500, the review fails even though other providers are available. This mirrors `Hermes` `fallback_providers` semantics for auxiliary tasks.

This PR adds a **model chain** for memory LLM calls.

## Changes
- **types.ts:** `MemoryConfig.llmFallbackModels?: string[]` — fallback chain tried in order after primary
- **config.ts:** parse `llmFallbackModels` + aliases `llmModelFallbacks` / `fallbackModels`; also supports array form `llmModelOverride: ["primary/fallback1", "fallback2"]`
- **review-memory-ops.ts:**
  - `resolveReviewModels()` / `getReviewModelChain()` — resolve `["provider/model"]` refs via `modelRegistry.getAll()`
  - `runDirectMemoryCompletion()` now iterates `primary + fallbacks` with per-model timeout/auth, falling through on `no_auth`/`provider_error`/`aborted`/`parse_error` to next model

## Example config
```json
{
  "llmModelOverride": "opencode-go/muse-spark-1.2-contributor",
  "llmFallbackModels": [
    "opencode-go/deepseek-v4-flash",
    "openrouter/anthropic/claude-sonnet-4"
  ]
}
```
or
```json
{ "llmModelOverride": ["opencode-go/muse-spark", "opencode-go/deepseek-v4-flash"] }
```

## Compatibility
- Fully backward compatible; no config = existing single-model behavior
- Falls back to active `ctx.model` if chain doesn't resolve
- Mirrors `hermes fallback_providers` per-turn semantics (chain is per-review, not persisted)

Fixes silent memory review failure when single override is disabled.