### PR TITLE
fix: bypass Markdown cap for policy-only memory writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **FTS5 index errors during markdown sync are surfaced instead of hidden** ([#184](https://github.com/chandra447/pi-hermes-memory/pull/184)): when the FTS5 search index is broken, memory writes still succeed in Markdown, but the tool result and `/memory-sync-markdown` now report the degraded search state together with the repair command instead of showing a silent zero-count success. Genuine database corruption is unaffected by the fallback and now recovers through the markdown sync path too: reconciliation runs inside `DatabaseManager.withCorruptionRecovery()`, so a corrupt `sessions.db` is quarantined, rebuilt, and the sync retried instead of failing every memory write.
+- **Policy-only memory writes bypass the Markdown character cap** ([#218](https://github.com/chandra447/pi-hermes-memory/issues/218)): SQLite is the query authority in policy-only mode, so adds, replacements, and atomic mutation plans can exceed the Markdown export limit without triggering automatic consolidation. Legacy-inject mode keeps its existing caps, grace windows, auto-consolidation, failure limits, and FIFO eviction.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ No manual action is needed. Launch Pi once after upgrade to let migration/normal
 | 📚 **Procedural Skills** | The agent saves *how* it solved problems as reusable docs |
 | ⚡ **Background Learning** | Every 10 turns (or 15 tool calls) the agent reviews and saves |
 | 🔧 **Correction Detection** | When you correct the agent, it saves immediately |
-| 🔄 **Auto-Consolidation** | When memory hits capacity, auto-merges instead of erroring |
+| 🔄 **Auto-Consolidation** | When legacy-inject memory hits capacity, auto-merges instead of erroring |
 | 🛡️ **Secret Scanning** | API keys, tokens, SSH keys blocked from persistence |
 | 📊 **Memory Aging** | Entries carry timestamps — consolidation knows what's stale |
 | 🏗️ **Two-Tier Memory** | Global + per-project memory, both searchable |
-| 💾 **Extended Store** | Unlimited searchable memories beyond core 5,000-char limit |
+| 💾 **Extended Store** | Policy-only memories remain searchable in SQLite beyond the Markdown export cap |
 | 🎓 **Onboarding** | `/memory-interview` pre-fills your profile on first session |
 
 ## How It Works
@@ -379,14 +379,14 @@ When you correct the agent, it saves immediately — no waiting for the backgrou
 
 ### Auto-Consolidation
 
-When memory, user profile, or failure memory hits its character limit, the extension automatically consolidates instead of returning an error:
+In `legacy-inject` mode, when memory, user profile, or failure memory hits its character limit, the extension automatically consolidates instead of returning an error:
 
 1. Spawns a one-shot `pi.exec()` process with a consolidation prompt
-2. The child agent merges related entries, removes outdated ones, keeps the most important facts
-3. Parent reloads from disk and retries the original save
-4. If consolidation fails, falls back to the original error
+2. The child agent merges related entries, removes outdated ones, and keeps the most important facts
+3. The parent reloads from disk and retries the original save
+4. If consolidation fails, the original error returns
 
-You can also trigger this manually with `/memory-consolidate`.
+In `policy-only` mode, SQLite is the query authority, so adds, replacements, and atomic mutation plans can exceed the Markdown export cap without automatic consolidation. You can still trigger consolidation manually with `/memory-consolidate`.
 
 ### Tool-Call-Aware Review
 
@@ -527,9 +527,9 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 | `memoryPolicyStyle` | `full` | Policy text used in `policy-only` mode: `full` preserves the default v0.7 policy; `compact` uses shorter built-in guidance; `custom` uses `memoryPolicyCustomText`; `none` injects no policy text |
 | `memoryPolicyCustomText` | unset | Custom policy text used when `memoryPolicyStyle` is `custom`; blank or missing text falls back to `compact` |
 | `standingInstructionsEnabled` | `true` | Inject `STANDING.md` (pinned via `/memory-pin`) into every session, in every memory mode |
-| `memoryCharLimit` | `5000` | Max characters in MEMORY.md |
-| `userCharLimit` | `5000` | Max characters in USER.md |
-| `projectCharLimit` | `5000` | Max characters in project-scoped MEMORY.md |
+| `memoryCharLimit` | `5000` | Max characters in MEMORY.md in `legacy-inject` mode; policy-only writes may exceed the Markdown export cap |
+| `userCharLimit` | `5000` | Max characters in USER.md in `legacy-inject` mode; policy-only writes may exceed the Markdown export cap |
+| `projectCharLimit` | `5000` | Max characters in project-scoped MEMORY.md in `legacy-inject` mode; policy-only writes may exceed the Markdown export cap |
 | `memoryDir` | `~/.pi/agent/pi-hermes-memory` | Custom directory for extension storage files |
 | `projectsMemoryDir` | `projects-memory` | Subdirectory under `~/.pi/agent/` for project-scoped memory |
 | `sessionSearch` | `{ "variant": "legacy" }` | Session search implementation: `legacy` keeps the existing SQLite/FTS snippet search; `anchors` uses the opt-in Markdown request surface and returns compact JSONL line-range anchors from `~/.pi/agent/sessions/` |
@@ -542,7 +542,7 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 | `reviewRecentMessages` | `0` | Recent messages included in background review (`0` = all) |
 | `reviewEnabled` | `true` | Enable/disable background learning loop |
 | `reviewTransport` | `direct` | LLM transport for background review, session flush, correction save, and manual consolidation: `direct` uses in-process `completeSimple()` with subprocess fallback; `subprocess` forces legacy `pi -p` only |
-| `memoryOverflowStrategy` | `auto-consolidate` | Behavior when MEMORY.md, USER.md, failures.md, or project-scoped memory reaches its character limit: `auto-consolidate` runs the existing consolidation flow; `reject` returns an error; `fifo-evict` rotates older entries in file order until the new entry fits |
+| `memoryOverflowStrategy` | `auto-consolidate` | Legacy-inject behavior when a Markdown memory file reaches its character limit: `auto-consolidate` runs the existing consolidation flow; `reject` returns an error; `fifo-evict` rotates older entries in file order until the new entry fits |
 | `autoConsolidate` | `true` | Legacy alias for `memoryOverflowStrategy` when `memoryOverflowStrategy` is not set (`true` = `auto-consolidate`, `false` = `reject`) |
 | `consolidationTimeoutMs` | `180000` | Maximum time in milliseconds for a consolidation run (auto and `/memory-consolidate` alike). Configured values are used verbatim; a consolidation pays child-process boot plus a full LLM turn, so values below the default are frequently killed mid-run and log a warning at startup |
 | `overflowGraceMs` | `180000` | Wall-clock grace period after a memory overflow before automatic consolidation is retried; this gives the active agent time to consolidate manually. Set to `0` to disable the grace period |
@@ -617,7 +617,7 @@ The `sessions.db` SQLite database stores session history and extended memory ent
 - **Background review cost**: Each review cycle costs one full LLM API call via a child `pi -p` process. Correction detection and explicit skill saves can add additional calls when the agent decides they are worth it.
 - **Session search requires indexing**: Past sessions must be indexed before they're searchable. Run `/memory-index-sessions` to bulk-import, or let the extension auto-index on session shutdown.
 - **Older Markdown memories may need backfill**: If you saved memories before the SQLite mirror existed or search looks stale, run `/memory-sync-markdown`.
-- **Core memory limits still apply**: SQLite search mirroring does not bypass the 5,000-char core Markdown limit. If consolidation cannot free space, the write fails instead of becoming SQLite-only memory invisibly.
+- **Core memory limits apply in `legacy-inject` mode**: policy-only writes can exceed the Markdown export cap because SQLite is the query authority, while manual `/memory-consolidate` remains available.
 - **System prompts are invisible**: Pi's TUI does not display the system prompt. Use `/memory-preview-context` to inspect whether policy-only or legacy memory injection is active.
 - **Project skill visibility depends on Pi discovery cycles**: project skills are exposed through `resources_discover` using the active project's `skills/` path. If a moved or newly created project skill doesn't show up immediately in a running session, trigger a reload/new session so Pi refreshes discovered resources.
 - **Project move requires active project context**: in `/memory-skills`, the `p` hotkey is disabled when Pi is not currently in a detected project directory.

--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -119,6 +119,9 @@ export class MemoryStore {
     if (target === "failure") return this.config.memoryCharLimit * 2; // Failures get more space
     return target === "user" ? this.config.userCharLimit : this.config.memoryCharLimit;
   }
+  private get capEnforced(): boolean {
+    return this.config.memoryMode !== "policy-only";
+  }
 
   private charCount(target: "memory" | "user" | "failure"): number {
     const entries = this.entriesFor(target);
@@ -245,7 +248,7 @@ export class MemoryStore {
     const encoded = this.encodeEntry(content, today, today, project);
 
     const newTotal = [...entries, encoded].join(ENTRY_DELIMITER).length;
-    if (newTotal > limit) {
+    if (this.capEnforced && newTotal > limit) {
       this.overflowSince[target] ??= Date.now();
       const strategy = this.memoryOverflowStrategy();
 
@@ -442,7 +445,7 @@ export class MemoryStore {
 
       const originalTotal = originalEntries.join(ENTRY_DELIMITER).length;
       const plannedTotal = plannedEntries.join(ENTRY_DELIMITER).length;
-      if (plannedTotal > this.charLimit(target)) {
+      if (this.capEnforced && plannedTotal > this.charLimit(target)) {
         return {
           success: false,
           error: `Memory mutation plan would put memory at ${plannedTotal}/${this.charLimit(target)} chars.`,
@@ -509,7 +512,7 @@ export class MemoryStore {
 
     const newTotal = testEntries.join(ENTRY_DELIMITER).length;
 
-    if (newTotal > this.charLimit(target)) {
+    if (this.capEnforced && newTotal > this.charLimit(target)) {
       return {
         success: false,
         error: `Replacement would put memory at ${newTotal}/${this.charLimit(target)} chars. Shorten or remove other entries first.`,

--- a/tests/store/memory-store.test.ts
+++ b/tests/store/memory-store.test.ts
@@ -184,6 +184,48 @@ describe("MemoryStore", { concurrency: 1 }, () => {
       assert.ok(result.error!.includes("chars"));
     });
 
+    it("bypasses the Markdown cap for memory, user, failure, and project stores in policy-only mode", async () => {
+      const config = makeConfig({
+        memoryMode: "policy-only",
+        memoryCharLimit: 1,
+        userCharLimit: 1,
+        projectCharLimit: 1,
+        memoryOverflowStrategy: "auto-consolidate",
+        autoConsolidate: true,
+      });
+      const store = new MemoryStore(config);
+      const projectStore = new MemoryStore({
+        ...config,
+        memoryDir: path.join(MEMORY_DIR, "project"),
+      });
+      let consolidatorCalls = 0;
+      const consolidator = async () => {
+        consolidatorCalls++;
+        return { consolidated: true };
+      };
+      store.setConsolidator(consolidator);
+      projectStore.setConsolidator(consolidator);
+      await store.loadFromDisk();
+      await projectStore.loadFromDisk();
+
+      const results = await Promise.all([
+        store.add("memory", `${TEST_MARKER} policy-only memory ${"x".repeat(100)}`),
+        store.add("user", `${TEST_MARKER} policy-only user ${"x".repeat(100)}`),
+        store.addFailure(`${TEST_MARKER} policy-only failure ${"x".repeat(100)}`, { category: "failure" }),
+        projectStore.add("memory", `${TEST_MARKER} policy-only project ${"x".repeat(100)}`),
+      ]);
+
+      for (const result of results) {
+        assert.equal(result.success, true, result.error);
+      }
+      assert.equal(consolidatorCalls, 0);
+      assert.equal(store.getRawEntriesForSync("memory").length, 1);
+      assert.equal(store.getRawEntriesForSync("user").length, 1);
+      assert.equal(store.getRawEntriesForSync("failure").length, 1);
+      assert.equal(projectStore.getRawEntriesForSync("memory").length, 1);
+    });
+
+
     it("rejects without consolidation when memoryOverflowStrategy is reject", async () => {
       let consolidatorCalled = false;
       const store = new MemoryStore(makeConfig({
@@ -603,6 +645,45 @@ describe("MemoryStore", { concurrency: 1 }, () => {
   // ─── replace() tests ───
 
   describe("replace()", () => {
+    it("bypasses the Markdown cap for replacements in policy-only mode", async () => {
+      const config = makeConfig({
+        memoryMode: "policy-only",
+        memoryCharLimit: 1,
+        userCharLimit: 1,
+        projectCharLimit: 1,
+      });
+      const store = new MemoryStore(config);
+      const projectStore = new MemoryStore({
+        ...config,
+        memoryDir: path.join(MEMORY_DIR, "project-replace"),
+      });
+      let consolidatorCalls = 0;
+      const consolidator = async () => {
+        consolidatorCalls++;
+        return { consolidated: true };
+      };
+      store.setConsolidator(consolidator);
+      projectStore.setConsolidator(consolidator);
+      await store.loadFromDisk();
+      await projectStore.loadFromDisk();
+      await store.add("memory", `${TEST_MARKER} replace memory seed`);
+      await store.add("user", `${TEST_MARKER} replace user seed`);
+      await store.addFailure(`${TEST_MARKER} replace failure seed`, { category: "failure" });
+      await projectStore.add("memory", `${TEST_MARKER} replace project seed`);
+
+      const replacement = `${TEST_MARKER} ${"x".repeat(100)}`;
+      const results = await Promise.all([
+        store.replace("memory", "replace memory seed", replacement),
+        store.replace("user", "replace user seed", replacement),
+        store.replace("failure", "replace failure seed", replacement),
+        projectStore.replace("memory", "replace project seed", replacement),
+      ]);
+
+      for (const result of results) {
+        assert.equal(result.success, true, result.error);
+      }
+      assert.equal(consolidatorCalls, 0);
+    });
     it("updates entry in file", async () => {
       const store = new MemoryStore(makeConfig());
       await store.loadFromDisk();
@@ -1317,6 +1398,52 @@ describe("MemoryStore", { concurrency: 1 }, () => {
         assert.match(result.error ?? "", /did not shrink/);
         assert.equal(await readRaw(memoryPath), beforeDisk);
       }
+    });
+    it("bypasses the Markdown cap for batch mutations in policy-only mode", async () => {
+      const config = makeConfig({
+        memoryMode: "policy-only",
+        memoryCharLimit: 1,
+        userCharLimit: 1,
+        projectCharLimit: 1,
+      });
+      const store = new MemoryStore(config);
+      const projectStore = new MemoryStore({
+        ...config,
+        memoryDir: path.join(MEMORY_DIR, "project-batch"),
+      });
+      let consolidatorCalls = 0;
+      const consolidator = async () => {
+        consolidatorCalls++;
+        return { consolidated: true };
+      };
+      store.setConsolidator(consolidator);
+      projectStore.setConsolidator(consolidator);
+      await store.loadFromDisk();
+      await projectStore.loadFromDisk();
+
+      const results = await Promise.all([
+        store.applyMutationPlan("memory", [
+          { action: "add", content: `${TEST_MARKER} batch memory ${"x".repeat(100)}` },
+          { action: "add", content: `${TEST_MARKER} batch memory second ${"x".repeat(100)}` },
+        ]),
+        store.applyMutationPlan("user", [
+          { action: "add", content: `${TEST_MARKER} batch user ${"x".repeat(100)}` },
+          { action: "add", content: `${TEST_MARKER} batch user second ${"x".repeat(100)}` },
+        ]),
+        store.applyMutationPlan("failure", [
+          { action: "add", content: `${TEST_MARKER} batch failure ${"x".repeat(100)}`, category: "failure" },
+          { action: "add", content: `${TEST_MARKER} batch failure second ${"x".repeat(100)}`, category: "failure" },
+        ]),
+        projectStore.applyMutationPlan("memory", [
+          { action: "add", content: `${TEST_MARKER} batch project ${"x".repeat(100)}` },
+          { action: "add", content: `${TEST_MARKER} batch project second ${"x".repeat(100)}` },
+        ]),
+      ]);
+
+      for (const result of results) {
+        assert.equal(result.success, true, result.error);
+      }
+      assert.equal(consolidatorCalls, 0);
     });
   });
 

--- a/tests/tools/memory-tool.test.ts
+++ b/tests/tools/memory-tool.test.ts
@@ -9,7 +9,7 @@ import path from "node:path";
 import { registerMemoryTool } from "../../src/tools/memory-tool.js";
 import { MemoryStore } from "../../src/store/memory-store.js";
 import { DatabaseManager } from "../../src/store/db.js";
-import { getMemories, syncMemoryEntry } from "../../src/store/sqlite-memory-store.js";
+import { getMemories, searchMemories, syncMemoryEntry } from "../../src/store/sqlite-memory-store.js";
 import { ENTRY_DELIMITER, MEMORY_FILE } from "../../src/constants.js";
 import { Value } from "typebox/value";
 
@@ -145,6 +145,42 @@ describe("registerMemoryTool", () => {
     const results = getMemories(dbManager, { target: 'memory', project: null });
     assert.strictEqual(results.length, 1);
     assert.strictEqual(results[0].content, 'Entry one');
+  });
+
+  it("lands over-cap policy-only adds in searchable SQLite", async () => {
+    let capturedResult: any;
+    const mockPi = {
+      registerTool: (def: any) => {
+        if (!capturedResult || def.name === "memory_add") capturedResult = def;
+      },
+    } as unknown as ExtensionAPI;
+    const store = new MemoryStore({
+      memoryMode: "policy-only",
+      memoryCharLimit: 40,
+      userCharLimit: 5000,
+      projectCharLimit: 5000,
+      nudgeInterval: 10,
+      reviewEnabled: false,
+      flushOnCompact: false,
+      flushOnShutdown: false,
+      flushMinTurns: 6,
+      autoConsolidate: false,
+      correctionDetection: false,
+      failureInjectionEnabled: true,
+      failureInjectionMaxAgeDays: 7,
+      failureInjectionMaxEntries: 5,
+      nudgeToolCalls: 15,
+      consolidationTimeoutMs: 60000,
+      memoryDir: tmpDir,
+    });
+    await store.loadFromDisk();
+    registerMemoryTool(mockPi, store, null, dbManager);
+    const first = await capturedResult.execute("tc-1", { action: "add", target: "memory", content: "alpha entry" }, undefined as any, undefined as any, undefined as any);
+    assert.strictEqual(first.details.success, true);
+    const second = await capturedResult.execute("tc-2", { action: "add", target: "memory", content: "beta entry past the tiny cap" }, undefined as any, undefined as any, undefined as any);
+    assert.strictEqual(second.details.success, true);
+    const results = searchMemories(dbManager, "beta entry past the tiny cap", { target: "memory" });
+    assert.ok(results.some((r) => r.content.includes("beta entry past the tiny cap")));
   });
 
   it("reports the matching target when replace is sent to the wrong target", async () => {


### PR DESCRIPTION
Fixes #218 (first slice; full SQLite-primary redesign remains future work).\n\n## Why\nUnder `policy-only` (the default) Markdown is never injected and never searched, yet `memory_add` enforces its 5000-char cap first, rejecting writes or spawning LLM consolidations to protect files nothing reads. Gating the cap on the mode that actually consumes the file removes the write-only failure loop with no behavior change elsewhere.\n\n## Scope\nOne `capEnforced` predicate in `src/store/memory-store.ts` (`memoryMode !== 'policy-only'`), applied at the add, replace, and mutation-plan capacity gates. No config schema change. README cap docs and CHANGELOG updated to mode-specific wording. Out: SQLite-primary rewrite, legacy-mode behavior, FIFO/consolidation logic.\n\n## Tradeoffs\nMarkdown stays source of truth and can drift from SQLite after sync failure or hand edits; unbounded policy-only files raise I/O cost. Accepted because SQLite was already the sole query authority and writes previously failed outright. Existing over-cap #214 stores stop rewrite-looping; switching such a store to legacy-inject re-exposes the old over-cap state.\n\n## Blast Radius\nDefault-true predicate shape: unset `memoryMode` keeps caps enforced. Legacy-inject caps, grace, auto-consolidation, 2x failure limit, and FIFO eviction pinned unchanged. Policy-only adds no longer invoke the consolidator; manual consolidation stays available.\n\n## Verification\n- Unit: over-limit add/replace/batch in policy-only for memory/user/failure/project with no consolidator call (delegate); new tool-level test proves an over-cap policy-only add lands in `memory_search`. Both fail pre-fix and pass post-fix.\n- `npm run check` clean; memory-store + memory-tool + auto-consolidate suites 148/148 pass.