### PR TITLE
fix: let background review survive turn cancellation

### DIFF
--- a/src/handlers/background-review.ts
+++ b/src/handlers/background-review.ts
@@ -118,12 +118,13 @@ async function runSubprocessReview(
   prompt: string,
   config: MemoryConfig,
   execChild: typeof execChildPrompt,
-  ctx: Pick<ExtensionContext, "cwd" | "model" | "signal">,
+  ctx: Pick<ExtensionContext, "cwd" | "model">,
 ): Promise<{ code: number; stdout?: string; stderr?: string }> {
+  // Reviews are deliberately detached from the interactive agent turn. Esc
+  // should stop the agent without discarding the low-priority persistence work.
   return execChild(pi, prompt, config, {
     cwd: ctx.cwd,
     model: resolveChildPiModel(ctx.model),
-    signal: ctx.signal,
     timeoutMs: 120000,
   });
 }

--- a/tests/handlers/background-review.test.ts
+++ b/tests/handlers/background-review.test.ts
@@ -800,6 +800,30 @@ describe("setupBackgroundReview", () => {
     });
   });
 
+  it("does not cancel a subprocess review when the interactive turn is interrupted", async () => {
+    const pi = createMockPi();
+    let childOptions: Record<string, unknown> | undefined;
+    setup(pi, { ...defaultConfig, reviewTransport: "direct" } as MemoryConfig, {
+      runDirectReview: async () => ({ ok: false, appliedCount: 0, fallbackReason: "no_auth" }),
+      execChildPrompt: async (_pi, _prompt, _config, options) => {
+        childOptions = options;
+        return { code: 0, stdout: "Nothing to save", stderr: "" };
+      },
+    });
+
+    fireMessageEnd("user");
+    fireMessageEnd("user");
+    fireMessageEnd("user");
+    const signal = new AbortController().signal;
+    for (let i = 0; i < 10; i++) {
+      fireTurnEnd(makeBranch(10), { signal });
+    }
+    await reviewSettledSignal.promise;
+
+    assert.ok(childOptions, "subprocess fallback should run");
+    assert.equal(childOptions.signal, undefined);
+  });
+
   it("surfaces one actionable diagnostic when direct and subprocess review both fail", async () => {
     const pi = createMockPi({ code: 1, stdout: "", stderr: "No API key for local-llama/local-9b" });
     setupWithDirectDeps(pi, {


### PR DESCRIPTION
Background auto-review is fire-and-forget, but its subprocess fallback forwards the interactive turn\u2019s AbortSignal. Pressing Esc therefore writes the watchdog cancellation marker and kills persistence work.

Do not pass the turn signal to background review subprocesses. The existing 120-second watchdog still bounds the child; explicit / session shutdown behavior is unchanged.

Adds a regression test covering an interrupted interactive turn.

Tests:
- npm run check
- npm test