### PR TITLE
fix(sessions): silently skip non-session jsonl artifacts during backfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ Create `~/.pi/agent/hermes-memory-config.json`:
   "projectsMemoryDir": "projects-memory",
   "sessionSearch": { "variant": "legacy" },
   "sessionRetentionDays": 0,
+  "sessionIndexExclude": [],
   "quickCheckOnOpen": true,
   "llmModelOverride": "openrouter/deepseek/deepseek-v4-flash",
   "llmThinkingOverride": "off",
@@ -535,6 +536,7 @@ Create `~/.pi/agent/hermes-memory-config.json`:
 | `projectsMemoryDir` | `projects-memory` | Subdirectory under `~/.pi/agent/` for project-scoped memory |
 | `sessionSearch` | `{ "variant": "legacy" }` | Session search implementation: `legacy` keeps the existing SQLite/FTS snippet search; `anchors` uses the opt-in Markdown request surface and returns compact JSONL line-range anchors from `~/.pi/agent/sessions/` |
 | `sessionRetentionDays` | `0` | Opt-in SQLite session retention, in days. `0` (default) disables pruning entirely and keeps the legacy count-only backfill preflight. When positive, sessions whose JSONL source file was last modified longer ago than the window are pruned from SQLite at startup — **rows only; the JSONL files in `~/.pi/agent/sessions/` are never deleted** — and both the deferred backfill and `/memory-index-sessions` skip files outside the window, so pruned sessions stay pruned instead of being re-indexed |
+| `sessionIndexExclude` | `[]` | First-level directory names under the sessions root to exclude from session indexing (exact names or `*` globs). The sessions directory is a shared namespace — extensions may store non-session JSONL artifacts there. Non-session files are already skipped by content sniffing (first line must be a `{"type":"session",...}` header) and no longer surface as backfill errors; use this setting to also skip whole directories regardless of content, e.g. `["subagent-artifacts"]` |
 | `quickCheckOnOpen` | `true` | Run a full SQLite integrity check asynchronously after opening the database; set to `false` to skip the startup scan (operation-time recovery remains enabled) |
 | `llmModelOverride` | unset | Optional model override for background review (direct and subprocess), correction save, session flush, and consolidation |
 | `llmThinkingOverride` | unset | Optional thinking override for those LLM calls; valid values are `off`, `minimal`, `low`, `medium`, `high`, and `xhigh`. If `llmModelOverride` is set and this is omitted, review/child calls default to `off` |

--- a/src/config.ts
+++ b/src/config.ts
@@ -69,6 +69,7 @@ const DEFAULT_CONFIG: MemoryConfig = {
   sessionSearch: { variant: "legacy" },
   quickCheckOnOpen: true,
   sessionRetentionDays: DEFAULT_SESSION_RETENTION_DAYS,
+  sessionIndexExclude: [],
 };
 
 export const DEFAULT_CONFIG_PATH = path.join(
@@ -146,6 +147,7 @@ export function loadConfig(configPath = DEFAULT_CONFIG_PATH): MemoryConfig {
         config.sessionRetentionDays = parsed.sessionRetentionDays;
       }
       if (typeof parsed.standingInstructionsEnabled === "boolean") config.standingInstructionsEnabled = parsed.standingInstructionsEnabled;
+      if (isStringArray(parsed.sessionIndexExclude)) config.sessionIndexExclude = parsed.sessionIndexExclude;
       if (typeof parsed.projectCharLimit === "number") config.projectCharLimit = parsed.projectCharLimit;
       if (typeof parsed.memoryDir === "string") {
         const normalizedMemoryDir = normalizeConfiguredMemoryDir(parsed.memoryDir);

--- a/src/handlers/index-sessions.ts
+++ b/src/handlers/index-sessions.ts
@@ -41,7 +41,7 @@ export function registerIndexSessionsCommand(pi: ExtensionAPI, config: MemoryCon
         try {
           // Retention is honored here too: a manual reindex must not re-add the
           // expired sessions the auto pruning just deleted.
-          const result = indexAllSessions(dbManager, SESSIONS_DIR, undefined, retentionCutoffMs(config.sessionRetentionDays));
+          const result = indexAllSessions(dbManager, SESSIONS_DIR, undefined, retentionCutoffMs(config.sessionRetentionDays), config.sessionIndexExclude);
           const stats = getSessionStats(dbManager);
 
           let output = `\n✅ Session indexing complete!\n\n`;

--- a/src/handlers/session-backfill.ts
+++ b/src/handlers/session-backfill.ts
@@ -32,6 +32,8 @@ export interface ScheduleSessionBackfillOptions {
   needsBackfillFn?: typeof needsBackfill;
   indexSessionsFn?: typeof indexChangedSessions;
   maxFilesToIndex?: number;
+  /** First-level dirs to skip in the all-projects scan (sessionIndexExclude config). */
+  sessionIndexExclude?: string[];
   touchBackfillTimestampFn?: typeof touchBackfillTimestamp;
   /**
    * Optional retention cutoff (ms epoch). Files older than this are excluded
@@ -43,8 +45,9 @@ export interface ScheduleSessionBackfillOptions {
 
 function formatBackfillResult(result: BulkIndexResult): string {
   const errorSuffix = result.errors.length > 0 ? ` (${result.errors.length} file error${result.errors.length === 1 ? '' : 's'})` : '';
+  const nonSessionSuffix = (result.nonSessionSkipped ?? 0) > 0 ? ` (${result.nonSessionSkipped} non-session files skipped)` : '';
   const limitSuffix = result.reachedLimit ? ' (startup limit reached)' : '';
-  return `🧠 Session backfill complete: ${result.sessionsIndexed} indexed, ${result.sessionsSkipped} skipped, ${result.messagesIndexed} messages${errorSuffix}${limitSuffix}.`;
+  return `🧠 Session backfill complete: ${result.sessionsIndexed} indexed, ${result.sessionsSkipped} skipped, ${result.messagesIndexed} messages${errorSuffix}${nonSessionSuffix}${limitSuffix}.`;
 }
 
 function notifyBestEffort(notify: NotifyFn | undefined, message: string, level: NotifyLevel): void {
@@ -102,7 +105,7 @@ export function scheduleSessionBackfill(
     setTimeoutFn(() => {
       measureLifecycleSync('session-backfill.callback', () => {
         try {
-          const result = indexSessionsFn(dbManager, sessionsDir, { maxFilesToIndex, retentionCutoffMs });
+          const result = indexSessionsFn(dbManager, sessionsDir, { maxFilesToIndex, retentionCutoffMs, excludeDirs: options.sessionIndexExclude });
           if (!result.reachedLimit) touchBackfillTimestampFn(dbManager);
           notifyBestEffort(options.notify, formatBackfillResult(result), result.errors.length > 0 || result.reachedLimit ? 'warning' : 'info');
         } catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -257,6 +257,7 @@ export default function (pi: ExtensionAPI) {
         // Exclude files older than the retention cutoff so sessions pruned by
         // retention are never re-indexed and never schedule another backfill.
         retentionCutoffMs: retentionCutoffMs(config.sessionRetentionDays),
+        sessionIndexExclude: config.sessionIndexExclude,
       });
     }
   });

--- a/src/store/session-indexer.ts
+++ b/src/store/session-indexer.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import { DEFAULT_MAX_MESSAGE_CONTENT_LENGTH } from '../constants.js';
 import { DatabaseManager } from './db.js';
-import { parseSessionFile, getSessionFiles, type ParsedSession } from './session-parser.js';
+import { parseSessionFile, getSessionFiles, isSessionFile, type ParsedSession } from './session-parser.js';
 
 export const LAST_SESSION_BACKFILL_KEY = 'last_session_backfill';
 export const SESSION_BACKFILL_INTERVAL_MS = 24 * 60 * 60 * 1000;
@@ -27,6 +27,12 @@ export interface BulkIndexResult {
   reachedLimit?: boolean;
   /** Session files skipped because their mtime is outside the retention window. */
   expiredSkipped?: number;
+  /**
+   * JSONL files skipped because their first line is not a `{"type":"session"}`
+   * header (see isSessionFile). Non-session extension artifacts living in the
+   * shared sessions directory land here instead of surfacing as parse errors.
+   */
+  nonSessionSkipped?: number;
 }
 
 interface SessionFileMetadata {
@@ -47,6 +53,12 @@ export interface IncrementalIndexOptions {
    * startup. Omit/0 to index every file (backwards-compatible default).
    */
   retentionCutoffMs?: number;
+  /**
+   * First-level directory names (exact or `*` globs) under the sessions root
+   * to skip entirely, from the `sessionIndexExclude` config. Applies only to
+   * the all-projects scan; an explicit projectDir is never filtered.
+   */
+  excludeDirs?: string[];
 }
 
 /**
@@ -340,6 +352,14 @@ function emptyBulkIndexResult(): BulkIndexResult {
 }
 
 function indexSessionFile(dbManager: DatabaseManager, file: string, result: BulkIndexResult): void {
+  if (!isSessionFile(file)) {
+    // Not a session JSONL (extension artifact in the shared sessions dir):
+    // skip silently — this is expected content, not an indexing failure, and
+    // not even a "processed" candidate file.
+    result.nonSessionSkipped = (result.nonSessionSkipped ?? 0) + 1;
+    return;
+  }
+
   result.sessionsProcessed++;
 
   const session = parseSessionFile(file);
@@ -376,8 +396,9 @@ export function indexAllSessions(
   sessionsDir: string,
   projectDir?: string,
   retentionCutoffMs = 0,
+  excludeDirs: string[] = [],
 ): BulkIndexResult {
-  const files = getSessionFiles(sessionsDir, projectDir);
+  const files = getSessionFiles(sessionsDir, projectDir, excludeDirs);
   const result = emptyBulkIndexResult();
   let expiredSkipped = 0;
 
@@ -419,7 +440,7 @@ export function indexChangedSessions(
   sessionsDir: string,
   options: IncrementalIndexOptions = {},
 ): BulkIndexResult {
-  const files = getSessionFiles(sessionsDir, options.projectDir);
+  const files = getSessionFiles(sessionsDir, options.projectDir, options.excludeDirs);
   const maxFilesToIndex = options.maxFilesToIndex ?? 50;
   const result = emptyBulkIndexResult();
 
@@ -432,6 +453,12 @@ export function indexChangedSessions(
   const changed: SessionFileMetadata[] = [];
   for (const file of files) {
     try {
+      if (!isSessionFile(file)) {
+        // Extension artifacts in the shared sessions dir: never queued, never
+        // counted against the per-startup cap, never surfaced as errors.
+        result.nonSessionSkipped = (result.nonSessionSkipped ?? 0) + 1;
+        continue;
+      }
       const metadata = getSessionFileMetadata(file);
       if (!isWithinRetention(metadata.mtimeMs, options.retentionCutoffMs)) {
         // Outside the retained window (e.g. pruned by pruneOldSessions):

--- a/src/store/session-parser.ts
+++ b/src/store/session-parser.ts
@@ -170,7 +170,59 @@ export function parseSessionFile(filePath: string): ParsedSession | null {
  * @param projectDir — Optional: specific project directory name (e.g., "--Users-...--")
  * @returns Array of file paths
  */
-export function getSessionFiles(sessionsDir: string, projectDir?: string): string[] {
+/**
+ * Cheap content sniff: does this file look like a Pi session JSONL?
+ *
+ * The format contract (see Pi docs/session-format.md) requires the first line
+ * to be a `{"type":"session",...}` header entry. The sessions directory is a
+ * shared namespace — extensions (e.g. pi-subagents' `subagent-artifacts/`)
+ * drop non-session JSONL artifacts there, and indexing them used to surface a
+ * "Failed to parse" error per file on every startup backfill. Sniffing the
+ * first line (bounded 4 KB read, never the whole file) lets callers skip such
+ * artifacts silently.
+ *
+ * Unreadable files return true so the existing parse path reports them as
+ * real errors instead of hiding genuinely broken session files.
+ */
+export function isSessionFile(filePath: string): boolean {
+  const SNIFF_BYTES = 4096;
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(filePath, 'r');
+    const buf = Buffer.alloc(SNIFF_BYTES);
+    const bytesRead = fs.readSync(fd, buf, 0, SNIFF_BYTES, 0);
+    if (bytesRead === 0) return false;
+    const firstLine = buf.subarray(0, bytesRead).toString('utf-8').split('\n', 1)[0].trim();
+    if (!firstLine) return false;
+    try {
+      const entry = JSON.parse(firstLine);
+      return entry !== null && typeof entry === 'object' && (entry as { type?: unknown }).type === 'session';
+    } catch {
+      return false;
+    }
+  } catch {
+    return true;
+  } finally {
+    if (fd !== undefined) {
+      try { fs.closeSync(fd); } catch { /* ignore */ }
+    }
+  }
+}
+
+/** Match a first-level directory name against exact names or `*` globs. */
+function matchesExcludePattern(name: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => {
+    if (!pattern.includes('*')) return pattern === name;
+    const escaped = pattern.split('*').map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('.*');
+    return new RegExp(`^${escaped}$`).test(name);
+  });
+}
+
+export function getSessionFiles(
+  sessionsDir: string,
+  projectDir?: string,
+  excludeDirs: string[] = [],
+): string[] {
   if (projectDir) {
     const dir = path.join(sessionsDir, projectDir);
     if (!fs.existsSync(dir)) return [];
@@ -185,6 +237,10 @@ export function getSessionFiles(sessionsDir: string, projectDir?: string): strin
   for (const entry of fs.readdirSync(sessionsDir)) {
     const entryPath = path.join(sessionsDir, entry);
     const stat = fs.statSync(entryPath);
+    if (stat.isDirectory() && matchesExcludePattern(entry, excludeDirs)) {
+      // User-configured exclusion (sessionIndexExclude): skip the whole dir.
+      continue;
+    }
     if (stat.isDirectory()) {
       // Scan .jsonl files inside project subdirectories
       for (const f of fs.readdirSync(entryPath)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,14 @@ export interface MemoryConfig {
    * Default: 0 (disabled).
    */
   sessionRetentionDays?: number;
+  /**
+   * First-level directory names (exact or `*` globs) under the sessions root
+   * to exclude from session indexing. The sessions directory is shared with
+   * extension artifacts (e.g. pi-subagents writes `subagent-artifacts/`);
+   * non-session JSONL is already skipped by content sniffing — use this to
+   * also skip whole directories regardless of content.
+   */
+  sessionIndexExclude?: string[];
 }
 
 export type MemoryCategory =

--- a/tests/store/session-indexer.test.ts
+++ b/tests/store/session-indexer.test.ts
@@ -196,17 +196,36 @@ describe('session-indexer', () => {
       assert.strictEqual(result2.sessionsIndexed, 0);
     });
 
-    it('should handle invalid JSONL files gracefully', () => {
+    it('should surface a session-headed file with corrupt body as an error', () => {
       const sessionsDir = path.join(tmpDir, 'sessions');
       const projDir = path.join(sessionsDir, 'test-project');
       fs.mkdirSync(projDir, { recursive: true });
 
-      // Invalid file (no session entry)
-      fs.writeFileSync(path.join(projDir, 'invalid.jsonl'), '{"type":"message","id":"m1"}');
+      // A session-typed first line (passes the sniff) that is missing the
+      // required id/cwd/timestamp fields: parseSessionFile yields no session,
+      // and since the file IS shaped like a session this must surface as an
+      // error rather than be silently swallowed like a foreign artifact.
+      fs.writeFileSync(path.join(projDir, 'invalid.jsonl'), '{"type":"session"}');
 
       const result = indexAllSessions(dbManager, sessionsDir);
       assert.strictEqual(result.sessionsProcessed, 1);
       assert.strictEqual(result.errors.length, 1);
+    });
+
+    it('should silently skip headerless files as non-session artifacts', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      const projDir = path.join(sessionsDir, 'test-project');
+      fs.mkdirSync(projDir, { recursive: true });
+
+      // No session entry at all: an extension artifact in the shared sessions
+      // dir. Skipped without error (the pre-sniff behavior was one error per
+      // such file on every startup backfill).
+      fs.writeFileSync(path.join(projDir, 'invalid.jsonl'), '{"type":"message","id":"m1"}');
+
+      const result = indexAllSessions(dbManager, sessionsDir);
+      assert.strictEqual(result.sessionsProcessed, 0);
+      assert.strictEqual(result.nonSessionSkipped, 1);
+      assert.strictEqual(result.errors.length, 0);
     });
 
     it('should handle empty sessions directory', () => {
@@ -358,7 +377,63 @@ describe('session-indexer', () => {
       const indexed = dbManager.getDb().prepare('SELECT id FROM sessions').all() as { id: string }[];
       assert.deepStrictEqual(indexed.map((r) => r.id), ['newer']);
     });
+
+    it('silently skips non-session JSONL artifacts without counting them as errors', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      writeJsonlSession(path.join(sessionsDir, 'project-a', 's1.jsonl'), 's1');
+      // Extension artifact: valid JSONL, but the first line is not a session header.
+      const artifact = path.join(sessionsDir, 'subagent-artifacts', 'worker_transcript.jsonl');
+      fs.mkdirSync(path.dirname(artifact), { recursive: true });
+      fs.writeFileSync(artifact, JSON.stringify({ type: 'transcript', events: [] }) + '\n');
+
+      const result = indexChangedSessions(dbManager, sessionsDir);
+
+      assert.strictEqual(result.errors.length, 0);
+      assert.strictEqual(result.nonSessionSkipped, 1);
+      assert.strictEqual(result.sessionsIndexed, 1);
+    });
+
+    it('non-session artifacts never consume the per-startup cap', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      const artifactDir = path.join(sessionsDir, 'subagent-artifacts');
+      fs.mkdirSync(artifactDir, { recursive: true });
+      for (let n = 0; n < 3; n++) {
+        fs.writeFileSync(path.join(artifactDir, `t${n}.jsonl`), JSON.stringify({ type: 'transcript', n }) + '\n');
+      }
+      writeJsonlSession(path.join(sessionsDir, 'real.jsonl'), 'real');
+
+      // Cap of 1: if artifacts were queued as changed files, the real session
+      // could be pushed out of the window. Sniffing keeps the cap for sessions.
+      const result = indexChangedSessions(dbManager, sessionsDir, { maxFilesToIndex: 1 });
+      assert.strictEqual(result.nonSessionSkipped, 3);
+      assert.strictEqual(result.sessionsIndexed, 1);
+      assert.strictEqual(result.errors.length, 0);
+    });
+
+    it('excludeDirs skips whole first-level directories regardless of content', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      // Even a session-shaped file inside an excluded dir must not be indexed.
+      writeJsonlSession(path.join(sessionsDir, 'nope-*', 's9.jsonl'), 's9');
+      writeJsonlSession(path.join(sessionsDir, 'project-a', 's1.jsonl'), 's1');
+
+      const result = indexChangedSessions(dbManager, sessionsDir, { excludeDirs: ['nope-*'] });
+      assert.strictEqual(result.sessionsIndexed, 1);
+      assert.strictEqual(result.errors.length, 0);
+      const db = dbManager.getDb();
+      const rows = db.prepare('SELECT id FROM sessions').all() as { id: string }[];
+      assert.deepStrictEqual(rows.map((r) => r.id), ['s1']);
+    });
+
+    it('indexAllSessions honors excludeDirs too', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      writeJsonlSession(path.join(sessionsDir, 'excluded', 's2.jsonl'), 's2');
+      writeJsonlSession(path.join(sessionsDir, 'kept', 's3.jsonl'), 's3');
+      const result = indexAllSessions(dbManager, sessionsDir, undefined, 0, ['excluded']);
+      assert.strictEqual(result.sessionsIndexed, 1);
+      assert.strictEqual(result.errors.length, 0);
+    });
   });
+
 
   describe('current session indexing helpers', () => {
     function writeSessionFile(filePath: string): void {

--- a/tests/store/session-parser.test.ts
+++ b/tests/store/session-parser.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { parseSessionFile, getSessionFiles, decodeProjectDir } from '../../src/store/session-parser.js';
+import { parseSessionFile, getSessionFiles, isSessionFile, decodeProjectDir } from '../../src/store/session-parser.js';
 
 describe('session-parser', () => {
   let tmpDir: string;
@@ -278,5 +278,92 @@ describe('session-parser', () => {
     it('should handle simple directory names', () => {
       assert.strictEqual(decodeProjectDir('my-project'), 'project');
     });
+  });
+});
+
+
+describe('isSessionFile', () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'is-session-file-test-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('accepts a file whose first line is a session header', () => {
+    const filePath = path.join(tmpDir, 'real.jsonl');
+    fs.writeFileSync(filePath, [
+      JSON.stringify({ type: 'session', id: 's1', timestamp: '2026-05-03T00:00:00Z', cwd: '/test' }),
+      JSON.stringify({ type: 'message', id: 'm1' }),
+    ].join('\n'));
+    assert.strictEqual(isSessionFile(filePath), true);
+  });
+
+  it('rejects non-session JSONL (extension artifacts)', () => {
+    const filePath = path.join(tmpDir, 'artifact.jsonl');
+    fs.writeFileSync(filePath, JSON.stringify({ type: 'transcript', events: [] }) + '\n');
+    assert.strictEqual(isSessionFile(filePath), false);
+  });
+
+  it('rejects empty files and files without a parseable first line', () => {
+    const empty = path.join(tmpDir, 'empty.jsonl');
+    fs.writeFileSync(empty, '');
+    assert.strictEqual(isSessionFile(empty), false);
+    const garbage = path.join(tmpDir, 'garbage.jsonl');
+    fs.writeFileSync(garbage, 'not json at all\n');
+    assert.strictEqual(isSessionFile(garbage), false);
+    const blank = path.join(tmpDir, 'blank.jsonl');
+    fs.writeFileSync(blank, '\n\n' + JSON.stringify({ type: 'session' }));
+    assert.strictEqual(isSessionFile(blank), false);
+  });
+
+  it('rejects JSON first lines that are not objects or not session-typed', () => {
+    const arr = path.join(tmpDir, 'arr.jsonl');
+    fs.writeFileSync(arr, '[1,2,3]\n');
+    assert.strictEqual(isSessionFile(arr), false);
+    const nul = path.join(tmpDir, 'nul.jsonl');
+    fs.writeFileSync(nul, 'null\n');
+    assert.strictEqual(isSessionFile(nul), false);
+  });
+});
+
+describe('getSessionFiles excludeDirs', () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exclude-dirs-test-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function touchSessionFile(dir: string, name: string): void {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, name), JSON.stringify({ type: 'session', id: name, timestamp: '2026-05-03T00:00:00Z', cwd: '/t' }) + '\n');
+  }
+
+  it('skips first-level directories matched exactly', () => {
+    const root = path.join(tmpDir, 'sessions');
+    touchSessionFile(path.join(root, 'keep'), 'a.jsonl');
+    touchSessionFile(path.join(root, 'drop'), 'b.jsonl');
+    const files = getSessionFiles(root, undefined, ['drop']);
+    assert.ok(files.every(f => !f.includes(`${path.sep}drop${path.sep}`)));
+    assert.strictEqual(files.length, 1);
+  });
+
+  it('supports * globs and does not match nested levels', () => {
+    const root = path.join(tmpDir, 'sessions');
+    touchSessionFile(path.join(root, 'artifacts-x'), 'a.jsonl');
+    touchSessionFile(path.join(root, 'project-a'), 'b.jsonl');
+    const files = getSessionFiles(root, undefined, ['artifacts-*']);
+    assert.strictEqual(files.length, 1);
+    assert.ok(files[0].includes('project-a'));
+  });
+
+  it('an explicit projectDir is never filtered by excludeDirs', () => {
+    const root = path.join(tmpDir, 'sessions');
+    touchSessionFile(path.join(root, 'drop'), 'a.jsonl');
+    const files = getSessionFiles(root, 'drop', ['drop']);
+    assert.strictEqual(files.length, 1);
   });
 });


### PR DESCRIPTION
## Symptom

On machines with heavy subagent usage, startup shows a noisy warning and burns the backfill budget:

```
Warning: 🧠 Session backfill complete: 0 indexed, 24 skipped, 0 messages (41 file errors).
```

All 41 "file errors" are `subagent-artifacts/*.jsonl` (pi-subagents worker transcripts) — files that were never sessions.

## Root cause

The sessions root is a **shared namespace**: pi core writes session transcripts there, but extensions also create sibling files/directories with `.jsonl` artifacts. `getSessionFiles()` treats every depth-1 subdirectory as a project dir and every `.jsonl` inside as a session; `parseSessionFile()` returns `null` for non-session content, and `indexChangedSessions()` counts each `null` as a per-file error.

## Fix (three layers, as discussed for the general case)

1. **Content sniffing** — new `isSessionFile()`: a file is a session candidate iff its first line parses as JSON with `type: "session"` (the documented session header). Non-session artifacts are skipped **silently** and reported via a new `nonSessionSkipped` counter appended to the backfill notice.
2. **Error tiering** — files that pass the sniff but fail to parse mid-way are still reported as errors; genuine format corruption is never hidden.
3. **`sessionIndexExclude` config** — list of directory names under the sessions root that are never scanned, as an escape hatch for artifacts that do carry a session header but shouldn't be indexed.

### Boundary note

Fork transcripts (`<session>/forks/*.jsonl`, which *do* start with a valid session header) live at depth 3 and stay outside the scanner's depth-2 walk, so behavior is unchanged for them. Whether forks should be searchable is a separate feature decision, deliberately not taken here.

## Tests

- 21/21 in `tests/store/session-parser.test.ts` (incl. 5 new `isSessionFile` + exclude cases)
- 51/51 in `tests/store/session-indexer.test.ts` (incl. new non-session-skip / error-tiering cases)
- Full suite: **all 52 test files pass**; `tsc --noEmit` clean
