### PR TITLE
fix(review): stop fallback chain on caller abort, merge array-form fallbacks

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -176,7 +176,7 @@ export function loadConfig(configPath = DEFAULT_CONFIG_PATH): MemoryConfig {
       }
       if (isStringArray(parsed.llmFallbackModels)) {
         const cleaned = (parsed.llmFallbackModels as string[]).map((s) => s.trim()).filter(Boolean);
-        if (cleaned.length > 0) config.llmFallbackModels = [...new Set(cleaned)];
+        if (cleaned.length > 0) config.llmFallbackModels = [...new Set([...(config.llmFallbackModels ?? []), ...cleaned])];
       }
       // Backward-compat alias: llmModelFallbacks / fallbackModels
       if (isStringArray((parsed as Record<string, unknown>).llmModelFallbacks)) {

--- a/src/handlers/review-memory-ops.ts
+++ b/src/handlers/review-memory-ops.ts
@@ -35,7 +35,7 @@ export interface DirectReviewResult {
 export interface RunDirectMemoryCompletionOptions {
   userPrompt: string;
   systemPrompt: string;
-  config: Pick<MemoryConfig, "llmModelOverride" | "llmThinkingOverride">;
+  config: Pick<MemoryConfig, "llmModelOverride" | "llmFallbackModels" | "llmThinkingOverride">;
   timeoutMs?: number;
   signal?: AbortSignal;
   requireAtomicShrink?: boolean;
@@ -519,6 +519,10 @@ export async function runDirectMemoryCompletion(
   let lastResult: DirectReviewResult | undefined;
   for (let mi = 0; mi < models.length; mi++) {
     const model = models[mi]!;
+    // A caller abort (user cancel, shutdown bound) ends the whole chain: the
+    // next iteration's listener would never fire for an already-aborted
+    // signal, so continuing would burn a full timeout per remaining model.
+    if (options.signal?.aborted) return aborted();
     const auth = await resolveRequestAuth(ctx.modelRegistry, model);
     if (options.signal?.aborted) return aborted();
     if (!auth.ok || !hasRequestAuth(auth)) {
@@ -583,7 +587,11 @@ export async function runDirectMemoryCompletion(
         response = await completeOnce();
       }
 
-      if (response.stopReason === "aborted" || controller.signal.aborted || options.signal?.aborted) {
+      if (options.signal?.aborted) {
+        clearTimeout(timeout);
+        return aborted();
+      }
+      if (response.stopReason === "aborted" || controller.signal.aborted) {
         lastResult = { ok: false, appliedCount: 0, fallbackReason: "aborted" };
         if (mi < models.length - 1) { clearTimeout(timeout); continue; }
         return lastResult;
@@ -632,7 +640,11 @@ export async function runDirectMemoryCompletion(
       clearTimeout(timeout);
       return { ok: true, appliedCount: applied.appliedCount };
     } catch (err) {
-      if (controller.signal.aborted || options.signal?.aborted) {
+      if (options.signal?.aborted) {
+        clearTimeout(timeout);
+        return aborted();
+      }
+      if (controller.signal.aborted) {
         lastResult = { ok: false, appliedCount: 0, fallbackReason: "aborted" };
       } else {
         lastResult = {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -109,6 +109,18 @@ describe("loadConfig", () => {
     assert.strictEqual(config.reviewEnabled, true);
   });
 
+  it("merges array-form override tails with explicit llmFallbackModels", () => {
+    fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(TEST_CONFIG_PATH, JSON.stringify({
+      llmModelOverride: ["p1/m1", "p2/m2"],
+      llmFallbackModels: ["p3/m3"],
+    }));
+    const config = loadConfig(TEST_CONFIG_PATH);
+    assert.strictEqual(config.llmModelOverride, "p1/m1");
+    assert.deepStrictEqual(config.llmFallbackModels, ["p2/m2", "p3/m3"]);
+  });
+
+
   it("parses sessionRetentionDays as opt-in, accepting explicit 0 to disable", () => {
     fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
 

--- a/tests/handlers/review-memory-ops.test.ts
+++ b/tests/handlers/review-memory-ops.test.ts
@@ -399,6 +399,87 @@ describe("provider auth resolution", () => {
   });
 });
 
+describe("fallback model chain", () => {
+  function twoModelRegistry() {
+    const m1 = { id: "m1", provider: "p1", api: "openai-completions", reasoning: false } as Model<Api>;
+    const m2 = { id: "m2", provider: "p2", api: "openai-completions", reasoning: false } as Model<Api>;
+    let authCalls = 0;
+    const registry = {
+      getApiKeyAndHeaders: async () => {
+        authCalls++;
+        return { ok: true as const, apiKey: "k" };
+      },
+      getAll: () => [m1, m2],
+      getAvailable: () => [m1, m2],
+    };
+    return { registry, get authCalls() { return authCalls; } };
+  }
+
+  function chainOptions(signal?: AbortSignal) {
+    return {
+      userPrompt: "u",
+      systemPrompt: "s",
+      config: { llmModelOverride: "p1/m1", llmFallbackModels: ["p2/m2"] },
+      ...(signal ? { signal } : {}),
+    };
+  }
+
+  const emptyReview = {
+    stopReason: "stop",
+    content: [{ type: "text", text: JSON.stringify({ operations: [] }) }],
+  };
+
+  it("stops the chain when the caller aborts instead of trying the next model", async () => {
+    const caller = new AbortController();
+    const attempted: string[] = [];
+    const complete = async (model: Model<Api>) => {
+      attempted.push(model.id);
+      caller.abort();
+      return { stopReason: "aborted" };
+    };
+    const chain = twoModelRegistry();
+
+    const result = await runDirectMemoryCompletion(
+      { model: undefined, modelRegistry: chain.registry } as never,
+      null as never,
+      null,
+      chainOptions(caller.signal),
+      null,
+      null,
+      { completeSimple: complete as never },
+    );
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.fallbackReason, "aborted");
+    assert.deepStrictEqual(attempted, ["m1"]);
+    assert.strictEqual(chain.authCalls, 1);
+  });
+
+  it("still tries the next model after a per-model timeout while the caller is alive", async () => {
+    const caller = new AbortController();
+    const attempted: string[] = [];
+    const complete = async (model: Model<Api>) => {
+      attempted.push(model.id);
+      if (attempted.length === 1) return { stopReason: "aborted" };
+      return emptyReview;
+    };
+
+    const chain = twoModelRegistry();
+    const result = await runDirectMemoryCompletion(
+      { model: undefined, modelRegistry: chain.registry } as never,
+      null as never,
+      null,
+      chainOptions(caller.signal),
+      null,
+      null,
+      { completeSimple: complete as never },
+    );
+
+    assert.deepStrictEqual(attempted, ["m1", "m2"]);
+    assert.strictEqual(result.ok, true);
+  });
+});
+
 describe("parseReviewOperations", () => {
   it("parses valid JSON operations", () => {
     const parsed = parseReviewOperations(JSON.stringify({


### PR DESCRIPTION
Follow-up to the adversarial review on #215 (merged as 4d0f1bb). Addresses the two Act-On findings so the merged chain can't regress shutdown/cancel behavior or silently drop config.

## Fixes
1. **Chain stops on caller abort** (`src/handlers/review-memory-ops.ts`): `runDirectMemoryCompletion` now returns `aborted()` immediately when `options.signal` is already aborted — at loop top, after the completion, and in `catch` — instead of resolving auth and trying the next `llmFallbackModels` entry. A fresh per-model `AbortController` never observes an already-aborted caller signal, so the old code paid a wasted auth round-trip per remaining model after user cancel / session-flush timeout / compaction abort. Per-model timeouts (controller aborted, caller alive) still fall through to the next model.
2. **Config merge instead of replace** (`src/config.ts`): explicit `llmFallbackModels` now merges with tails seeded from array-form `llmModelOverride: [primary, ...fallbacks]` (matching the alias behavior below it). Previously `{llmModelOverride: [a, c], llmFallbackModels: [e]}` silently dropped `c`.
3. **Type widening**: `RunDirectMemoryCompletionOptions.config` now includes `llmFallbackModels` so the chain is reachable through the public options type.

## Verification
- New regression tests, mutation-checked (fail pre-fix, pass post-fix): chain abort stops after the first model with a single auth call; timeout fallthrough preserved; config merge pinned.
- `npm run check` clean, `check:min-sdk` clean, full suite: all 52 test files pass.

Not addressed here (returned to authors): #175 qmd search, #216 WCM recall.